### PR TITLE
Fix ColorPicker icons in NumberBox

### DIFF
--- a/FluentAvalonia/Styling/Controls/ColorPickerStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/ColorPickerStyles.axaml
@@ -88,13 +88,13 @@
                                 <RepeatButton Name="PopupUpSpinButton" Focusable="False"
                                               FontSize="18"
                                               Classes="NumberBoxSpinButtonStyle NumberBoxPopupButton"
-                                              Content="&#xF2B9;" />
+                                              Content="{StaticResource ChevronUpGlyph}" />
 
                                 <RepeatButton Name="PopupDownSpinButton" Focusable="False"
                                               FontSize="18"
                                               Classes="NumberBoxSpinButtonStyle NumberBoxPopupButton"
                                               Grid.Row="1"
-                                              Content="&#xF2A6;" />
+                                              Content="{StaticResource ChevronDownGlyph}" />
                             </Grid>
                         </Border>
                     </Popup>
@@ -104,13 +104,13 @@
                                   Grid.Column="1"
                                   FontSize="18"
                                   Classes="NumberBoxSpinButtonStyle"
-                                  Content="&#xF2B9;" />
+                                  Content="{StaticResource ChevronUpGlyph}" />
 
                     <RepeatButton Name="DownSpinButton"
                                   Grid.Row="1"
                                   Grid.Column="2"
                                   FontSize="18"
-                                  Content="&#xF2A6;"
+                                  Content="{StaticResource ChevronDownGlyph}"
                                   Classes="NumberBoxSpinButtonStyle" />
 
                  </Grid>

--- a/FluentAvalonia/Styling/Controls/NumberBoxStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/NumberBoxStyles.axaml
@@ -199,13 +199,13 @@
 									<RepeatButton Name="PopupUpSpinButton" Focusable="False"
 												FontSize="18"
 												Classes="NumberBoxSpinButtonStyle NumberBoxPopupButton"
-												Content="&#xE70E;" />
+												Content="{StaticResource ChevronUpGlyph}" />
 
 									<RepeatButton Name="PopupDownSpinButton" Focusable="False"
 												FontSize="18"
 												Classes="NumberBoxSpinButtonStyle NumberBoxPopupButton"
 												Grid.Row="1"
-												Content="&#xE70D;" />
+												Content="{StaticResource ChevronDownGlyph}" />
 								</Grid>
 							</Border>
 						</Popup>
@@ -224,14 +224,14 @@
 									Grid.Column="1"
 									FontSize="18"
 									Classes="NumberBoxSpinButtonStyle"
-									Content="&#xE70E;"
+									Content="{StaticResource ChevronUpGlyph}"
 									Margin="4"/>
 
 						<RepeatButton Name="DownSpinButton"
 									Grid.Row="1"
 									Grid.Column="2"
 									FontSize="18"
-									Content="&#xE70D;"
+									Content="{StaticResource ChevronDownGlyph}"
 									Classes="NumberBoxSpinButtonStyle"
 									Margin="0 4 4 4"/>
 

--- a/FluentAvalonia/Styling/StylesV2/BaseResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/BaseResources.axaml
@@ -29,6 +29,9 @@
     <avconv:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="BottomLeft, BottomRight"/>
     <avconv:CornerRadiusFilterConverter x:Key="LeftCornerRadiusFilterConverter" Filter="TopLeft, BottomLeft"/>
 
+    <x:String x:Key="ChevronDownGlyph">&#xE70D;</x:String>
+    <x:String x:Key="ChevronUpGlyph">&#xE70E;</x:String>
+
     <!--
         Preserving for reference:
         <x:String x:Key="ControlFastOutSlowInKeySpline">0,0,0,1</x:String>


### PR DESCRIPTION
PR adds a fix to the `NumberBox` within the `ColorPicker` not being mapped to their correct glyph codepoint. Added two resources `ChevronUpGlyph` and `ChevronDownGlyph` to BaseResources.axaml so both the regular `NumberBox` and the re-templated `NumberBox` within the `ColorPicker` styles are kept in sync.

Fixes #89

![image](https://user-images.githubusercontent.com/40413319/153959542-e4b91a84-dc8c-44e2-8484-61fbdbad0904.png)
