### PR TITLE
v1.1.3 Update

### DIFF
--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -10,8 +10,8 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.1.2</Version>
-        <AssemblyVersion>1.1.2.0</AssemblyVersion>
+        <Version>1.1.3</Version>
+        <AssemblyVersion>1.1.3.0</AssemblyVersion>
     </PropertyGroup>
 
 

--- a/FluentAvalonia/Styling/BasicControls/DataGridStyles.axaml
+++ b/FluentAvalonia/Styling/BasicControls/DataGridStyles.axaml
@@ -1,0 +1,580 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:ui="using:FluentAvalonia.UI.Controls">
+	
+	<Style Selector="DataGridCell">
+		<Setter Property="Background" Value="{DynamicResource DataGridCellBackgroundBrush}" />
+		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+		<Setter Property="VerticalContentAlignment" Value="Stretch" />
+		<Setter Property="FontSize" Value="15" />
+		<Setter Property="MinHeight" Value="32" />
+		<Setter Property="Focusable" Value="False" />
+		<Setter Property="Template">
+			<ControlTemplate>
+				<Grid x:Name="PART_CellRoot"
+					  ColumnDefinitions="*,Auto"
+					  Background="{TemplateBinding Background}">
+
+					<Rectangle x:Name="CurrencyVisual"
+							   HorizontalAlignment="Stretch"
+							   VerticalAlignment="Stretch"
+							   Fill="Transparent"
+							   IsHitTestVisible="False"
+							   Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
+							   StrokeThickness="1" />
+					<Grid x:Name="FocusVisual"
+						  IsHitTestVisible="False">
+						<Rectangle HorizontalAlignment="Stretch"
+								   VerticalAlignment="Stretch"
+								   Fill="Transparent"
+								   IsHitTestVisible="False"
+								   Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
+								   StrokeThickness="2" />
+						<Rectangle Margin="2"
+								   HorizontalAlignment="Stretch"
+								   VerticalAlignment="Stretch"
+								   Fill="Transparent"
+								   IsHitTestVisible="False"
+								   Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
+								   StrokeThickness="1" />
+					</Grid>
+
+					<ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}"
+									  Content="{TemplateBinding Content}"
+									  Margin="{TemplateBinding Padding}"
+									  TextBlock.Foreground="{TemplateBinding Foreground}"
+									  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+									  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+					<Rectangle x:Name="InvalidVisualElement"
+							   HorizontalAlignment="Stretch"
+							   VerticalAlignment="Stretch"
+							   IsHitTestVisible="False"
+							   Stroke="{DynamicResource DataGridCellInvalidBrush}"
+							   StrokeThickness="1" />
+
+					<Rectangle Name="PART_RightGridLine"
+							   Grid.Column="1"
+							   VerticalAlignment="Stretch"
+							   Width="1"
+							   Fill="{DynamicResource DataGridFillerColumnGridLinesBrush}" />
+				</Grid>
+			</ControlTemplate>
+		</Setter>
+	</Style>
+
+	<Style Selector="DataGridCell /template/ Rectangle#CurrencyVisual">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGridCell /template/ Grid#FocusVisual">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGridCell:current /template/ Rectangle#CurrencyVisual">
+		<Setter Property="IsVisible" Value="True" />
+	</Style>
+	<Style Selector="DataGrid:focus DataGridCell:current /template/ Grid#FocusVisual">
+		<Setter Property="IsVisible" Value="True" />
+	</Style>
+	<Style Selector="DataGridCell /template/ Rectangle#InvalidVisualElement">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGridCell:invalid /template/ Rectangle#InvalidVisualElement">
+		<Setter Property="IsVisible" Value="True" />
+	</Style>
+	<Style Selector="DataGridCell > TextBox DataValidationErrors">
+		<Setter Property="Template" Value="{DynamicResource TooltipDataValidationContentTemplate}" />
+		<Setter Property="ErrorTemplate" Value="{DynamicResource TooltipDataValidationErrorTemplate}" />
+	</Style>
+
+
+	<!-- DATA GRID COLUMN HEADER -->
+	<Style Selector="DataGridColumnHeader">
+		<Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForegroundBrush}" />
+		<Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderBackgroundBrush}" />
+		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="Focusable" Value="False" />
+		<Setter Property="SeparatorBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+		<Setter Property="Padding" Value="12,0,0,0" />
+		<Setter Property="FontSize" Value="12" />
+		<Setter Property="MinHeight" Value="32" />
+		<Setter Property="Template">
+			<ControlTemplate>
+				<Grid Name="PART_ColumnHeaderRoot"
+					  ColumnDefinitions="*,Auto"
+					  Background="{TemplateBinding Background}">
+
+					<Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+						  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+						  Margin="{TemplateBinding Padding}">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition MinWidth="32"
+											  Width="Auto" />
+						</Grid.ColumnDefinitions>
+
+						<ContentPresenter Content="{TemplateBinding Content}" />
+
+						<ui:FontIcon Name="SortIcon"
+									 Grid.Column="1"
+									 HorizontalAlignment="Center"
+									 VerticalAlignment="Center"
+									 FontSize="18"
+									 FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+					</Grid>
+
+					<Rectangle Name="VerticalSeparator"
+							   Grid.Column="1"
+							   Width="1"
+							   VerticalAlignment="Stretch"
+							   Fill="{TemplateBinding SeparatorBrush}"
+							   IsVisible="{TemplateBinding AreSeparatorsVisible}" />
+
+					<Grid x:Name="FocusVisual"
+						  IsHitTestVisible="False">
+						<Rectangle x:Name="FocusVisualPrimary"
+								   HorizontalAlignment="Stretch"
+								   VerticalAlignment="Stretch"
+								   Fill="Transparent"
+								   IsHitTestVisible="False"
+								   Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
+								   StrokeThickness="2" />
+						<Rectangle x:Name="FocusVisualSecondary"
+								   Margin="2"
+								   HorizontalAlignment="Stretch"
+								   VerticalAlignment="Stretch"
+								   Fill="Transparent"
+								   IsHitTestVisible="False"
+								   Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
+								   StrokeThickness="1" />
+					</Grid>
+				</Grid>
+			</ControlTemplate>
+		</Setter>
+	</Style>
+
+	<Style Selector="DataGridColumnHeader /template/ Grid#FocusVisual">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGridColumnHeader:focus-visible /template/ Grid#FocusVisual">
+		<Setter Property="IsVisible" Value="True" />
+	</Style>
+
+	<Style Selector="DataGridColumnHeader:pointerover /template/ Grid#PART_ColumnHeaderRoot">
+		<Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderHoveredBackgroundColor}" />
+	</Style>
+	<Style Selector="DataGridColumnHeader:pressed /template/ Grid#PART_ColumnHeaderRoot">
+		<Setter Property="Background" Value="{DynamicResource DataGridColumnHeaderPressedBackgroundColor}" />
+	</Style>
+
+	<Style Selector="DataGridColumnHeader:dragIndicator">
+		<Setter Property="Opacity" Value="0.5" />
+	</Style>
+
+	<Style Selector="DataGridColumnHeader /template/ ui|FontIcon#SortIcon">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+
+	<Style Selector="DataGridColumnHeader:sortascending /template/ ui|FontIcon#SortIcon">
+		<Setter Property="IsVisible" Value="True" />
+		<Setter Property="Glyph" Value="&#xF821;" />
+	</Style>
+
+	<Style Selector="DataGridColumnHeader:sortdescending /template/ ui|FontIcon#SortIcon">
+		<Setter Property="IsVisible" Value="True" />
+		<Setter Property="Glyph" Value="&#xF811;" />
+	</Style>
+
+
+
+	<!-- DATA GRID ROW -->
+	<Style Selector="DataGridRow">
+		<Setter Property="Focusable" Value="False" />
+		<Setter Property="Template">
+			<ControlTemplate>
+				<DataGridFrozenGrid Name="PART_Root"
+									RowDefinitions="*,Auto,Auto"
+									ColumnDefinitions="Auto,*">
+
+					<Rectangle Name="BackgroundRectangle"
+							   Grid.RowSpan="2"
+							   Grid.ColumnSpan="2" />
+					<Rectangle x:Name="InvalidVisualElement"
+							   Grid.ColumnSpan="2"
+							   Fill="{DynamicResource DataGridRowInvalidBrush}" />
+
+					<DataGridRowHeader Name="PART_RowHeader"
+									   Grid.RowSpan="3"
+									   DataGridFrozenGrid.IsFrozen="True" />
+					<DataGridCellsPresenter Name="PART_CellsPresenter"
+											Grid.Column="1"
+											DataGridFrozenGrid.IsFrozen="True" />
+					<DataGridDetailsPresenter Name="PART_DetailsPresenter"
+											  Grid.Row="1"
+											  Grid.Column="1"
+											  Background="{DynamicResource DataGridDetailsPresenterBackgroundBrush}" />
+					<Rectangle Name="PART_BottomGridLine"
+							   Grid.Row="2"
+							   Grid.Column="1"
+							   HorizontalAlignment="Stretch"
+							   Height="1" />
+
+				</DataGridFrozenGrid>
+			</ControlTemplate>
+		</Setter>
+	</Style>
+
+	<Style Selector="DataGridRow /template/ Rectangle#InvalidVisualElement">
+		<Setter Property="Opacity" Value="0" />
+	</Style>
+	<Style Selector="DataGridRow:invalid /template/ Rectangle#InvalidVisualElement">
+		<Setter Property="Opacity" Value="0.4" />
+	</Style>
+	<Style Selector="DataGridRow:invalid /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Opacity" Value="0" />
+	</Style>
+
+	<Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource ControlFillColorTransparentBrush}" />
+	</Style>
+	<Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
+	</Style>
+	<Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundOpacity}" />
+	</Style>
+	<Style Selector="DataGridRow:selected:pointerover /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedHoveredUnfocusedBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedHoveredUnfocusedBackgroundOpacity}" />
+	</Style>
+	<Style Selector="DataGridRow:selected:focus /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedBackgroundOpacity}" />
+	</Style>
+	<Style Selector="DataGridRow:selected:pointerover:focus /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedHoveredBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedHoveredBackgroundOpacity}" />
+	</Style>
+
+
+	<Style Selector="DataGridRowHeader">
+		<Setter Property="Background" Value="{DynamicResource DataGridRowHeaderBackgroundBrush}" />
+		<Setter Property="Focusable" Value="False" />
+		<Setter Property="SeparatorBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+		<Setter Property="AreSeparatorsVisible" Value="False" />
+		<Setter Property="Template">
+			<ControlTemplate>
+				<Grid x:Name="PART_Root"
+					  RowDefinitions="*,*,Auto"
+					  ColumnDefinitions="Auto,*">
+					<Border Grid.RowSpan="3"
+							Grid.ColumnSpan="2"
+							BorderBrush="{TemplateBinding SeparatorBrush}"
+							BorderThickness="0,0,1,0">
+						<Grid Background="{TemplateBinding Background}">
+							<Rectangle x:Name="RowInvalidVisualElement"
+									   Fill="{DynamicResource DataGridRowInvalidBrush}"
+									   Stretch="Fill" />
+							<Rectangle x:Name="BackgroundRectangle"
+									   Stretch="Fill" />
+						</Grid>
+					</Border>
+					<Rectangle x:Name="HorizontalSeparator"
+							   Grid.Row="2"
+							   Grid.ColumnSpan="2"
+							   Height="1"
+							   Margin="1,0,1,0"
+							   HorizontalAlignment="Stretch"
+							   Fill="{TemplateBinding SeparatorBrush}"
+							   IsVisible="{TemplateBinding AreSeparatorsVisible}" />
+
+					<ContentPresenter Grid.RowSpan="2"
+									  Grid.Column="1"
+									  HorizontalAlignment="Center"
+									  VerticalAlignment="Center"
+									  Content="{TemplateBinding Content}" />
+				</Grid>
+			</ControlTemplate>
+		</Setter>
+	</Style>
+
+	<Style Selector="DataGridRowHeader /template/ Rectangle#RowInvalidVisualElement">
+		<Setter Property="Opacity" Value="0" />
+	</Style>
+	<Style Selector="DataGridRowHeader:invalid /template/ Rectangle#RowInvalidVisualElement">
+		<Setter Property="Opacity" Value="0.4" />
+	</Style>
+	<Style Selector="DataGridRowHeader:invalid /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Opacity" Value="0" />
+	</Style>
+
+	<Style Selector="DataGridRowHeader /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource SystemControlTransparentBrush}" />
+	</Style>
+	<Style Selector="DataGridRow:pointerover DataGridRowHeader /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource SystemListLowColor}" />
+	</Style>
+	<Style Selector="DataGridRowHeader:selected /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundOpacity}" />
+	</Style>
+	<Style Selector="DataGridRow:pointerover DataGridRowHeader:selected /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedHoveredUnfocusedBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedHoveredUnfocusedBackgroundOpacity}" />
+	</Style>
+	<Style Selector="DataGridRowHeader:selected:focus /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedBackgroundOpacity}" />
+	</Style>
+	<Style Selector="DataGridRow:pointerover DataGridRowHeader:selected:focus /template/ Rectangle#BackgroundRectangle">
+		<Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedHoveredBackgroundColor}" />
+		<Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedHoveredBackgroundOpacity}" />
+	</Style>
+
+
+	<!-- DATA GRID ROW GROUP HEADER -->
+	<Style Selector="DataGridRowGroupHeader">
+		<Setter Property="Focusable" Value="False" />
+		<Setter Property="Foreground" Value="{DynamicResource DataGridRowGroupHeaderForegroundBrush}" />
+		<Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderBackgroundBrush}" />
+		<Setter Property="FontSize" Value="15" />
+		<Setter Property="MinHeight" Value="32" />
+		<Setter Property="Template">
+			<ControlTemplate>
+				<DataGridFrozenGrid Name="PART_Root"
+									MinHeight="{TemplateBinding MinHeight}"
+									ColumnDefinitions="Auto,Auto,Auto,Auto,*"
+									RowDefinitions="*,Auto">
+
+					<Rectangle Name="IndentSpacer"
+							   Grid.Column="1" />
+					<ToggleButton Name="ExpanderButton"
+								  Grid.Column="2"
+								  Width="12"
+								  Height="12"
+								  Margin="12,0,0,0"
+								  Background="{TemplateBinding Background}"
+								  Foreground="{TemplateBinding Foreground}"
+								  Focusable="False" />
+
+					<StackPanel Grid.Column="3"
+								Orientation="Horizontal"
+								VerticalAlignment="Center"
+								Margin="12,0,0,0">
+						<TextBlock Name="PropertyNameElement"
+								   Margin="4,0,0,0"
+								   IsVisible="{TemplateBinding IsPropertyNameVisible}"
+								   Foreground="{TemplateBinding Foreground}" />
+						<TextBlock Margin="4,0,0,0"
+								   Text="{Binding Key}"
+								   Foreground="{TemplateBinding Foreground}" />
+						<TextBlock Name="ItemCountElement"
+								   Margin="4,0,0,0"
+								   IsVisible="{TemplateBinding IsItemCountVisible}"
+								   Foreground="{TemplateBinding Foreground}" />
+					</StackPanel>
+
+					<Rectangle x:Name="CurrencyVisual"
+							   Grid.ColumnSpan="5"
+							   HorizontalAlignment="Stretch"
+							   VerticalAlignment="Stretch"
+							   Fill="Transparent"
+							   IsHitTestVisible="False"
+							   Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
+							   StrokeThickness="1" />
+					<Grid x:Name="FocusVisual"
+						  Grid.ColumnSpan="5"
+						  IsHitTestVisible="False">
+						<Rectangle HorizontalAlignment="Stretch"
+								   VerticalAlignment="Stretch"
+								   Fill="Transparent"
+								   IsHitTestVisible="False"
+								   Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
+								   StrokeThickness="2" />
+						<Rectangle Margin="2"
+								   HorizontalAlignment="Stretch"
+								   VerticalAlignment="Stretch"
+								   Fill="Transparent"
+								   IsHitTestVisible="False"
+								   Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
+								   StrokeThickness="1" />
+					</Grid>
+
+					<DataGridRowHeader Name="PART_RowHeader"
+									   Grid.RowSpan="2"
+									   DataGridFrozenGrid.IsFrozen="True" />
+
+					<Rectangle x:Name="PART_BottomGridLine"
+							   Grid.Row="1"
+							   Grid.ColumnSpan="5"
+							   Height="1" />
+				</DataGridFrozenGrid>
+			</ControlTemplate>
+		</Setter>
+	</Style>
+
+	<Style Selector="DataGridRowGroupHeader /template/ ToggleButton#ExpanderButton">
+		<Setter Property="Template">
+			<ControlTemplate>
+				<Border Grid.Column="0"
+						Width="12"
+						Height="12"
+						Background="Transparent"
+						HorizontalAlignment="Center"
+						VerticalAlignment="Center">
+					<ui:SymbolIcon Symbol="ChevronRight"
+								   VerticalAlignment="Center"
+								   HorizontalAlignment="Center"
+								   FontSize="16" />
+				</Border>
+			</ControlTemplate>
+		</Setter>
+	</Style>
+
+	<Style Selector="DataGridRowGroupHeader /template/ ToggleButton#ExpanderButton:checked /template/ ui|SymbolIcon">
+		<Setter Property="RenderTransform" Value="rotate(90deg)" />
+	</Style>
+
+	<Style Selector="DataGridRowGroupHeader /template/ DataGridFrozenGrid#PART_Root">
+		<Setter Property="Background" Value="{Binding $parent[DataGridRowGroupHeader].Background}" />
+	</Style>
+	<Style Selector="DataGridRowGroupHeader:pointerover /template/ DataGridFrozenGrid#PART_Root">
+		<Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderHoveredBackgroundBrush}" />
+	</Style>
+	<Style Selector="DataGridRowGroupHeader:pressed /template/ DataGridFrozenGrid#PART_Root">
+		<Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderPressedBackgroundBrush}" />
+	</Style>
+
+	<Style Selector="DataGridRowGroupHeader /template/ Rectangle#CurrencyVisual">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGridRowGroupHeader /template/ Grid#FocusVisual">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGridRowGroupHeader:current /template/ Rectangle#CurrencyVisual">
+		<Setter Property="IsVisible" Value="True" />
+	</Style>
+	<Style Selector="DataGrid:focus DataGridRowGroupHeader:current /template/ Grid#FocusVisual">
+		<Setter Property="IsVisible" Value="True" />
+	</Style>
+
+
+	<!-- DATA GRID -->
+	<Style Selector="DataGrid">
+		<Setter Property="RowBackground" Value="Transparent" />
+		<Setter Property="AlternatingRowBackground" Value="Transparent" />
+		<Setter Property="HeadersVisibility" Value="Column" />
+		<Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+		<Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+		<Setter Property="SelectionMode" Value="Extended" />
+		<Setter Property="GridLinesVisibility" Value="None" />
+		<Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+		<Setter Property="VerticalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+		<Setter Property="DropLocationIndicatorTemplate">
+			<Template>
+				<Rectangle Fill="{DynamicResource DataGridDropLocationIndicatorBackground}"
+						   Width="2" />
+			</Template>
+		</Setter>
+		<Setter Property="Template">
+			<ControlTemplate>
+				<Border Background="{TemplateBinding Background}"
+						BorderThickness="{TemplateBinding BorderThickness}"
+						BorderBrush="{TemplateBinding BorderBrush}">
+					<Grid RowDefinitions="Auto,*,Auto,Auto"
+						  ColumnDefinitions="Auto,*,Auto">
+						<Grid.Resources>
+							<ControlTemplate x:Key="TopLeftHeaderTemplate"
+											 TargetType="DataGridColumnHeader">
+								<Grid x:Name="TopLeftHeaderRoot"
+									  RowDefinitions="*,*,Auto">
+									<Border Grid.RowSpan="2"
+											BorderThickness="0,0,1,0"
+											BorderBrush="{DynamicResource DataGridGridLinesBrush}" />
+									<Rectangle Grid.RowSpan="2"
+											   VerticalAlignment="Bottom"
+											   StrokeThickness="1"
+											   Height="1"
+											   Fill="{DynamicResource DataGridGridLinesBrush}" />
+								</Grid>
+							</ControlTemplate>
+							<ControlTemplate x:Key="TopRightHeaderTemplate"
+											 TargetType="DataGridColumnHeader">
+								<Grid x:Name="RootElement" />
+							</ControlTemplate>
+						</Grid.Resources>
+
+						<DataGridColumnHeader Name="PART_TopLeftCornerHeader"
+											  Template="{StaticResource TopLeftHeaderTemplate}" />
+						<DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
+														Grid.Column="1"
+														Grid.ColumnSpan="2" />
+						<!--<DataGridColumnHeader Name="PART_TopRightCornerHeader"
+                                  Grid.Column="2"
+                                  Template="{StaticResource TopRightHeaderTemplate}" />-->
+						<Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
+								   Grid.ColumnSpan="3"
+								   VerticalAlignment="Bottom"
+								   Height="1"
+								   Fill="{DynamicResource DataGridGridLinesBrush}" />
+
+						<DataGridRowsPresenter Name="PART_RowsPresenter"
+											   Grid.Row="1"
+											   Grid.RowSpan="2"
+											   Grid.ColumnSpan="3">
+							<DataGridRowsPresenter.GestureRecognizers>
+								<ScrollGestureRecognizer CanHorizontallyScroll="True" CanVerticallyScroll="True" />
+							</DataGridRowsPresenter.GestureRecognizers>
+						</DataGridRowsPresenter>
+						<Rectangle Name="PART_BottomRightCorner"
+								   Fill="{DynamicResource DataGridScrollBarsSeparatorBackground}"
+								   Grid.Column="2"
+								   Grid.Row="2" />
+						<!--<Rectangle Name="BottomLeftCorner"
+                       Fill="{DynamicResource DataGridScrollBarsSeparatorBackground}"
+                       Grid.Row="2"
+                       Grid.ColumnSpan="2" />-->
+						<ScrollBar Name="PART_VerticalScrollbar"
+								   Orientation="Vertical"
+								   Grid.Column="2"
+								   Grid.Row="1"
+								   Width="{DynamicResource ScrollBarSize}" />
+
+						<Grid Grid.Column="1"
+							  Grid.Row="2"
+							  ColumnDefinitions="Auto,*">
+							<Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
+							<ScrollBar Name="PART_HorizontalScrollbar"
+									   Grid.Column="1"
+									   Orientation="Horizontal"
+									   Height="{DynamicResource ScrollBarSize}" />
+						</Grid>
+						<Border x:Name="PART_DisabledVisualElement"
+								Grid.ColumnSpan="3"
+								Grid.RowSpan="4"
+								IsHitTestVisible="False"
+								HorizontalAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								CornerRadius="2"
+								Background="{DynamicResource DataGridDisabledVisualElementBackground}"
+								IsVisible="{Binding !$parent[DataGrid].IsEnabled}" />
+					</Grid>
+				</Border>
+			</ControlTemplate>
+		</Setter>
+	</Style>
+
+	<Style Selector="DataGrid:empty-columns /template/ DataGridColumnHeader#PART_TopLeftCornerHeader">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGrid:empty-columns /template/ DataGridColumnHeadersPresenter#PART_ColumnHeadersPresenter">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+	<Style Selector="DataGrid:empty-columns /template/ Rectangle#PART_ColumnHeadersAndRowsSeparator">
+		<Setter Property="IsVisible" Value="False" />
+	</Style>
+
+
+
+</Styles>

