### PR TITLE
Add overload to ContentDialog.Hide which provides an option to provide a dialog result

### DIFF
--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -453,12 +453,22 @@ namespace FluentAvalonia.UI.Controls
 			return await tcs.Task;
 		}
 
-		public void Hide()
+		/// <summary>
+		/// Closes the current <see cref="ContentDialog"/> without a result (<see cref="ContentDialogResult"/>.<see cref="ContentDialogResult.None"/>)
+		/// </summary>
+		public void Hide() => Hide(ContentDialogResult.None);
+		
+
+		/// <summary>
+		/// Closes the current <see cref="ContentDialog"/> with the given <see cref="ContentDialogResult"/> <para>ddd</para>
+		/// </summary>
+		/// <param name="dialogResult">The <see cref="ContentDialogResult"/> to return</param>
+		public void Hide(ContentDialogResult dialogResult)
 		{
-			result = ContentDialogResult.None;
+			result = dialogResult;
 			HideCore();
 		}
-
+		
 		internal void CompleteButtonClickDeferral()
 		{
 			IsEnabled = true;

--- a/FluentAvaloniaSamples/Pages/DialogsFlyouts/ContentDialogInputExample.axaml
+++ b/FluentAvaloniaSamples/Pages/DialogsFlyouts/ContentDialogInputExample.axaml
@@ -1,0 +1,18 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:FluentAvaloniaSamples.ViewModels"
+             mc:Ignorable="d"
+             x:DataType="viewModels:ContentDialogViewModel"
+             Padding="0, 10"
+             x:Class="FluentAvaloniaSamples.Pages.DialogsFlyouts.ContentDialogInputExample">
+    <StackPanel Spacing="10" MinWidth="400">
+        <TextBlock>Try out some magic keywords</TextBlock>
+        <AutoCompleteBox FilterMode="StartsWithOrdinal"
+                         Watermark="Write a keyword, for example 'ok', 'not ok' or 'hide'"
+                         Text="{CompiledBinding UserInput}"
+                         Items="{Binding AvailableKeyWords}" 
+                         AttachedToVisualTree="InputField_OnAttachedToVisualTree" />
+    </StackPanel>
+</UserControl>

--- a/FluentAvaloniaSamples/Pages/DialogsFlyouts/ContentDialogInputExample.axaml.cs
+++ b/FluentAvaloniaSamples/Pages/DialogsFlyouts/ContentDialogInputExample.axaml.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+
+namespace FluentAvaloniaSamples.Pages.DialogsFlyouts
+{
+    public class ContentDialogInputExample : UserControl
+    {
+        public ContentDialogInputExample()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        private void InputField_OnAttachedToVisualTree(object sender, VisualTreeAttachmentEventArgs e)
+        {
+            // We will set the focus into our input field just after it got attached to the visual tree.
+            if (sender is InputElement inputElement)
+            {
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    KeyboardDevice.Instance.SetFocusedElement(inputElement, NavigationMethod.Unspecified,
+                        KeyModifiers.None);
+                });
+            }
+        }
+    }
+}

--- a/FluentAvaloniaSamples/Pages/DialogsFlyouts/ContentDialogPage.axaml
+++ b/FluentAvaloniaSamples/Pages/DialogsFlyouts/ContentDialogPage.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -67,6 +67,44 @@
                 </local:ControlExample.Options>
                 
             </local:ControlExample>
