### PR TITLE
Hot fix for MenuItem

### DIFF
--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -18,8 +18,8 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.2.0</Version>
-        <AssemblyVersion>1.2.0.0</AssemblyVersion>
+        <Version>1.2.1</Version>
+        <AssemblyVersion>1.2.1.0</AssemblyVersion>
     </PropertyGroup>
 
 

--- a/FluentAvalonia/Styling/BasicControls/MenuItemStyles.axaml
+++ b/FluentAvalonia/Styling/BasicControls/MenuItemStyles.axaml
@@ -83,7 +83,7 @@
                                 <ColumnDefinition Width="Auto"
                                                   SharedSizeGroup="MenuItemChevron" />
                             </Grid.ColumnDefinitions>
-                            <ContentPresenter Name="PART_IconPresenter" Background="Beige"
+                            <ContentPresenter Name="PART_IconPresenter"
                                               Content="{TemplateBinding Icon}"
                                               Width="16"
                                               Height="16"

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
     <AvaloniaResource Include="Pages\SampleCode\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Pages\SampleCode\CoreWindow3.cs.txt" />
+    <None Remove="Pages\SampleCode\CoreWindow3.xaml.txt" />
   </ItemGroup>  
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.10.12" />

--- a/FluentAvaloniaSamples/Pages/FAControlPages/CoreWindowPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/CoreWindowPage.axaml
@@ -65,6 +65,16 @@ Simply edit the colors in that class to your liking and CoreWindow will automati
                 </x:String>
             </TextBlock>
         </ctrls:ControlExample>
+
+        <ctrls:ControlExample Header="Custom TitleBar - Adding an Icon"
+                              CSharpSource="avares://FluentAvaloniaSamples/Pages/SampleCode/CoreWindow3.cs.txt"
+                              XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/CoreWindow3.xaml.txt">
+            <TextBlock TextWrapping="Wrap">
+                <x:String xml:space="preserve">
+By default, CoreWindow does not support Icons. However, with the ability set your own titlebar element, you can add an icon to your window (like I do for the sample app)
+                </x:String>
+            </TextBlock>
+        </ctrls:ControlExample>
         
     </StackPanel>
 </UserControl>

--- a/FluentAvaloniaSamples/Pages/SampleCode/CoreWindow3.cs.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/CoreWindow3.cs.txt
@@ -1,0 +1,61 @@
+﻿// Now we visit code behind of the MainView
+
+// The best place to do setup is in the OnOpened handler of the Window - this ensures everything
+// is initialized and ready to go.
+public override void OnOpened()
+{
+    // Helper method
+    // Note SetTitleBar is really only for the example. You can move that logic here
+    // if you're already on a CoreWindow object
+    SetTitleBar(this);
+}
+
+
+// However, if you're using a View that isn't a window, subscribe to the Opened event of the
+// owning window in OnAttachedToVisualTree
+protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+{
+    base.OnAttachedToVisualTree(e);
+
+    if (e.Root is Window b)
+    {
+        b.Opened += OnParentWindowOpened;
+    }
+}
+
+private void OnParentWindowOpened(object, EventArgs)
+{
+    // We can remove the eventhandler now, as we only need this once
+    (sender as Window).Opened -= OnParentWindowOpened;
+
+    // Helper method
+    SetTitleBar(sender as CoreWindow);
+}
+
+
+private void SetTitleBar(CoreWindow cw)
+{
+    // Grab the ICoreApplicationViewTitleBar attached to the CoreWindow object
+    // On Windows, this will never be null. On Mac/Linux, it will be - make sure
+    // to null check
+    var titleBar = cw.TitleBar;
+    if (titleBar != null)
+    {
+        // Tell CoreWindow we want to remove the default TitleBar and set our own
+        titleBar.ExtendViewIntoTitleBar = true;
+
+        // Retreive reference to the Xaml element we're using a TitleBar
+        if (this.FindControl<Grid>("TitleBarHost") is Grid g)
+        {
+            // Call SetTitleBar to tell CoreWindow the element we want to use as the TitleBar
+            cw.SetTitleBar(g);
+            // Set the margin of the Custom TitleBar so it doesn't overlap with the CaptionButtons
+            g.Margin = new Thickness(0, 0, titleBar.SystemOverlayRightInset, 0);
+
+            // You can optionally subscribe to LayoutMetricsChanged to be notified of when TitleBar bounds change
+            // Right now, it doesn't do much. It will be more important when RTL layouts are supported as that will
+            // notify you of a change in the SystemOverlay[Left/Right]Inset properties and require adjusting
+            // that margin
+        }
+    }
+}

--- a/FluentAvaloniaSamples/Pages/SampleCode/CoreWindow3.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/CoreWindow3.xaml.txt
@@ -1,0 +1,42 @@
+﻿<!-- 
+Use a top-level view here, something that won't get unloaded as part of navigation 
+MainWindow/MainView is a good place
+-->
+<Window xmlns...>
+    
+    <!-- 
+    Root element to contain the custom titlebar and window content 
+    I'm using a DockPanel, but any panel type will work
+    -->
+
+    <DockPanel>
+        <!--
+        Setup your xaml titlebar element. 
+        This can be any control, so long as it is hit testable 
+        -->
+        <Grid Background="Transparent"
+              Name="TitleBarHost"
+              ColumnDefinitions="Auto,*"
+              DockPanel.Dock="Top">
+
+            <!-- Adding an Image control to add an Icon -->
+            <Image Margin="12 4"
+                   IsHitTestVisible="False"
+                   Source="{Binding ...}"
+                   Width="18" Height="18"
+                   Name="WindowIcon" />
+
+            <!-- Add a TextBlock for the Window title text -->
+            <TextBlock Text="{Binding Title, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
+                       FontSize="12"
+                       IsHitTestVisible="False"
+                       VerticalAlignment="Center"
+                       Grid.Column="1"/>
+
+            <!-- You can of course add other content to your titlebar if you wish -->
+        </Grid>
+
+        <!-- Rest of your Window/View content goes here -->
+
+    </DockPanel>
+</Window>


### PR DESCRIPTION
Quick fix for MenuItem. When I was fixing the MenuItem padding, I set a background on one of the template items, and inadvertently left it in (really shows in Dark mode). This PR removes that.

Also added a custom titlebar example to the CoreWindow page, particularly demonstrating how to add an Icon.

Fixes #86 