### PR TITLE
v1.1.8 update

### DIFF
--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -35,8 +35,8 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="0.10.10" />
-		<PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.10" />
+		<PackageReference Include="Avalonia" Version="0.10.11" />
+		<PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.11" />
 	</ItemGroup>
 </Project>

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -17,8 +17,8 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.1.7</Version>
-        <AssemblyVersion>1.1.7.0</AssemblyVersion>
+        <Version>1.1.8</Version>
+        <AssemblyVersion>1.1.8.0</AssemblyVersion>
     </PropertyGroup>
 
 

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
@@ -291,7 +291,7 @@ namespace FluentAvalonia.UI.Controls
 					_minRecoverWidth = _primaryItemsHost.DesiredSize.Width;// + trackWid;
 				}
 
-				_overflowSeparator.IsVisible = _numInOverflow > 0;
+				_overflowSeparator.IsVisible = _numInOverflow > 0 && SecondaryCommands.Count > 0;
 			}
 
 			var overflowVis = OverflowButtonVisibility;
@@ -303,8 +303,7 @@ namespace FluentAvalonia.UI.Controls
 			{
 				_moreButton.IsVisible = overflowVis == CommandBarOverflowButtonVisibility.Visible;
 			}
-
-			
+						
 			return base.MeasureOverride(availableSize);
 		}
 

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
@@ -77,6 +77,19 @@ namespace FluentAvalonia.UI.Controls
 				_systemCaptionButtons.Height = _titleBar.Height;
 			}
 
+			if (_titleBar != null && Presenter != null)
+			{
+				if (_titleBar.ExtendViewIntoTitleBar)
+				{
+					(Presenter as ContentPresenter).Margin = new Thickness();
+				}
+				else
+				{
+					(Presenter as ContentPresenter).Margin = new Thickness(0,
+						_titleBar.Height, 0, 0);
+				}
+			}
+
 			SetTitleBarColors();
 		}
 

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
@@ -119,7 +119,11 @@ namespace FluentAvalonia.UI.Controls
 			return base.WndProc(hWnd, msg, wParam, lParam);
 		}
 
-		internal void SetOwner(CoreWindow wnd) => _owner = wnd;
+		internal void SetOwner(CoreWindow wnd)
+		{
+			 _owner = wnd;
+			((IPseudoClasses)wnd.Classes).Set(":windows10", !_isWindows11);
+		}
 
 		private int GetResizeHandleHeight()
 		{

--- a/FluentAvalonia/UI/Controls/GridView/GridViewItem.cs
+++ b/FluentAvalonia/UI/Controls/GridView/GridViewItem.cs
@@ -75,7 +75,7 @@ namespace FluentAvalonia.UI.Controls
 				}
 			};
 
-			await ani.RunAsync(this);
+			await ani.RunAsync(this, null);
 		}
 	}
 }

--- a/FluentAvalonia/UI/Controls/ListView/Items/ListViewItem.cs
+++ b/FluentAvalonia/UI/Controls/ListView/Items/ListViewItem.cs
@@ -73,7 +73,7 @@ namespace FluentAvalonia.UI.Controls
 				}
 			};
 
-			await ani.RunAsync(this);
+			await ani.RunAsync(this, null);
 		}
 	}
 }

--- a/FluentAvalonia/UI/Media/NavigationTransitionInfo.cs
+++ b/FluentAvalonia/UI/Media/NavigationTransitionInfo.cs
@@ -87,7 +87,7 @@ namespace FluentAvalonia.UI.Media.Animation
 				FillMode = FillMode.Forward
 			};
 
-            await animation.RunAsync(ctrl);
+            await animation.RunAsync(ctrl, null);
 
 			(ctrl as IVisual).Opacity = 1;
 		}
@@ -131,7 +131,7 @@ namespace FluentAvalonia.UI.Media.Animation
 				FillMode = FillMode.Forward
             };
 
-            await animation.RunAsync(ctrl);
+            await animation.RunAsync(ctrl, null);
 
 			(ctrl as IVisual).Opacity = 1;
         }
@@ -174,7 +174,7 @@ namespace FluentAvalonia.UI.Media.Animation
 				FillMode = FillMode.Forward
 			};
 
-            await animation.RunAsync(ctrl);
+            await animation.RunAsync(ctrl, null);
 
 			(ctrl as IVisual).Opacity = 1;
 		}

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,9 +11,9 @@
     <AvaloniaResource Include="DescriptionTexts\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.10" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.10" />
+    <PackageReference Include="Avalonia" Version="0.10.11" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />


### PR DESCRIPTION
Minor update to bump to Avalonia 0.10.11 and a couple minor fixes:

CoreWindow
- Makes sure `:windows10` pseudoclass is added when on Windows 10 (fixes #61)
On Windows 10 with WinUI composition enabled (WS_NOREDIRECTIONBITMAP ex. window style), the top border of the window is missing, so I fake it by adding a border to the top of the window. This isn't the ideal solution as if you use a different accent color than the system or disable WinUI Comp it will show, but I tried to implement what Windows Terminal did, but was unsuccessful (if you want to take a look or even take a crack at it, look at `_OnPaint()` in NonClientIslandWindow.cpp on their repo).
- Ensures the Window's ContentPresenter has a top margin equivalent to titlebar height on startup

CommandBar
- Hide the overflow separator if overflow is enabled but `SecondaryCommands` are empty (fixes #62)

Next update will be 1.2 sometime in January, finishing (or at least mostly finishing) the work I started in 1.1.7 on the ListView/GridView, (most likely) porting the TabView from WinUI, and revamping the Sample app