--- a/FluentAvalonia/Styling/BasicControls/ToggleSwitchStyle.axaml
+++ b/FluentAvalonia/Styling/BasicControls/ToggleSwitchStyle.axaml
@@ -33,6 +33,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+		<Setter Property="MinWidth" Value="{StaticResource ToggleSwitchThemeMinWidth}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid Background="{TemplateBinding Background}"
@@ -45,9 +46,8 @@
                       VerticalAlignment="Top"/>
 
                     <Grid Grid.Row="1"
-                      MinWidth="{DynamicResource ToggleSwitchThemeMinWidth}"
-                      HorizontalAlignment="Left"
-                      VerticalAlignment="Top">
+						  HorizontalAlignment="Left"
+						  VerticalAlignment="Top">
 
                         <Grid.RowDefinitions>
                             <RowDefinition Height="{DynamicResource ToggleSwitchPreContentMargin}" />

--- a/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
+++ b/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
@@ -9,6 +9,8 @@ using FluentAvalonia.Interop;
 using FluentAvalonia.UI.Media;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace FluentAvalonia.Styling
@@ -82,6 +84,10 @@ namespace FluentAvalonia.Styling
 					_controlsVersion = value;
 					Init(true);
 					Owner?.NotifyHostedResourcesChanged(ResourcesChangedEventArgs.Empty);