+
+            <local:ControlExample Header="ContentDialog with Custom Content"
+                                  TargetType="ContentDialog"
+                                  UsageNotes="{Binding ContentDialogUsageNotes}">
+                <local:ControlExample.CSharpSource>
+                    <x:String xml:space="preserve">
+public async void ShowInputDialogAsync()
+{
+    var dialog = new ContentDialog()
+    {
+        Title = "My Dialog Title", 
+        PrimaryButtonText = "Ok", SecondaryButtonText = "Not OK", CloseButtonText = "Close"
+    };
+
+    
+    var viewModel = new MyViewModel(dialog); // Pass the dialog if you need to hide it from the ViewModel.
+
+    dialog.Content = new ContentDialogInputExample() // In our case the Content is a UserControl, but can be anything.
+    {
+        DataContext = viewModel
+    };
+
+    var result = await dialog.ShowAsync();
+}
+                    </x:String>
+                </local:ControlExample.CSharpSource>
+                <StackPanel Spacing="20">
+                    <TextBlock xml:space="preserve">
+This example launches a ContentDialog with a TextBox which automatically closes based on the user input.
+
+  ● write "accept" or "ok" to close the dialog with the result 'Primary'
+  ● write "dismiss" or "not ok" to close the dialog with the result 'Secondary'
+  ● write "cancel", "close" or "hide" to close the dialog with the result 'None'
+                    </TextBlock>
+                    <Button Content="Show Input" Command="{Binding ShowInputDialogAsync}" />
+                </StackPanel>
+            </local:ControlExample>
+
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/FluentAvaloniaSamples/ViewModels/ContentDialogViewModel.cs
+++ b/FluentAvaloniaSamples/ViewModels/ContentDialogViewModel.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAvalonia.UI.Controls;
+using FluentAvaloniaSamples.Pages.DialogsFlyouts;
+
+namespace FluentAvaloniaSamples.ViewModels
+{
+    public class ContentDialogViewModel : ViewModelBase
+    {
+        private readonly ContentDialog dialog;
+        
+        public ContentDialogViewModel(ContentDialog dialog)
+        {
+            if (dialog is null)
+            {
+                throw new ArgumentNullException(nameof(dialog));
+            }
+
+            this.dialog = dialog;
+            dialog.Closed += DialogOnClosed;
+        }
+
+        private void DialogOnClosed(ContentDialog sender, ContentDialogClosedEventArgs args)
+        {
+            dialog.Closed -= DialogOnClosed;
+
+            var resultHint = new ContentDialog()
+            {
+                Content = $"You chose \"{args.Result}\"", 
+                Title = "Result", 
+                PrimaryButtonText = "Thanks"
+            };
+
+            _ = resultHint.ShowAsync();
+        }
+
+        private string _UserInput;
+
+        /// <summary>
+        /// Gets or sets the user input to check 
+        /// </summary>
+        public string UserInput
+        {
+            get => _UserInput;
+            set
+            {
+                if (RaiseAndSetIfChanged(ref _UserInput, value))
+                {
+                    HandleUserInput();
+                }
+            } 
+        }
+
+        private void HandleUserInput()
+        {
+            switch (UserInput.ToLowerInvariant())
+            {
+                case "accept":
+                case "ok":
+                    dialog.Hide(ContentDialogResult.Primary);
+                    break;
+                    
+                case "dismiss":
+                case "not ok":
+                    dialog.Hide(ContentDialogResult.Secondary);
+                    break;
+                
+                case "cancel":
+                case "close":
+                case "hide":
+                    dialog.Hide();
+                    break;
+            }
+        }
+
+        private static readonly string[] _AvailableKeyWords = new[]
+        {
+            "Accept",
+            "OK",
+            "Dismiss",
+            "Not OK",
+            "Close",
+            "Cancel",
+            "Hide"
+        };
+
+        public string[] AvailableKeyWords => _AvailableKeyWords;
+    }
+}

--- a/FluentAvaloniaSamples/ViewModels/MainWindowViewModel.cs
+++ b/FluentAvaloniaSamples/ViewModels/MainWindowViewModel.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using FluentAvaloniaSamples.Pages.DialogsFlyouts;
 
 namespace FluentAvaloniaSamples.ViewModels
 {
@@ -177,6 +178,23 @@ namespace FluentAvaloniaSamples.ViewModels
 			}
         }
 
+        public async void ShowInputDialogAsync()
+        {
+	        var dialog = new ContentDialog()
+	        {
+		        Title = "Let's go ...",
+		        PrimaryButtonText = "Ok :-)", SecondaryButtonText = "Not OK :-(", CloseButtonText = "Leave me alone!"
+	        };
+
+	        var viewModel = new ContentDialogViewModel(dialog);
+	        dialog.Content = new ContentDialogInputExample()
+	        {
+		        DataContext = viewModel
+	        };
+
+	        _ = await dialog.ShowAsync();
+        }
+        
 		private async void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
 		{
 			var def = args.GetDeferral();


### PR DESCRIPTION
## What does this PR do? 
Added an overload to `ContentDialog.Hide(ContentDialogResult dialogResult))`.  This enables the developer to have more control over the user input if needed.

## Documentation
Added an example to the demo App. If there there are any online docs which should be updated please guide me. 

## Preview
![Animation](https://user-images.githubusercontent.com/47110241/141758560-364015c2-9aff-4c0d-bc40-afbb61f256a3.png)

## Closed issues
Closes #53 

Happy coding 
Tim