### PR TITLE
Added flyout events to color picker button

### DIFF
--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
@@ -104,6 +104,8 @@ namespace FluentAvalonia.UI.Controls
 
 			// Keep track of which button the flyout is active on
 			_flyoutActive = true;
+
+            FlyoutOpened?.Invoke(this, EventArgs.Empty);
 		}
 
 		private void OnColorPickerColorChanged(ColorPicker sender, ColorChangedEventArgs args)
@@ -115,18 +117,17 @@ namespace FluentAvalonia.UI.Controls
 		{
 			if (_flyoutActive)
 			{
-				_flyoutActive = false;				
-			}
+                FlyoutDismissed?.Invoke(this, EventArgs.Empty);
+            }
 		}
 
 		private void OnFlyoutConfirmed(ColorPickerFlyout sender, object args)
 		{
 			if (_flyoutActive)
 			{
-				_flyoutActive = false;
-
-				Color = _flyout.ColorPicker.Color;
-			}
+                Color = _flyout.ColorPicker.Color;
+                FlyoutConfirmed?.Invoke(this, Color);
+            }
 		}
 
 		private void OnFlyoutClosed(object sender, EventArgs e)
@@ -135,7 +136,13 @@ namespace FluentAvalonia.UI.Controls
 			{
 				_flyout.ColorPicker.ColorChanged -= OnColorPickerColorChanged;
 			}
-		}
+
+            if (_flyoutActive)
+            {
+                FlyoutClosed?.Invoke(this, EventArgs.Empty);
+                _flyoutActive = false;
+            }
+        }
 
 		private static ColorPickerFlyout _flyout;
 

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
@@ -124,9 +124,10 @@ namespace FluentAvalonia.UI.Controls
 		private void OnFlyoutConfirmed(ColorPickerFlyout sender, object args)
 		{
 			if (_flyoutActive)
-			{
+            {
+                var oldColor = Color;
                 Color = _flyout.ColorPicker.Color;
-                FlyoutConfirmed?.Invoke(this, Color);
+                FlyoutConfirmed?.Invoke(this, new ColorChangedEventArgs(oldColor, Color));
             }
 		}
 

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
@@ -1,10 +1,12 @@
-﻿using Avalonia.Data;
+﻿using System;
+using Avalonia.Data;
 using Avalonia;
 using Avalonia.Media;
 using FluentAvalonia.UI.Media;
 using System.Collections.Generic;
 using Avalonia.Collections;
 using Avalonia.Controls;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls
 {
@@ -200,7 +202,24 @@ namespace FluentAvalonia.UI.Controls
 			set => SetValue(ShowAcceptDismissButtonsProperty, value);
 		}
 
-		private bool _isCompact = true;
+        /// <summary>
+        /// Raised when the color change was confirmed and the flyout closes.
+        /// </summary>
+        public event TypedEventHandler<ColorPickerButton, Color> FlyoutConfirmed;
+        /// <summary>
+        /// Raised when the color change was dismissed and the flyout closes.
+        /// </summary>
+        public event TypedEventHandler<ColorPickerButton, object> FlyoutDismissed;
+
+        /// <summary> Raised when the flyout opens.
+        /// </summary>
+        public event TypedEventHandler<ColorPickerButton, object> FlyoutOpened;
+        /// <summary>
+        /// Raised when the flyout closes regardless of confirmation or dismissal.
+        /// </summary>
+        public event TypedEventHandler<ColorPickerButton, object> FlyoutClosed;
+
+        private bool _isCompact = true;
 		private bool _isAlphaEnabled = true;
 		private IEnumerable<Color> _customPaletteColors;
 	}

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
@@ -205,19 +205,21 @@ namespace FluentAvalonia.UI.Controls
         /// <summary>
         /// Raised when the color change was confirmed and the flyout closes.
         /// </summary>
-        public event TypedEventHandler<ColorPickerButton, Color> FlyoutConfirmed;
+        public event TypedEventHandler<ColorPickerButton, ColorChangedEventArgs> FlyoutConfirmed;
+
         /// <summary>
         /// Raised when the color change was dismissed and the flyout closes.
         /// </summary>
-        public event TypedEventHandler<ColorPickerButton, object> FlyoutDismissed;
+        public event TypedEventHandler<ColorPickerButton, EventArgs> FlyoutDismissed;
 
         /// <summary> Raised when the flyout opens.
         /// </summary>
-        public event TypedEventHandler<ColorPickerButton, object> FlyoutOpened;
+        public event TypedEventHandler<ColorPickerButton, EventArgs> FlyoutOpened;
+
         /// <summary>
         /// Raised when the flyout closes regardless of confirmation or dismissal.
         /// </summary>
-        public event TypedEventHandler<ColorPickerButton, object> FlyoutClosed;
+        public event TypedEventHandler<ColorPickerButton, EventArgs> FlyoutClosed;
 
         private bool _isCompact = true;
 		private bool _isAlphaEnabled = true;

--- a/FluentAvalonia/UI/Controls/Flyouts/ColorPickerFlyout.cs
+++ b/FluentAvalonia/UI/Controls/Flyouts/ColorPickerFlyout.cs
@@ -43,9 +43,9 @@ namespace FluentAvalonia.UI.Controls
 
 		protected override void OnConfirmed()
 		{
-			Hide();
-			Confirmed?.Invoke(this, EventArgs.Empty);
-		}
+            Confirmed?.Invoke(this, EventArgs.Empty);
+            Hide();
+        }
 
 		protected override void OnOpening(CancelEventArgs args)
 		{
@@ -57,9 +57,9 @@ namespace FluentAvalonia.UI.Controls
 
 		private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)
 		{
-			Hide();
-			Dismissed?.Invoke(this, EventArgs.Empty);
-		}
+            Dismissed?.Invoke(this, EventArgs.Empty);
+            Hide();
+        }
 
 		private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
 		{


### PR DESCRIPTION
Hi there,

The ColorPickerButton had no way of letting me know when it's flyout was being opened or closed, so I added those events in this PR.

For my own application I've been using the color picker with the confirm/dismiss buttons disabled to realtime show the difference your new selection makes (the new color is displayed on the LEDs of devices). This is great but I need to know when the user is finished picking a color so I can execute an undo/redo command, hence this PR :)

I made a slight tweak to `ColorPickerFlyout` here to make sure events happen in a (to me) more logical order, it also made managing the `_isFlyoutOpen` state of `ColorPickerButton` a bit easier.

The order of things is now always:
- `OnFlyoutOpened`
- `OnFlyoutDismissed` or `OnFlyoutConfirmed`
- `OnFlyoutClosed`

Ofcourse the dismissed/confirmed events never fire if you disabled that functionality, I made sure this doesn't break anything.

PS: I really like what you did with the demo application, great job 👍🏻 