+					if (value == 1)
+					{
+						Debug.WriteLine("NOTE: Fluent v1 Styles are now considered deprecated, and support will be removed from FluentAvalonia in a future version");						
+					}
 				}
 			}
 		}

--- a/FluentAvalonia/Styling/StylesV2/Controls.axaml
+++ b/FluentAvalonia/Styling/StylesV2/Controls.axaml
@@ -38,6 +38,7 @@
     <StyleInclude Source="/Styling/BasicControls/NativeMenuBar.axaml" />
     <StyleInclude Source="/Styling/BasicControls/ProgressBar.axaml" />
     <StyleInclude Source="/Styling/BasicControls/ButtonSpinner.axaml" />
+	<StyleInclude Source="/Styling/BasicControls/DataGridStyles.axaml" />
 
 
     <!-- NEW CONTROLS -->

--- a/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
@@ -1302,7 +1302,43 @@
         <StaticResource x:Key="ProgressBarBorderBrush" ResourceKey="ControlStrokeColorDefaultBrush" />
         <!--<StaticResource x:Key="ProgressBarPausedForegroundColor" ResourceKey="SystemFillColorCaution" />
         <StaticResource x:Key="ProgressBarErrorForegroundColor" ResourceKey="SystemFillColorCritical" />-->
-        
-    </Styles.Resources>
+
+		<!-- DATA GRID -->
+		<Thickness x:Key="DataGridTextColumnCellTextBlockMargin">12,0,12,0</Thickness>
+		<x:Double x:Key="ListAccentLowOpacity">0.6</x:Double>
+		<x:Double x:Key="ListAccentMediumOpacity">0.8</x:Double>
+		<StaticResource x:Key="DataGridCellBackgroundBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+		<StaticResource x:Key="DataGridCurrencyVisualPrimaryBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+		<StaticResource x:Key="DataGridCellFocusVisualPrimaryBrush" ResourceKey="FocusStrokeColorOuter" />
+		<StaticResource x:Key="DataGridCellFocusVisualSecondaryBrush" ResourceKey="FocusStrokeColorInner" />
+		<StaticResource x:Key="DataGridCellInvalidBrush" ResourceKey="SystemFillColorCriticalBrush" />
+		<StaticResource x:Key="DataGridFillerColumnGridLinesBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+		<StaticResource x:Key="DataGridGridLinesBrush" ResourceKey="DividerStrokeColorDefaultBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderBackgroundBrush" ResourceKey="ControlFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderHoveredBackgroundColor" ResourceKey="ControlFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderPressedBackgroundColor" ResourceKey="ControlFillColorTertiaryBrush" />
+		<StaticResource x:Key="DataGridDetailsPresenterBackgroundBrush" ResourceKey="SolidBackgroundFillColorBase" />
+		<StaticResource x:Key="DataGridRowInvalidBrush" ResourceKey="SystemFillColorCriticalBackgroundBrush" />
+		<StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
+		<StaticResource x:Key="DataGridRowSelectedBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
+		<StaticResource x:Key="DataGridRowHeaderBackgroundBrush" ResourceKey="ControlFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderBackgroundBrush" ResourceKey="SolidBackgroundFillColorBaseBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderPressedBackgroundBrush" ResourceKey="SubtleFillColorTertiaryBrush" />
+		<SolidColorBrush x:Key="DataGridDropLocationIndicatorBackground" Color="#3F4346" />
+		<StaticResource x:Key="DataGridScrollBarsSeparatorBackground" ResourceKey="ControlFillColorTertiaryBrush" />
+		<SolidColorBrush x:Key="DataGridDisabledVisualElementBackground" Color="#8CFFFFFF" />
+
+
+
+	</Styles.Resources>
     
 </Styles>

