### PR TITLE
Add Binding to ContentTemplate in DataGridColumnHeader

### DIFF
--- a/FluentAvalonia/Styling/BasicControls/DataGridStyles.axaml
+++ b/FluentAvalonia/Styling/BasicControls/DataGridStyles.axaml
@@ -113,7 +113,8 @@
 											  Width="Auto" />
 						</Grid.ColumnDefinitions>
 
-						<ContentPresenter Content="{TemplateBinding Content}" />
+						<ContentPresenter Content="{TemplateBinding Content}" 
+						                  ContentTemplate="{TemplateBinding ContentTemplate}" />
 
 						<ui:FontIcon Name="SortIcon"
 									 Grid.Column="1"


### PR DESCRIPTION
Hi @amwx ,

Avalonia now supports HeaderTemplate, which should be reflected in the DataGridColumnHeader-Style

Happy coding 
Tim
