### PR TITLE
Fixed NRE when right clicking a TextBox/AutoCompleteBox

### DIFF
--- a/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyout.cs
+++ b/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyout.cs
@@ -163,6 +163,9 @@ namespace FluentAvalonia.UI.Controls
 		protected override void OnOpening(CancelEventArgs args)
 		{
 			base.OnOpening(args);
+			if (_commandBar == null)
+				return;
+			
 			if (PrimaryCommands.Count > 0 && _commandBar.PrimaryCommands.Count == 0)
 			{
 				_commandBar.PrimaryCommands.AddRange(PrimaryCommands);


### PR DESCRIPTION
Amazing job with this project so far!
A little fix, after 1.1.2 right clicking `TextBox` or `AutoCompleteBox` cause NRE since `_commandBar` is not created yet.