--- a/FluentAvalonia/Styling/StylesV2/LightResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/LightResources.axaml
@@ -1351,6 +1351,40 @@
 		<Thickness x:Key="CommandBarFlyoutBorderUpThemeThickness">1,1,1,0</Thickness>
 		<Thickness x:Key="CommandBarFlyoutBorderDownThemeThickness">1,0,1,1</Thickness>
 		<StaticResource x:Key="CommandBarFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
+
+		<!-- DATA GRID -->
+		<Thickness x:Key="DataGridTextColumnCellTextBlockMargin">12,0,12,0</Thickness>
+		<x:Double x:Key="ListAccentLowOpacity">0.6</x:Double>
+		<x:Double x:Key="ListAccentMediumOpacity">0.8</x:Double>
+		<StaticResource x:Key="DataGridCellBackgroundBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+		<StaticResource x:Key="DataGridCurrencyVisualPrimaryBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+		<StaticResource x:Key="DataGridCellFocusVisualPrimaryBrush" ResourceKey="FocusStrokeColorOuter" />
+		<StaticResource x:Key="DataGridCellFocusVisualSecondaryBrush" ResourceKey="FocusStrokeColorInner" />
+		<StaticResource x:Key="DataGridCellInvalidBrush" ResourceKey="SystemFillColorCriticalBrush" />
+		<StaticResource x:Key="DataGridFillerColumnGridLinesBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+		<StaticResource x:Key="DataGridGridLinesBrush" ResourceKey="DividerStrokeColorDefaultBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderBackgroundBrush" ResourceKey="ControlFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderHoveredBackgroundColor" ResourceKey="ControlFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridColumnHeaderPressedBackgroundColor" ResourceKey="ControlFillColorTertiaryBrush" />
+		<StaticResource x:Key="DataGridDetailsPresenterBackgroundBrush" ResourceKey="SolidBackgroundFillColorBase" />
+		<StaticResource x:Key="DataGridRowInvalidBrush" ResourceKey="SystemFillColorCriticalBackgroundBrush" />
+		<StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
+		<StaticResource x:Key="DataGridRowSelectedBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredBackgroundColor" ResourceKey="AccentFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowSelectedHoveredBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
+		<StaticResource x:Key="DataGridRowHeaderBackgroundBrush" ResourceKey="ControlFillColorDefaultBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderBackgroundBrush" ResourceKey="SolidBackgroundFillColorBaseBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
+		<StaticResource x:Key="DataGridRowGroupHeaderPressedBackgroundBrush" ResourceKey="SubtleFillColorTertiaryBrush" />
+		<SolidColorBrush x:Key="DataGridDropLocationIndicatorBackground" Color="#3F4346" />
+		<StaticResource x:Key="DataGridScrollBarsSeparatorBackground" ResourceKey="ControlFillColorTertiaryBrush" />
+		<SolidColorBrush x:Key="DataGridDisabledVisualElementBackground" Color="#8CFFFFFF" />
 		
 		
     </Styles.Resources>

