### PR TITLE
V1.1.6 update

### DIFF
--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -10,8 +10,8 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.1.5</Version>
-        <AssemblyVersion>1.1.5.0</AssemblyVersion>
+        <Version>1.1.6</Version>
+        <AssemblyVersion>1.1.6.0</AssemblyVersion>
     </PropertyGroup>
 
 
@@ -27,8 +27,8 @@
 	    <AvaloniaResource Include="Fonts\*.*" />
     </ItemGroup> 
     <ItemGroup>
-      <PackageReference Include="Avalonia" Version="0.10.9" />
-      <PackageReference Include="Avalonia.Desktop" Version="0.10.9" />
-      <PackageReference Include="Avalonia.Diagnostics" Version="0.10.9" />
+      <PackageReference Include="Avalonia" Version="0.10.10" />
+      <PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
+      <PackageReference Include="Avalonia.Diagnostics" Version="0.10.10" />
     </ItemGroup>
 </Project>

--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -899,7 +899,7 @@ namespace FluentAvalonia.UI.Controls
 			{
 				// OverlayLayer is a Canvas, so we won't get a signal to resize if the window
 				// bounds change. Subscribe to force update
-				wb.GetObservable(BoundsProperty).Subscribe(_ => OnRootBoundsChanged());
+				_rootBoundsWatcher = wb.GetObservable(BoundsProperty).Subscribe(_ => OnRootBoundsChanged());
 			}
 		}
 

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,9 +11,9 @@
     <AvaloniaResource Include="DescriptionTexts\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.9" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.9" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.9" />
+    <PackageReference Include="Avalonia" Version="0.10.10" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />

--- a/FluentAvaloniaSamples/Views/Internal/CoreWindow.cs
+++ b/FluentAvaloniaSamples/Views/Internal/CoreWindow.cs
@@ -221,7 +221,7 @@ namespace FluentAvaloniaSamples.Views.Internal
 		{
 			_owner = wnd;
 
-			if (_version.BuildNumber > 22000)
+			if (_version.BuildNumber >= 22000)
 			{
 				((IPseudoClasses)_owner.Classes).Set(":windows11", true);
 			}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Bringing more of Fluent design and WinUI controls into Avalonia.
 [![Nuget](https://img.shields.io/nuget/v/FluentAvaloniaUI?style=flat-square)](https://www.nuget.org/packages/FluentAvaloniaUI/)
 (NOTE: nuget package is under id FluentAvaloniaUI)
 
-Currently Targets: Avalonia 0.10.9 & .net core 5.0
+Currently Targets: Avalonia 0.10.10 & .net core 5.0
+
 Note: Windows 7, 8/8.1 are not supported by FluentAvalonia.
 
 # Getting Started
@@ -24,9 +25,9 @@ To include the styles for FluentAvalonia, add the following to your App.xaml (or
 
     <sty:FluentAvaloniaTheme />
     
-By default, FluentAvalonia is now using the new WinUI styles that have been rolling out since last November. These are still a work in progress both here and in WinUI itself. Most controls in core Avalonia also have been provided a template here to provide a cohesive UX, thus making FluentAvalonia independent. See the Core Basic Controls page for the controls that do not have a corresponding template present and you will need to provide one. In these cases, only a template is needed and no additional resources are necessary.
+By default, FluentAvalonia is now using the new WinUI styles that have been rolling out since November 2020. These are still a work in progress both here and in WinUI itself. All controls in core Avalonia also have been provided a template here to provide a cohesive UX, thus making FluentAvalonia independent (style wise).
 
-As of v1.1.5, Fluent v1 styles (what in core Avalonia) are no longer supported within FluentAvalonia.
+As of v1.1.5, Fluent v1 styles (what's in core Avalonia) are no longer supported within FluentAvalonia.
 
 FluentAvaloniaTheme has several additional options for customizing:
 


### PR DESCRIPTION
Small update for:

- Master already contains PR #54, adding to NuGet package update
- Fixes possible memory leak with ContentDialogHost not actually assigning a disposable for the root/window bounds change
- Updates Avalonia packages to 0.10.10
- Fixed Sample App CoreWindow pseudoclass to properly reflect Windows 11