### PR TITLE
ContentDialog - wrong property usage for IsSecondaryButtonEnabled

### DIFF
--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -165,11 +165,11 @@ namespace FluentAvalonia.UI.Controls
 		{
 			get
 			{
-				return GetValue(IsPrimaryButtonEnabledProperty);
+				return GetValue(IsSecondaryButtonEnabledProperty);
 			}
 			set
 			{
-				SetValue(IsPrimaryButtonEnabledProperty, value);
+				SetValue(IsSecondaryButtonEnabledProperty, value);
 			}
 		}
 


### PR DESCRIPTION
Fixed wrong property usage for IsSecondaryButtonEnabled in ContentDialog.cs