--- a/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyout.cs
+++ b/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyout.cs
@@ -14,6 +14,10 @@ namespace FluentAvalonia.UI.Controls
 	{
 		public CommandBarFlyout()
 		{
+			// TEMPORARY FIX...REVERT TO CREATEPRESENTER() WHEN NRE ISSUE FIXED
+			_commandBar = new CommandBarFlyoutCommandBar();
+			_commandBar.SetOwningFlyout(this);
+
 			PrimaryCommands = new AvaloniaList<ICommandBarElement>();
 			SecondaryCommands = new AvaloniaList<ICommandBarElement>();
 
@@ -140,9 +144,6 @@ namespace FluentAvalonia.UI.Controls
 
 		protected override Control CreatePresenter()
 		{
-			_commandBar = new CommandBarFlyoutCommandBar();
-			_commandBar.SetOwningFlyout(this);
-
 			_presenter = new FlyoutPresenter
 			{
 				Background = null,
@@ -163,6 +164,7 @@ namespace FluentAvalonia.UI.Controls
 		protected override void OnOpening(CancelEventArgs args)
 		{
 			base.OnOpening(args);
+
 			if (PrimaryCommands.Count > 0 && _commandBar.PrimaryCommands.Count == 0)
 			{
 				_commandBar.PrimaryCommands.AddRange(PrimaryCommands);

--- a/FluentAvalonia/UI/Controls/Flyouts/ColorPickerFlyout.cs
+++ b/FluentAvalonia/UI/Controls/Flyouts/ColorPickerFlyout.cs
@@ -36,6 +36,13 @@ namespace FluentAvalonia.UI.Controls
 		protected override void OnOpening(CancelEventArgs args)
 		{
 			base.OnOpening(args);
+			
+		}
+
+		protected override void OnOpened()
+		{
+			base.OnOpened();
+			// TEMPORARY FIX...REVERT TO ONOPENING AFTER NRE ISSUE FIXED
 			(Popup.Child as PickerFlyoutPresenter).ShowHideButtons(ShouldShowConfirmationButtons());
 		}
 


### PR DESCRIPTION
- Added `DataGrid` styles, note: V2 styles only
- Allow setting MinWidth on `ToggleSwitch`
- Added temporary fix to not have NRE with certain flyouts (CommandBarFlyout & ColorPickerButton). This arose from some changes to FlyoutBase in Avalonia 0.10.7

NOTE:
As of v1.1.3, v1 styles are considered deprecated in FluentAvalonia. You may still continue to use them, however, they will be removed in a future version and new controls within this library, including the NavigationView, will no longer support the original fluent theme. Remaining avalonia controls that do have templates in this library will be added for full compatibility with Avalonia, just with the new styles.

Following the release of Win 11, I will also be making a pass through this library to make sure everything is up to date with WinUI, and adding support for the high contrast theme