### PR TITLE
Task dialogs!

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/FluentAvalonia/Core/ApplicationModel/CoreApplicationViewTitleBar.cs
+++ b/FluentAvalonia/Core/ApplicationModel/CoreApplicationViewTitleBar.cs
@@ -61,10 +61,18 @@ namespace FluentAvalonia.Core.ApplicationModel
         /// <summary>
         /// Gets the width of the system-reserved region of the upper-right corner of the app window. This region is reserved when the current language is a left-to-right language.
         /// </summary>
-        /// <remarks>
-        /// This is a constant, I've set the buttons to 46px in width * 3 = 138
-        /// </remarks>
-        public double SystemOverlayRightInset => 138;
+        public double SystemOverlayRightInset
+        {
+            get => _insetWidthRight;
+            internal set
+            {
+                if (_insetWidthRight != value)
+                {
+                    _insetWidthRight = value;
+                    LayoutMetricsChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
 
 		public event TypedEventHandler<CoreApplicationViewTitleBar, EventArgs> LayoutMetricsChanged;
 
@@ -122,5 +130,6 @@ namespace FluentAvalonia.Core.ApplicationModel
 		private CoreWindow _owner;
         private IControl _customTitleBar;
         private IDisposable _customTitleBarDisp;
+        private double _insetWidthRight = double.NaN;
 	}
 }

--- a/FluentAvalonia/Core/Internal/VisualStateHelper.cs
+++ b/FluentAvalonia/Core/Internal/VisualStateHelper.cs
@@ -43,7 +43,17 @@ namespace FluentAvalonia.Core
             {
                 var @class = cr.TakeUntil(',');
 
-                ((IPseudoClasses)element.Classes).Set(@class.ToString(), set);
+                if (@class[@class.Length - 1] == '!')
+				{
+                    @class = @class.Slice(0, @class.Length - 1);
+                    ((IPseudoClasses)element.Classes).Set(@class.ToString(), false);
+                }
+                else
+                {
+                    ((IPseudoClasses)element.Classes).Set(@class.ToString(), set);
+                }
+
+                
 
                 if (!cr.End)
                     cr.Skip(1);

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -18,8 +18,8 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.2.1</Version>
-        <AssemblyVersion>1.2.1.0</AssemblyVersion>
+        <Version>1.3.0-beta1</Version>
+        <AssemblyVersion>1.2.1.999</AssemblyVersion>
     </PropertyGroup>
 
 

--- a/FluentAvalonia/Styling/Controls/CoreWindowStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/CoreWindowStyles.axaml
@@ -47,6 +47,10 @@
 		<Setter Property="Foreground" Value="{DynamicResource FATitle_SysCaptionForegroundPressed}" />
 	</Style>
 
+    <Style Selector="Button.SystemCaption:disabled /template/ Border">
+        <Setter Property="Opacity" Value="0.5" />
+    </Style>
+
 	<Style Selector="Window[IsActive=False] Button.SystemCaption /template/ Border">
 		<Setter Property="Background" Value="{DynamicResource FATitle_SysCaptionBackgroundInactive}" />
 	</Style>
@@ -98,6 +102,15 @@
 		<Setter Property="Content" Value="&#xE8BB;" />
 	</Style>
 
+    <Style Selector="Window:windows[CanResize=False] uip|MinMaxCloseControl /template/ Button#MaxRestoreButton">
+        <Setter Property="IsEnabled" Value="False" />
+    </Style>
+    <Style Selector="Window:windows:dialog uip|MinMaxCloseControl /template/ Button#MaxRestoreButton">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="Window:windows:dialog uip|MinMaxCloseControl /template/ Button#MinimizeButton">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
 
 	<Style Selector="Window:windows">
 		<Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource ApplicationPageBackgroundThemeBrush}" />
@@ -117,7 +130,7 @@
 								   VerticalAlignment="Top">
 								<TextBlock Name="TitleText"
 										   Text="{TemplateBinding Title}"
-										   Margin="32 0 0 0"
+										   Margin="12 0 0 0"
 										   FontSize="12"
 										   VerticalAlignment="Center"
 										   HorizontalAlignment="Left" />

--- a/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogButtonStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogButtonStyles.axaml
@@ -1,0 +1,84 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="using:FluentAvalonia.UI.Controls"
+        xmlns:core="using:FluentAvalonia.Core"
+         xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">
+    
+    <!-- TASKDIALOGBUTTONHOST -->
+    <Style Selector="uip|TaskDialogButtonHost">
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThemeThickness}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Name="Root">
+                    <Panel>
+                        <StackPanel Spacing="12" Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    Margin="{TemplateBinding Padding}">
+                            <Viewbox Width="18" Height="18" Name="IconHost">
+                                <ui:IconSourceElement IconSource="{TemplateBinding IconSource}" />
+                            </Viewbox>
+                            
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              CornerRadius="{TemplateBinding CornerRadius}" />
+                        </StackPanel>
+                        
+                        
+                        <Border Name="BorderElement"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                RenderTransform="scaleY(-1)"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                IsHitTestVisible="False" />
+                    </Panel>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="uip|TaskDialogButtonHost /template/ Border#Root">
+        <Setter Property="Transitions">
+            <Transitions>
+                <BrushTransition Duration="00:00:00.083" Property="Background" />
+            </Transitions>
+        </Setter>
+    </Style>
+    <Style Selector="uip|TaskDialogButtonHost /template/ Viewbox#IconHost">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogButtonHost:icon /template/ Viewbox#IconHost">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogButtonHost:pointerover /template/ Border#BorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
+    </Style>
+    <Style Selector="uip|TaskDialogButtonHost:pointerover /template/ Border#Root">
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
+    </Style>
+    
+    <Style Selector="uip|TaskDialogButtonHost:pressed /template/ Border#BorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+    </Style>
+    <Style Selector="uip|TaskDialogButtonHost:pressed /template/ Border#Root">
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogButtonHost:disabled /template/ Border#BorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
+    </Style>
+    <Style Selector="uip|TaskDialogButtonHost:disabled /template/ Border#Root">
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+    </Style>
+</Styles>

--- a/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogCommandStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogCommandStyles.axaml
@@ -1,0 +1,92 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="using:FluentAvalonia.UI.Controls"
+        xmlns:core="using:FluentAvalonia.Core"
+         xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">
+    <!-- TASKDIALOGCOMMAND HOST -->
+    <Style Selector="uip|TaskDialogCommandHost">
+        <Setter Property="Background" Value="{DynamicResource TaskDialogCommandBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TaskDialogCommandBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource TaskDialogCommandBorderThickness}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Padding="{TemplateBinding Padding}"
+                        Name="Root">
+                    <Grid ColumnDefinitions="Auto,*">
+                        <Viewbox Width="18" Height="18" Margin="0 0 12 0" Name="IconHost">
+                            <ui:IconSourceElement IconSource="{Binding IconSource}" />
+                        </Viewbox>
+                        <StackPanel Spacing="2" Grid.Column="1">
+                            <TextBlock Text="{Binding Text}"
+                                       FontWeight="SemiBold"
+                                       Name="Text"/>
+                            <TextBlock Text="{Binding Description}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Name="Description"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost /template/ Border#Root">
+        <Setter Property="Transitions">
+            <Transitions>
+                <BrushTransition Duration="00:00:00.083" Property="Background" />
+            </Transitions>
+        </Setter>
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost /template/ TextBlock#Text">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandTextForeground}" />
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost /template/ TextBlock#Description">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandDescriptionForeground}" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogCommandHost /template/ Viewbox#IconHost">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogCommandHost:icon /template/ Viewbox#IconHost">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogCommandHost:pointerover /template/ Border#Root">
+        <Setter Property="Background" Value="{DynamicResource TaskDialogCommandBackgroundPointerOver}" />
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost:pointerover /template/ TextBlock#Text">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandTextForegroundPointerOver}" />
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost:pointerover /template/ TextBlock#Description">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandDescriptionForegroundPointerOver}" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogCommandHost:pressed /template/ Border#Root">
+        <Setter Property="Background" Value="{DynamicResource TaskDialogCommandBackgroundPressed}" />
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost:pressed /template/ TextBlock#Text">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandTextForegroundPressed}" />
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost:pressed /template/ TextBlock#Description">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandDescriptionForegroundPressed}" />
+    </Style>
+
+    <Style Selector="uip|TaskDialogCommandHost:disabled /template/ Border#Root">
+        <Setter Property="Background" Value="{DynamicResource TaskDialogCommandBackgroundDisabled}" />
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost:disabled /template/ TextBlock#Text">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandTextForegroundDisabled}" />
+    </Style>
+    <Style Selector="uip|TaskDialogCommandHost:disabled /template/ TextBlock#Description">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogCommandDescriptionForegroundDisabled}" />
+    </Style>
+
+</Styles>

--- a/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
@@ -89,7 +89,8 @@
                             Name="ContentRoot">
                         <Grid RowDefinitions="Auto,Auto,*,Auto">
                             <Border Background="{DynamicResource TaskDialogHeaderBackground}"
-                                    Padding="{DynamicResource TaskDialogHeaderPadding}">
+                                    Padding="{DynamicResource TaskDialogHeaderPadding}"
+                                    Name="HeaderRoot">
                                 <TextBlock Text="{TemplateBinding Header}"
                                            TextWrapping="Wrap"
                                            FontSize="{DynamicResource TaskDialogHeaderFontSize}"
@@ -97,7 +98,7 @@
                             </Border>
 
                             <DockPanel Grid.Row="1"
-                                       Name="ContentHost"
+                                       Name="SubHeaderRoot"
                                        Margin="{DynamicResource TaskDialogSubHeaderPadding}">
                                 <Viewbox Name="IconHost"
                                          DockPanel.Dock="Left"
@@ -198,6 +199,12 @@
     <Style Selector="ui|TaskDialog /template/ Viewbox#IconHost">
         <Setter Property="IsVisible" Value="False" />
     </Style>
+    <Style Selector="ui|TaskDialog /template/ Border#HeaderRoot">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="ui|TaskDialog /template/ DockPanel#SubHeaderRoot">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
 
     <Style Selector="ui|TaskDialog /template/ StackPanel#MoreDetailsPanel">
         <Setter Property="IsVisible" Value="False" />
@@ -212,6 +219,18 @@
 
     <Style Selector="ui|TaskDialog /template/ ProgressBar#ProgressBar">
         <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:header /template/ Border#HeaderRoot">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:subheader /template/ DockPanel#SubHeaderRoot">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:icon /template/ DockPanel#SubHeaderRoot">
+        <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="ui|TaskDialog:icon /template/ Viewbox#IconHost">

--- a/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
@@ -1,0 +1,326 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="using:FluentAvalonia.UI.Controls"
+        xmlns:core="using:FluentAvalonia.Core"
+         xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">
+    <Design.PreviewWith>
+        <Border Padding="20">
+            <Border BorderBrush="#35EFEFEF" BorderThickness="1">
+                <ui:TaskDialog IconSource="SaveFilled" IsVisible="True"
+                               Header="Dialog Heading" 
+                               Content="Dialog Content goes here"
+                               FooterVisibility="Auto"
+                               ShowProgressBar="True" core:VisualStateHelper.ForcedClassesProperty=":open,:progressSuspend"
+                           SubHeader="Subheader goes here">
+                    <ui:TaskDialog.Buttons>
+                        <ui:TaskDialogButton Text="OK" IconSource="Checkmark" IsDefault="True" />
+                        <ui:TaskDialogButton Text="Cancel" IconSource="Dismiss" IsEnabled="False"/>
+                    </ui:TaskDialog.Buttons>
+
+                    <ui:TaskDialog.Commands>
+                        <ui:TaskDialogCommand Text="Text here" Description="A bigger description goes here" IconSource="Map" />
+                        <ui:TaskDialogCommand Text="Text here" Description="A bigger description goes here" IsEnabled="False"/>
+                        <ui:TaskDialogCommand Text="Text here"/>
+                        <ui:TaskDialogCheckBox Text="CheckBox" />
+                        <ui:TaskDialogRadioButton Text="RadioButton" />
+                    </ui:TaskDialog.Commands>
+
+                    <ui:TaskDialog.Footer>
+                        <CheckBox Content="Never show me this again" />
+                    </ui:TaskDialog.Footer>
+                </ui:TaskDialog>
+            </Border>
+        </Border>
+    </Design.PreviewWith>
+
+    <Styles.Resources>
+        <x:Double x:Key="TaskDialogMinWidth">320</x:Double>
+        <x:Double x:Key="TaskDialogMaxWidth">648</x:Double>
+        <x:Double x:Key="TaskDialogMinHeight">184</x:Double>
+        <x:Double x:Key="TaskDialogMaxHeight">800</x:Double>
+
+        <x:String x:Key="TaskDialogFooterButtonNormalText">More Details</x:String>
+        <x:String x:Key="TaskDialogFooterButtonExpandedText">Less Details</x:String>
+
+        <Thickness x:Key="TaskDialogHeaderPadding">18 9</Thickness>
+        <Thickness x:Key="TaskDialogSubHeaderPadding">18 9</Thickness>
+        <x:Double x:Key="TaskDialogIconSize">48</x:Double>
+        <Thickness x:Key="TaskDialogContentMargin">18 9</Thickness>
+        <Thickness x:Key="TaskDialogButtonHostMargin">18</Thickness>
+
+        <FontWeight x:Key="TaskDialogHeaderFontWeight">SemiBold</FontWeight>
+        <x:Double x:Key="TaskDialogHeaderFontSize">20</x:Double>
+        <FontWeight x:Key="TaskDialogSubHeaderFontWeight">Normal</FontWeight>
+        <x:Double x:Key="TaskDialogSubHeaderFontSize">16</x:Double>
+    </Styles.Resources>
+
+    <StyleInclude Source="/Styling/Controls/TaskDialog/TaskDialogButtonStyles.axaml" />
+    <StyleInclude Source="/Styling/Controls/TaskDialog/TaskDialogCommandStyles.axaml" />
+    
+    <Style Selector="Button.TaskDialog_MoreDetails">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogFooterButtonForeground}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="Transparent">
+                    <TextBlock Text="{TemplateBinding Content}" />
+                </Border>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="Button.TaskDialog_MoreDetails:pointerover /template/ TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogFooterButtonForegroundPointerOver}" />
+    </Style>
+    <Style Selector="Button.TaskDialog_MoreDetails:pressed /template/ TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogFooterButtonForegroundPressed}" />
+    </Style>
+    
+
+    <Style Selector="ui|TaskDialog">
+        <Setter Property="Background" Value="{DynamicResource ContentDialogBackground}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel Name="LayoutRoot">
+                    <Border Background="{TemplateBinding Background}"
+                            MinWidth="{DynamicResource TaskDialogMinWidth}"
+                            MaxWidth="{DynamicResource TaskDialogMaxWidth}"
+                            MinHeight="{DynamicResource TaskDialogMinHeight}"
+                            MaxHeight="{DynamicResource TaskDialogMaxHeight}"
+                            ClipToBounds="True"
+                            Name="ContentRoot">
+                        <Grid RowDefinitions="Auto,Auto,*,Auto">
+                            <Border Background="{DynamicResource TaskDialogHeaderBackground}"
+                                    Padding="{DynamicResource TaskDialogHeaderPadding}">
+                                <TextBlock Text="{TemplateBinding Header}"
+                                           TextWrapping="Wrap"
+                                           FontSize="{DynamicResource TaskDialogHeaderFontSize}"
+                                           FontWeight="{StaticResource TaskDialogHeaderFontWeight}" />
+                            </Border>
+
+                            <DockPanel Grid.Row="1"
+                                       Name="ContentHost"
+                                       Margin="{DynamicResource TaskDialogSubHeaderPadding}">
+                                <Viewbox Name="IconHost"
+                                         DockPanel.Dock="Left"
+                                         Width="{StaticResource TaskDialogIconSize}"
+                                         Height="{StaticResource TaskDialogIconSize}"
+                                         Margin="0 0 12 0">
+                                    <ui:IconSourceElement IconSource="{TemplateBinding IconSource}" />
+                                </Viewbox>
+
+                                <TextBlock Name="SubHeaderHost"
+                                           Text="{TemplateBinding SubHeader}"
+                                           FontWeight="{StaticResource TaskDialogSubHeaderFontWeight}"
+                                           HorizontalAlignment="Left"
+                                           VerticalAlignment="Center"
+                                           TextWrapping="Wrap"
+                                           FontSize="{StaticResource TaskDialogSubHeaderFontSize}" />
+                            </DockPanel>
+
+                            <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                                          VerticalScrollBarVisibility="Auto"
+                                          Grid.Row="2"
+                                          Margin="{StaticResource TaskDialogContentMargin}">
+                                <StackPanel Spacing="18">
+                                    <ContentPresenter Name="ContentPresenter"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      HorizontalContentAlignment="Stretch"
+                                                      VerticalContentAlignment="Stretch"
+                                                      HorizontalAlignment="Stretch"
+                                                      VerticalAlignment="Stretch"
+                                                      Grid.Row="2">
+                                        <ContentPresenter.Styles>
+                                            <Style Selector="TextBlock">
+                                                <Setter Property="TextWrapping" Value="Wrap" />
+                                            </Style>
+                                        </ContentPresenter.Styles>
+                                    </ContentPresenter>
+
+                                    <ProgressBar Name="ProgressBar"
+                                                 Grid.Row="3" />
+
+                                    <ItemsPresenter Name="CommandsHost"
+                                                    Grid.Row="4">
+                                        <ItemsPresenter.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Spacing="2" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsPresenter.ItemsPanel>
+                                    </ItemsPresenter>
+
+                                    <StackPanel Name="MoreDetailsPanel"
+                                                Grid.Row="5">
+                                        <Button Classes="TaskDialog_MoreDetails"
+                                                Name="MoreDetailsButton"/>
+                                        <ContentPresenter Name="FooterHost"
+                                                          VerticalContentAlignment="Top"
+                                                          HorizontalContentAlignment="Stretch"
+                                                          VerticalAlignment="Top"
+                                                          HorizontalAlignment="Stretch"
+                                                          Content="{TemplateBinding Footer}"
+                                                          ContentTemplate="{TemplateBinding FooterTemplate}" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </ScrollViewer>
+
+                            <Border Padding="{StaticResource TaskDialogButtonHostMargin}"
+                                    Grid.Row="3"
+                                    Background="{DynamicResource TaskDialogButtonAreaBackground}">
+                                <ItemsPresenter Name="ButtonsHost"
+                                                KeyboardNavigation.TabNavigation="Continue">
+                                    <ItemsPresenter.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <uip:TaskDialogButtonsPanel Spacing="8"  />
+                                        </ItemsPanelTemplate>
+                                    </ItemsPresenter.ItemsPanel>
+                                </ItemsPresenter>
+                            </Border>
+                        </Grid>
+                    </Border>
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="ui|TaskDialog:hidden:not(:hosted) /template/ Panel#LayoutRoot">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="ui|TaskDialog:open:not(:hosted) /template/ Panel#LayoutRoot">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+    
+    <Style Selector="ui|TaskDialog /template/ Panel#LayoutRoot">
+        <Setter Property="Background" Value="{x:Null}" />
+    </Style>
+    <Style Selector="ui|TaskDialog /template/ Border#ContentRoot">
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+    </Style>
+    <Style Selector="ui|TaskDialog /template/ Viewbox#IconHost">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog /template/ StackPanel#MoreDetailsPanel">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="ui|TaskDialog /template/ Button#MoreDetailsButton">
+        <Setter Property="Content" Value="{StaticResource TaskDialogFooterButtonNormalText}" />
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="ui|TaskDialog /template/ ContentPresenter#FooterHost">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog /template/ ProgressBar#ProgressBar">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:icon /template/ Viewbox#IconHost">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:footerAuto /template/ Button#MoreDetailsButton">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:footerAuto:expanded /template/ Button#MoreDetailsButton">
+        <Setter Property="Content" Value="{StaticResource TaskDialogFooterButtonExpandedText}" />
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:footer:expanded /template/ ContentPresenter#FooterHost">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+    
+    <Style Selector="ui|TaskDialog:footer /template/ StackPanel#MoreDetailsPanel">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:progress /template/ ProgressBar#ProgressBar">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:progressError /template/ ProgressBar#ProgressBar">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogProgressBarErrorColor}" />
+        <Setter Property="Background" Value="{DynamicResource TaskDialogProgressBarErrorBackgroundColor}" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:progressSuspend /template/ ProgressBar#ProgressBar">
+        <Setter Property="Foreground" Value="{DynamicResource TaskDialogProgressBarSuspendColor}" />
+        <Setter Property="Background" Value="{DynamicResource TaskDialogProgressBarSuspendBackgroundColor}" />
+    </Style>
+
+    <Style Selector="ui|TaskDialog:hosted /template/ Panel#LayoutRoot">
+        <Setter Property="Background" Value="{DynamicResource TaskDialogSmokeFill}" />
+    </Style>
+    <Style Selector="ui|TaskDialog:hosted /template/ Border#ContentRoot">
+        <Setter Property="BorderBrush" Value="{DynamicResource TaskDialogBorderBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource TaskDialogBorderWidth}" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="BoxShadow" Value="0 8 32 0 #66000000" />
+    </Style>
+
+    <!--Handle hidden dialog-->
+    <Style Selector="ui|TaskDialog:hosted:hidden /template/ Panel#LayoutRoot">
+        <Style.Animations>
+            <Animation Duration="00:00:00.167" FillMode="Forward">
+                <KeyFrame Cue="0%">
+                    <Setter Property="Opacity" Value="1.0"/>
+                </KeyFrame>
+                <KeyFrame Cue="100%">
+                    <Setter Property="Opacity" Value="0.0"/>
+                    <Setter Property="IsVisible" Value="False" />
+                </KeyFrame>
+            </Animation>
+        </Style.Animations>
+    </Style>
+    <Style Selector="ui|TaskDialog:hosted:hidden /template/ Border#ContentRoot">
+        <Style.Animations>
+            <Animation Duration="00:00:00.167" FillMode="Forward">
+                <KeyFrame Cue="0%">
+                    <Setter Property="ScaleTransform.ScaleX" Value="1.0"/>
+                    <Setter Property="ScaleTransform.ScaleY" Value="1.0"/>
+                </KeyFrame>
+                <KeyFrame Cue="100%" KeySpline="0,0 0,1">
+                    <Setter Property="ScaleTransform.ScaleX" Value="1.05"/>
+                    <Setter Property="ScaleTransform.ScaleY" Value="1.05"/>
+                </KeyFrame>
+            </Animation>
+        </Style.Animations>
+    </Style>
+
+    <!--Handle open dialog-->
+    <Style Selector="ui|TaskDialog:hosted:open /template/ Panel#LayoutRoot">
+        <Setter Property="IsVisible" Value="True"/>
+        <Style.Animations>
+            <!-- Animation applies with priority of LocalValue
+                 To overrule the IsVisible=False in :hidden, set
+                 IsVisible=True in BOTH KeyFrames here -->
+            <Animation Duration="00:00:00.250" FillMode="Forward">
+                <KeyFrame Cue="0%">
+                    <Setter Property="IsVisible" Value="True"/>
+                    <Setter Property="Opacity" Value="0.0"/>
+                </KeyFrame>
+                <KeyFrame Cue="100%">
+                    <Setter Property="IsVisible" Value="True"/>
+                    <Setter Property="Opacity" Value="1.0"/>
+                </KeyFrame>
+            </Animation>
+        </Style.Animations>
+    </Style>
+    <Style Selector="ui|TaskDialog:hosted:open /template/ Border#ContentRoot">
+        <Style.Animations>
+            <Animation Duration="00:00:00.250" FillMode="Forward">
+                <KeyFrame Cue="0%">
+                    <Setter Property="ScaleTransform.ScaleX" Value="1.05"/>
+                    <Setter Property="ScaleTransform.ScaleY" Value="1.05"/>
+                </KeyFrame>
+                <KeyFrame Cue="100%" KeySpline="0,0 0,1">
+                    <Setter Property="ScaleTransform.ScaleX" Value="1.00"/>
+                    <Setter Property="ScaleTransform.ScaleY" Value="1.00"/>
+                </KeyFrame>
+            </Animation>
+        </Style.Animations>
+    </Style>
+</Styles>

--- a/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
@@ -85,7 +85,6 @@
                             MaxWidth="{DynamicResource TaskDialogMaxWidth}"
                             MinHeight="{DynamicResource TaskDialogMinHeight}"
                             MaxHeight="{DynamicResource TaskDialogMaxHeight}"
-                            ClipToBounds="True"
                             Name="ContentRoot">
                         <Grid RowDefinitions="Auto,Auto,*,Auto">
                             <Border Background="{DynamicResource TaskDialogHeaderBackground}"
@@ -166,7 +165,8 @@
 
                             <Border Padding="{StaticResource TaskDialogButtonHostMargin}"
                                     Grid.Row="3"
-                                    Background="{DynamicResource TaskDialogButtonAreaBackground}">
+                                    Background="{DynamicResource TaskDialogButtonAreaBackground}"
+                                    Name="ButtonBorder">
                                 <ItemsPresenter Name="ButtonsHost"
                                                 KeyboardNavigation.TabNavigation="Continue">
                                     <ItemsPresenter.ItemsPanel>
@@ -278,6 +278,12 @@
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="BoxShadow" Value="0 8 32 0 #66000000" />
+    </Style>
+    <Style Selector="ui|TaskDialog:hosted /template/ Border#HeaderRoot">
+        <Setter Property="CornerRadius" Value="{Binding Source={StaticResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}}" />
+    </Style>
+    <Style Selector="ui|TaskDialog:hosted /template/ Border#ButtonBorder">
+        <Setter Property="CornerRadius" Value="{Binding Source={StaticResource OverlayCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}}" />
     </Style>
 
     <!--Handle hidden dialog-->

--- a/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml
@@ -44,7 +44,7 @@
 
         <Thickness x:Key="TaskDialogHeaderPadding">18 9</Thickness>
         <Thickness x:Key="TaskDialogSubHeaderPadding">18 9</Thickness>
-        <x:Double x:Key="TaskDialogIconSize">48</x:Double>
+        <x:Double x:Key="TaskDialogIconSize">36</x:Double>
         <Thickness x:Key="TaskDialogContentMargin">18 9</Thickness>
         <Thickness x:Key="TaskDialogButtonHostMargin">18</Thickness>
 

--- a/FluentAvalonia/Styling/StylesV2/Controls.txt
+++ b/FluentAvalonia/Styling/StylesV2/Controls.txt
@@ -76,3 +76,4 @@
 /Styling/Controls/CommandBar/CommandBarFlyoutCommandBarStyles.axaml
 /Styling/Controls/InfoBadgeStyles.axaml
 /Styling/Controls/TabView/TabViewStyles.axaml
+/Styling/Controls/TaskDialog/TaskDialogStyles.axaml

--- a/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
@@ -1945,4 +1945,50 @@
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
+
+
+    <!-- TASK DIALOG -->
+    <!-- Dialog -->
+    <StaticResource x:Key="TaskDialogHeaderBackground" ResourceKey="LayerFillColorAltBrush" />
+    <StaticResource x:Key="TaskDialogBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
+    <StaticResource x:Key="TaskDialogButtonAreaBackground" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarErrorColor" ResourceKey="SystemFillColorCriticalBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarSuspendColor" ResourceKey="SystemFillColorCautionBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarErrorBackgroundColor" ResourceKey="SystemFillColorCriticalBackgroundBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarSuspendBackgroundColor" ResourceKey="SystemFillColorCautionBackgroundBrush" />
+    <StaticResource x:Key="TaskDialogFooterButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogFooterButtonForegroundPointerOver" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogFooterButtonForegroundPressed" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogSmokeFill" ResourceKey="SmokeFillColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogBorderBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
+    <Thickness x:Key="TaskDialogBorderWidth">1</Thickness>
+    <!-- Buttons -->
+    <StaticResource x:Key="TaskDialogButtonBackground" ResourceKey="ControlFillColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrush" ResourceKey="ControlElevationBorderBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+    <Thickness x:Key="TaskDialogButtonBorderThickness">1</Thickness>
+    <!-- Commands -->
+    <StaticResource x:Key="TaskDialogCommandBackground" ResourceKey="SystemControlTransparentBrush" />
+    <StaticResource x:Key="TaskDialogCommandBorderBrush" ResourceKey="SystemControlTransparentBrush" />
+    <Thickness x:Key="TaskDialogCommandBorderThickness">0</Thickness>
+    <StaticResource x:Key="TaskDialogCommandTextForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForeground" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundPointerOver" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundPressed" ResourceKey="AccentTextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundDisabled" ResourceKey="AccentTextFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
 </ResourceDictionary>

--- a/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <!-- TODO: Get the Color resources -->
+    
     <!-- These defaults are taken from Windows 10 High Contrast theme -->
     <Color x:Key="SystemColorWindowTextColor">#FFFFFF</Color>
     <Color x:Key="SystemColorGrayTextColor">#FF3FF23F</Color>
@@ -1887,4 +1887,48 @@
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
+
+
+    <!-- TASK DIALOG -->
+    <!-- Dialog -->
+    <StaticResource x:Key="TaskDialogHeaderBackground" ResourceKey="LayerFillColorAltBrush" />
+    <StaticResource x:Key="TaskDialogBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
+    <StaticResource x:Key="TaskDialogButtonAreaBackground" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarErrorColor" ResourceKey="SystemFillColorCriticalBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarSuspendColor" ResourceKey="SystemFillColorCautionBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarErrorBackgroundColor" ResourceKey="SystemFillColorCriticalBackgroundBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarSuspendBackgroundColor" ResourceKey="SystemFillColorCautionBackgroundBrush" />
+    <StaticResource x:Key="TaskDialogFooterButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogSmokeFill" ResourceKey="SmokeFillColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogBorderBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
+    <Thickness x:Key="TaskDialogBorderWidth">1</Thickness>
+    <!-- Buttons -->
+    <StaticResource x:Key="TaskDialogButtonBackground" ResourceKey="ControlFillColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrush" ResourceKey="ControlElevationBorderBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+    <Thickness x:Key="TaskDialogButtonBorderThickness">1</Thickness>
+    <!-- Commands -->
+    <StaticResource x:Key="TaskDialogCommandBackground" ResourceKey="SystemControlTransparentBrush" />
+    <StaticResource x:Key="TaskDialogCommandBorderBrush" ResourceKey="SystemControlTransparentBrush" />
+    <Thickness x:Key="TaskDialogCommandBorderThickness">0</Thickness>
+    <StaticResource x:Key="TaskDialogCommandTextForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForeground" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundPointerOver" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundPressed" ResourceKey="AccentTextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundDisabled" ResourceKey="AccentTextFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />    
 </ResourceDictionary>

--- a/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
@@ -1820,7 +1820,7 @@
     <Thickness x:Key="IconInfoBadgeIconMargin">4,4,4,4</Thickness>
 
     <!-- TABVIEW -->
-    <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SystemControlBackgroundBaseLowBrush" />
+    <!--<StaticResource x:Key="TabViewBackground"                                       ResourceKey="SystemControlBackgroundBaseLowBrush" />
     <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="SystemControlBackgroundBaseLowBrush" />
     <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SystemControlHighlightChromeHighBrush" />
     <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="SystemControlHighlightChromeHighBrush" />
@@ -1866,26 +1866,26 @@
     <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonForeground"           ResourceKey="SystemControlBackgroundBaseMediumBrush" />
     <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonForeground"       ResourceKey="SystemControlBackgroundBaseMediumBrush" />
     <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonForeground"          ResourceKey="SystemControlBackgroundBaseMediumBrush" />
-    <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground"          ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+    <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground"          ResourceKey="SystemControlDisabledBaseMediumLowBrush" />-->
 
     <!-- Note: These theme resources below are no longer used and might be removed in a future WinUI update. -->
-    <StaticResource x:Key="TabViewButtonBackgroundActiveTab"                        ResourceKey="SystemControlTransparentBrush" />
+    <!--<StaticResource x:Key="TabViewButtonBackgroundActiveTab"                        ResourceKey="SystemControlTransparentBrush" />
     <StaticResource x:Key="TabViewButtonForegroundActiveTab"                        ResourceKey="SystemControlBackgroundBaseMediumBrush" />
 
     <StaticResource x:Key="TabViewBorderBrush"                                      ResourceKey="CardStrokeColorDefault" />
-    <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />
+    <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />-->
     <!-- NOTE THIS WAS CHANGED UNTIL WE GET BRUSH TRANSFORMS IMPLEMENTED -->
-    <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-        <!--MappingMode="Absolute" 
+    <!--<LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+        MappingMode="Absolute" 
         <LinearGradientBrush.RelativeTransform>
             <ScaleTransform ScaleY="-1" CenterY="0.5"/>
         </LinearGradientBrush.RelativeTransform>-->
-        <LinearGradientBrush.GradientStops>
+    <!--<LinearGradientBrush.GradientStops>
             <GradientStop Offset="0.88" Color="{DynamicResource SystemColorHighlightColor}"/>
             <GradientStop Offset="0.88" Color="Transparent"/>
 
         </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
+    </LinearGradientBrush>-->
 
 
 

--- a/FluentAvalonia/Styling/StylesV2/LightResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/LightResources.axaml
@@ -2008,6 +2008,51 @@
 
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
+
     
     
+    <!-- TASK DIALOG -->
+    <!-- Dialog -->
+    <StaticResource x:Key="TaskDialogHeaderBackground" ResourceKey="LayerFillColorAltBrush" />
+    <StaticResource x:Key="TaskDialogBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
+    <StaticResource x:Key="TaskDialogButtonAreaBackground" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarErrorColor" ResourceKey="SystemFillColorCriticalBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarSuspendColor" ResourceKey="SystemFillColorCautionBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarErrorBackgroundColor" ResourceKey="SystemFillColorCriticalBackgroundBrush" />
+    <StaticResource x:Key="TaskDialogProgressBarSuspendBackgroundColor" ResourceKey="SystemFillColorCautionBackgroundBrush" />
+    <StaticResource x:Key="TaskDialogFooterButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogFooterButtonForegroundPointerOver" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogFooterButtonForegroundPressed" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogSmokeFill" ResourceKey="SmokeFillColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogBorderBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
+    <Thickness x:Key="TaskDialogBorderWidth">1</Thickness>
+    <!-- Buttons -->
+    <StaticResource x:Key="TaskDialogButtonBackground" ResourceKey="ControlFillColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrush" ResourceKey="ControlElevationBorderBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+    <StaticResource x:Key="TaskDialogButtonBorderBrushDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+    <Thickness x:Key="TaskDialogButtonBorderThickness">1</Thickness>
+    <!-- Commands -->
+    <StaticResource x:Key="TaskDialogCommandBackground" ResourceKey="SystemControlTransparentBrush" />
+    <StaticResource x:Key="TaskDialogCommandBorderBrush" ResourceKey="SystemControlTransparentBrush" />
+    <Thickness x:Key="TaskDialogCommandBorderThickness">0</Thickness>
+    <StaticResource x:Key="TaskDialogCommandTextForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForeground" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundPointerOver" ResourceKey="AccentTextFillColorPrimaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundPressed" ResourceKey="AccentTextFillColorSecondaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
+    <StaticResource x:Key="TaskDialogCommandBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+    <StaticResource x:Key="TaskDialogCommandTextForegroundDisabled" ResourceKey="AccentTextFillColorDisabledBrush" />
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
 </ResourceDictionary>

--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -13,10 +13,10 @@ using System.Threading.Tasks;
 
 namespace FluentAvalonia.UI.Controls
 {
-	/// <summary>
-	/// Presents a asyncronous dialog to the user.
-	/// </summary>
-	public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
+    /// <summary>
+    /// Presents a asyncronous dialog to the user.
+    /// </summary>
+    public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
 	{
 		public ContentDialog()
 		{
@@ -591,65 +591,5 @@ namespace FluentAvalonia.UI.Controls
 		private Button _primaryButton;
 		private Button _secondaryButton;
 		private Button _closeButton;
-	}
-
-	/// <summary>
-	/// Special control to host a <see cref="ContentDialog"/>
-	/// </summary>
-	/// <remarks>
-	/// This class should generally not be used outside of FluentAvalonia, and is
-	/// only public for Xaml styling support
-	/// </remarks>
-	public class DialogHost : ContentControl, IStyleable
-	{
-		public DialogHost()
-		{
-			Background = null;
-			HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center;
-			VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center;
-		}
-
-		Type IStyleable.StyleKey => typeof(OverlayPopupHost);
-
-		protected override Size MeasureOverride(Size availableSize)
-		{
-			_ = base.MeasureOverride(availableSize);
-
-			if (this.VisualRoot is TopLevel tl)
-			{
-				return tl.ClientSize;
-			}
-			else if (VisualRoot is IControl c)
-			{
-				return c.Bounds.Size;
-			}
-
-			return Size.Empty;
-		}
-
-		protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
-		{
-			base.OnAttachedToVisualTree(e);
-			if (e.Root is IControl wb)
-			{
-				// OverlayLayer is a Canvas, so we won't get a signal to resize if the window
-				// bounds change. Subscribe to force update
-				_rootBoundsWatcher = wb.GetObservable(BoundsProperty).Subscribe(_ => OnRootBoundsChanged());
-			}
-		}
-
-		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-		{
-			base.OnDetachedFromVisualTree(e);
-			_rootBoundsWatcher?.Dispose();
-			_rootBoundsWatcher = null;
-		}
-
-		private void OnRootBoundsChanged()
-		{
-			InvalidateMeasure();
-		}
-
-		private IDisposable _rootBoundsWatcher;
 	}
 }

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
@@ -65,9 +65,48 @@ namespace FluentAvalonia.UI.Controls
         /// </summary>
 		public CoreApplicationViewTitleBar TitleBar => _titleBar;
 
+        /// <summary>
+        /// Gets or sets whether the window should show in a dialog state with the 
+        /// maximize and minimize buttons hidden.
+        /// </summary>
+        /// <remarks>
+        ///  WINDOWS only, only respected on window launch
+        /// </remarks>
+        public bool ShowAsDialog
+        {
+            get => _hideSizeButtons;
+            set
+            {
+                _hideSizeButtons = value;
+                PseudoClasses.Set(":dialog", value);
+            }
+        }
+
         protected internal bool IsWindows11 { get; internal set; }
 
-		protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            var sz = base.MeasureOverride(availableSize);
+
+            if (_systemCaptionButtons != null)
+            {
+                var wid = _systemCaptionButtons.DesiredSize.Width;
+                if (_customTitleBar != null)
+                {
+                    wid += _defaultTitleBar.DesiredSize.Width;
+                }
+
+                if (_titleBar.SystemOverlayRightInset != wid)
+                {
+                    _titleBar.SystemOverlayRightInset = wid;
+                    _defaultTitleBar.Margin = new Avalonia.Thickness(0, 0, _titleBar.SystemOverlayRightInset, 0);
+                }
+            }
+
+            return sz;
+        }
+
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
 		{
 			base.OnApplyTemplate(e);
 
@@ -79,12 +118,14 @@ namespace FluentAvalonia.UI.Controls
 
 			if (_defaultTitleBar != null)
 			{
-				_defaultTitleBar.Margin = new Avalonia.Thickness(0, 0, _titleBar.SystemOverlayRightInset, 0);
+				//_defaultTitleBar.Margin = new Avalonia.Thickness(0, 0, _titleBar.SystemOverlayRightInset, 0);
 				_defaultTitleBar.Height = _titleBar.Height;
 			}
 
 			if (_systemCaptionButtons != null)
 			{
+                //_systemCaptionButtons.ApplyTemplate();
+
 				_systemCaptionButtons.Height = _titleBar.Height;
 			}
 
@@ -100,7 +141,7 @@ namespace FluentAvalonia.UI.Controls
 						_titleBar.Height, 0, 0);
 				}
 			}
-
+               
 			SetTitleBarColors();
 		}
 
@@ -187,6 +228,9 @@ namespace FluentAvalonia.UI.Controls
 
 		internal bool HitTestMaximizeButton(Point pos)
 		{
+            if (ShowAsDialog || !CanResize)
+                return false;
+
 			return _systemCaptionButtons.HitTestMaxButton(pos);
 		}
 
@@ -292,5 +336,6 @@ namespace FluentAvalonia.UI.Controls
 		private Panel _defaultTitleBar;
 		private IControl _customTitleBar;
 		private Border _templateRoot;
+        private bool _hideSizeButtons;
 	}
 }

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
@@ -88,12 +88,22 @@ namespace FluentAvalonia.UI.Controls
         {
             var sz = base.MeasureOverride(availableSize);
 
+            // UGLY HACK: Seems with CanResize=False, the window shrinks exactly the amount
+            // we modify the window in WM_NCCALCSIZE so we need to fix that here
+            // But the content measures to the normal size - so in constrained environments
+            // like the TaskDialog, stuff gets cut off
+            if (!CanResize && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                sz = sz.WithWidth(sz.Width + 16)
+                    .WithHeight(sz.Height + 8);
+            }
+
             if (_systemCaptionButtons != null)
             {
                 var wid = _systemCaptionButtons.DesiredSize.Width;
                 if (_customTitleBar != null)
                 {
-                    wid += _defaultTitleBar.DesiredSize.Width;
+                    wid += _defaultTitleBar.Width;
                 }
 
                 if (_titleBar.SystemOverlayRightInset != wid)

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
@@ -42,19 +42,14 @@ namespace FluentAvalonia.UI.Controls
 				if (PlatformImpl is CoreWindowImpl cwi)
 				{
 					cwi.SetOwner(this);
+                    cwi.WindowOpened += WindowOpened_Windows;
 				}
 
 				ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.NoChrome;
 				ExtendClientAreaToDecorationsHint = true;
 				PseudoClasses.Add(":windows");
 
-				ApplicationViewTitleBar.Instance.TitleBarPropertyChanged += OnTitleBarPropertyChanged;
-
-                var faTheme = AvaloniaLocator.Current.GetService<FluentAvaloniaTheme>();
-                if (faTheme != null)
-                {
-                    faTheme.RequestedThemeChanged += OnRequestedThemeChanged;
-                }
+                PlatformImpl.Closed += WindowClosed_Windows;
 			}
 		}
 
@@ -155,7 +150,32 @@ namespace FluentAvalonia.UI.Controls
 			SetTitleBarColors();
 		}
 
-		internal void ExtendTitleBar(bool extend)
+        private void WindowOpened_Windows(object sender, EventArgs e)
+        {
+            ApplicationViewTitleBar.Instance.TitleBarPropertyChanged += OnTitleBarPropertyChanged;
+
+            var faTheme = AvaloniaLocator.Current.GetService<FluentAvaloniaTheme>();
+            if (faTheme != null)
+            {
+                faTheme.RequestedThemeChanged += OnRequestedThemeChanged;
+            }
+        }
+
+        private void WindowClosed_Windows()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                ApplicationViewTitleBar.Instance.TitleBarPropertyChanged -= OnTitleBarPropertyChanged;
+
+                var faTheme = AvaloniaLocator.Current.GetService<FluentAvaloniaTheme>();
+                if (faTheme != null)
+                {
+                    faTheme.RequestedThemeChanged -= OnRequestedThemeChanged;
+                }
+            }
+        }
+
+        internal void ExtendTitleBar(bool extend)
 		{
 			if (Design.IsDesignMode)
 				return;

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
@@ -26,6 +26,8 @@ namespace FluentAvalonia.UI.Controls
 			_isWindows11 = version.BuildNumber >= 22000;
 		}
 
+        public event EventHandler WindowOpened;
+
 		protected override IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
 		{
 			switch ((WM)msg)
@@ -120,7 +122,14 @@ namespace FluentAvalonia.UI.Controls
 			return base.WndProc(hWnd, msg, wParam, lParam);
 		}
 
-		internal void SetOwner(CoreWindow wnd)
+        public override void Show(bool activate, bool isDialog)
+        {
+            base.Show(activate, isDialog);
+
+            WindowOpened?.Invoke(this, EventArgs.Empty);
+        }
+
+        internal void SetOwner(CoreWindow wnd)
 		{
 			 _owner = wnd;
 			((IPseudoClasses)wnd.Classes).Set(":windows10", !_isWindows11);

--- a/FluentAvalonia/UI/Controls/Internal/DialogHost.cs
+++ b/FluentAvalonia/UI/Controls/Internal/DialogHost.cs
@@ -1,0 +1,115 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Styling;
+using System;
+
+namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Special control to host a <see cref="ContentDialog"/> or <see cref="TaskDialog"/>
+    /// </summary>
+    /// <remarks>
+    /// This class should generally not be used outside of FluentAvalonia, and is
+    /// only public for Xaml styling support
+    /// </remarks>
+    public class DialogHost : ContentControl, IStyleable
+	{
+		public DialogHost()
+		{
+			Background = null;
+			HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center;
+			VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center;
+		}
+
+		Type IStyleable.StyleKey => typeof(OverlayPopupHost);
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			_ = base.MeasureOverride(availableSize);
+
+			if (VisualRoot is TopLevel tl)
+			{
+				return tl.ClientSize;
+			}
+			else if (VisualRoot is IControl c)
+			{
+				return c.Bounds.Size;
+			}
+
+			return Size.Empty;
+		}
+
+		protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+		{
+			base.OnAttachedToVisualTree(e);
+			if (e.Root is IControl wb)
+			{
+				// OverlayLayer is a Canvas, so we won't get a signal to resize if the window
+				// bounds change. Subscribe to force update
+				_rootBoundsWatcher = wb.GetObservable(BoundsProperty).Subscribe(_ => OnRootBoundsChanged());
+			}
+		}
+
+		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+		{
+			base.OnDetachedFromVisualTree(e);
+			_rootBoundsWatcher?.Dispose();
+			_rootBoundsWatcher = null;
+		}
+
+        protected override void OnPointerEnter(PointerEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnPointerLeave(PointerEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnPointerReleased(PointerReleasedEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnPointerMoved(PointerEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnKeyUp(KeyEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        private void OnRootBoundsChanged()
+		{
+			InvalidateMeasure();
+		}
+
+		private IDisposable _rootBoundsWatcher;
+	}
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
@@ -1,0 +1,44 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+
+namespace FluentAvalonia.UI.Controls.Primitives
+{
+    /// <summary>
+    /// Represents a button in a TaskDialog
+    /// </summary>
+    /// <remarks>
+    /// This type should not be used directly and is generated automatically
+    /// by a TaskDialog
+    /// </remarks>
+    public class TaskDialogButtonHost : Avalonia.Controls.Button
+    {
+        public static readonly StyledProperty<IconSource> IconSourceProperty =
+            AvaloniaProperty.Register<TaskDialogButtonHost, IconSource>(nameof(IconSource));
+
+        public IconSource IconSource
+        {
+            get => GetValue(IconSourceProperty);
+            set => SetValue(IconSourceProperty, value);
+        }
+
+        protected override void OnClick()
+        {
+            base.OnClick();
+
+            if (DataContext is TaskDialogButton tdb)
+            {
+                tdb.RaiseClick();
+            }
+        }
+
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == IconSourceProperty)
+            {
+                PseudoClasses.Set(":icon", change.NewValue.GetValueOrDefault() != null);
+            }
+        }
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogCommandHost.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogCommandHost.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia;
+
+namespace FluentAvalonia.UI.Controls.Primitives
+{
+    /// <summary>
+    /// Represents a command button in a TaskDialog
+    /// </summary>
+    /// <remarks>
+    /// This type should not be used directly and is generated automatically
+    /// by a TaskDialog
+    /// </remarks>
+    public class TaskDialogCommandHost : TaskDialogButtonHost
+    {
+        public static readonly StyledProperty<string> DescriptionProperty =
+            AvaloniaProperty.Register<TaskDialogCommandHost, string>(nameof(Description));
+
+        public string Description
+        {
+            get => GetValue(DescriptionProperty);
+            set => SetValue(DescriptionProperty, value);
+        }
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -16,7 +16,7 @@ using AvButton = Avalonia.Controls.Button;
 namespace FluentAvalonia.UI.Controls
 {
     [PseudoClasses(":hosted", ":hidden", ":open")]
-    [PseudoClasses(":icon", ":footer", ":footerAuto", ":expanded")]
+    [PseudoClasses(":header", ":subheader", ":icon", ":footer", ":footerAuto", ":expanded")]
     [PseudoClasses(":progress", ":progressError", ":progressSuspend")]
     /// <summary>
     /// Represents and enhanced dialog with enhanced button, command, and progress support
@@ -75,6 +75,14 @@ namespace FluentAvalonia.UI.Controls
             else if (change.Property == IconSourceProperty)
             {
                 PseudoClasses.Set(":icon", change.NewValue.GetValueOrDefault() != null);
+            }
+            else if (change.Property == HeaderProperty)
+            {
+                PseudoClasses.Set(":header", change.NewValue.GetValueOrDefault() != null);
+            }
+            else if (change.Property == SubHeaderProperty)
+            {
+                PseudoClasses.Set(":subheader", change.NewValue.GetValueOrDefault() != null);
             }
         }
        

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -1,0 +1,512 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAvalonia.UI.Controls.Primitives;
+using AvButton = Avalonia.Controls.Button;
+
+namespace FluentAvalonia.UI.Controls
+{
+    [PseudoClasses(":hosted", ":hidden", ":open")]
+    [PseudoClasses(":icon", ":footer", ":footerAuto", ":expanded")]
+    [PseudoClasses(":progress", ":progressError", ":progressSuspend")]
+    /// <summary>
+    /// Represents and enhanced dialog with enhanced button, command, and progress support
+    /// </summary>
+    public partial class TaskDialog : ContentControl
+    {
+        public TaskDialog()
+        {
+            PseudoClasses.Add(":hidden");
+            _buttons = new List<TaskDialogButton>();
+            _commands = new List<TaskDialogCommand>();
+
+            AddHandler(AvButton.ClickEvent, OnButtonClick, RoutingStrategies.Bubble, true);
+            AddHandler(KeyDownEvent, OnKeyDownPreview, RoutingStrategies.Tunnel, true);
+        }
+
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+        {
+            base.OnApplyTemplate(e);
+
+            _buttonsHost = e.NameScope.Get<ItemsPresenter>("ButtonsHost");
+            _commandsHost = e.NameScope.Get<ItemsPresenter>("CommandsHost");
+
+            _moreDetailsButton = e.NameScope.Find<AvButton>("MoreDetailsButton");
+
+            _progressBar = e.NameScope.Find<ProgressBar>("ProgressBar");
+
+            if (_moreDetailsButton != null)
+            {
+                _moreDetailsButton.Click += MoreDetailsButtonClick;
+            }
+
+            SetButtons();
+            SetCommands();
+        }
+
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == FooterVisibilityProperty)
+            {
+                var val = change.NewValue.GetValueOrDefault<TaskDialogFooterVisibility>();
+
+                PseudoClasses.Set(":footerAuto", val == TaskDialogFooterVisibility.Auto);
+                PseudoClasses.Set(":footer", val != TaskDialogFooterVisibility.Never);
+            }
+            else if (change.Property == IsFooterExpandedProperty)
+            {
+                PseudoClasses.Set(":expanded", change.NewValue.GetValueOrDefault<bool>());
+            }
+            else if (change.Property == ShowProgressBarProperty)
+            {
+                PseudoClasses.Set(":progress", change.NewValue.GetValueOrDefault<bool>());
+            }
+            else if (change.Property == IconSourceProperty)
+            {
+                PseudoClasses.Set(":icon", change.NewValue.GetValueOrDefault() != null);
+            }
+        }
+       
+        private void OnKeyDownPreview(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Hide();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Enter)
+            {
+                if (_defaultButton != null && _defaultButton.DataContext is TaskDialogButton b)
+                {
+                    if (b.Command?.CanExecute(b.CommandParameter) == true)
+                    {
+                        b.Command.Execute(b.CommandParameter);
+                    }
+
+                    b.RaiseClick();
+
+                    if (b is TaskDialogCommand com && !com.ClosesOnInvoked)
+                        return;
+
+                    CloseCore(b.DialogResult);
+                    e.Handled = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Shows the TaskDialog
+        /// </summary>
+        /// <param name="showHosted">Optional parameter that specifies whether this dialog should show in the OverlayLayer even on windowing platforms. Defaults to false</param>
+        /// <returns>The TaskDialog result corresponding to the command/button used to close the dialog</returns>
+        /// <remarks>
+        /// Before calling this method, you MUST set <see cref="XamlRoot"/> property to the TopLevel/Window that should
+        /// own or host this Dialog. If you declare the dialog in Xaml, this is done automatically since 
+        /// the dialog is already attached to the visual tree
+        /// </remarks>
+        public async Task<object> ShowAsync(bool showHosted = false)
+        {
+            bool declaredInXaml = ((IVisual)this).IsAttachedToVisualTree;
+            if (!declaredInXaml && XamlRoot == null)
+            {
+                throw new InvalidOperationException("XamlRoot not set on TaskDialog. This should be set to the TopLevel that should own or host the dialog.");
+            }
+
+            OnOpening();
+
+            var owner = XamlRoot ?? VisualRoot;
+
+            void UnparentDialog()
+            {
+                _xamlOwner = Parent;
+                if (_xamlOwner is Panel p)
+                {
+                    _xamlOwnerChildIndex = p.Children.IndexOf(this);
+                    p.Children.RemoveAt(_xamlOwnerChildIndex);
+                }
+                else if (_xamlOwner is IContentControl icc)
+                {
+                    icc.Content = null;
+                }
+                else if (_xamlOwner is IContentPresenter icp)
+                {
+                    icp.Content = null;
+                }
+                else if (_xamlOwner is Decorator d)
+                {
+                    d.Child = null;
+                }
+            }
+
+            if (showHosted || !(owner is WindowBase))
+            {
+                // Hosted in OverlayLayer
+                _tcs = new TaskCompletionSource<object>();
+                if (declaredInXaml)
+                {
+                    UnparentDialog();
+                }
+
+                var host = new DialogHost
+                {
+                    Content = this
+                };
+                _host = host;
+
+                var overlayLayer = OverlayLayer.GetOverlayLayer(owner);
+                if (overlayLayer == null)
+                    throw new InvalidOperationException("Unable to find OverlayLayer for hosting the TaskDialog");
+
+                overlayLayer.Children.Add(host);
+                PseudoClasses.Set(":hosted", true);
+
+                OnOpened();
+
+                PseudoClasses.Set(":open", true);                
+                PseudoClasses.Set(":hidden", false);
+
+                return await _tcs.Task;
+            }
+            else
+            {
+                if (declaredInXaml)
+                {
+                    UnparentDialog();
+                }
+
+                PseudoClasses.Set(":hidden", false);
+                var host = new TaskDialogWindowHost(this);
+                host[!Window.TitleProperty] = this[!TitleProperty];
+                host.Opened += (s, e) =>
+                {
+                    OnOpened();
+                };
+
+                _host = host;
+                IsVisible = true;
+
+                var result = await host.ShowDialog<object>(owner as Window);
+
+                return result ?? TaskDialogStandardResult.None;
+            }
+        }
+
+        /// <summary>
+        /// Hides the TaskDialog with a <see cref="TaskDialogStandardResult.None"/> result
+        /// </summary>
+        public void Hide()
+        {
+            CloseCore(TaskDialogStandardResult.None);
+        }
+
+        /// <summary>
+        /// Hides the dialog with the specified dialog result
+        /// </summary>
+        public void Hide(object result)
+        {
+            CloseCore(result);
+        }
+
+        internal void CompleteClosingDeferral(object result) 
+        {
+            IsEnabled = true;
+            FinalCloseDialog(result);
+        }
+
+        protected virtual void OnOpening()
+        {
+            Opening?.Invoke(this, EventArgs.Empty);
+        }
+
+        protected virtual void OnOpened()
+        {
+            Opened?.Invoke(this, EventArgs.Empty);
+
+            _defaultButton.Focus();
+        }
+
+        protected virtual void OnClosing(TaskDialogClosingEventArgs args)
+        {
+            Closing?.Invoke(this, args);
+        }
+
+        protected virtual void OnClosed()
+        {
+            Closed?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void CloseCore(object result)
+        {
+            var ea = new TaskDialogClosingEventArgs(this, result);
+            OnClosing(ea);
+
+            if (ea.Cancel)
+                return;
+
+            if (!ea.IsDeferred)
+            {
+                FinalCloseDialog(result);
+            }
+            else
+            {
+                // Diable interaction with the dialog while the deferral is active
+                IsEnabled = false;
+            }
+        }
+
+        private async void FinalCloseDialog(object result)
+        {
+            void ReturnDialogToParent()
+            {
+                if (_xamlOwner == null)
+                    return;
+
+                if (_xamlOwner is Panel p)
+                {
+                    p.Children.Insert(_xamlOwnerChildIndex, this);
+                }
+                else if (_xamlOwner is Decorator d)
+                {
+                    d.Child = this;
+                }
+                else if (_xamlOwner is IContentControl icc)
+                {
+                    icc.Content = this;
+                }
+                else if (_xamlOwner is IContentPresenter icp)
+                {
+                    icp.Content = this;
+                }
+            }
+
+            if (_host is Window w)
+            {
+                // Hide the window, but don't close it while we shut down
+                // Mainly so we can take out the dialog and put it back
+                // if it was declared in Xaml and this doesn't show
+                // on screen
+                w.Hide();
+                IsVisible = false;
+
+                w.Content = null;
+                ReturnDialogToParent();
+
+                PseudoClasses.Set(":hosted", false);
+                PseudoClasses.Set(":hidden", true);
+
+                // Fully close the dialog sending the result back
+                w.Close(result);
+            }
+            else if (_host is DialogHost dh)
+            {
+                IsHitTestVisible = false;
+
+                Focus();
+
+                PseudoClasses.Set(":open", false);
+                PseudoClasses.Set(":hidden", true);
+
+                // Let the close animation finish (now 0.167s in new WinUI update...)
+                // We'll wait just a touch longer to be sure
+                await Task.Delay(200);
+
+                IsHitTestVisible = true;
+
+                dh.Content = null;
+                ReturnDialogToParent();
+
+                var overlayLayer = OverlayLayer.GetOverlayLayer(dh);
+                // If OverlayLayer isn't found here, this may be a reentrant call (hit ESC multiple times quickly, etc)
+                // Don't fail, and return. If this isn't reentrant, there's bigger issues...
+                if (overlayLayer == null)
+                    return;
+
+                overlayLayer.Children.Remove(dh);
+
+                _tcs.TrySetResult(result);
+            }
+
+            OnClosed();
+        }
+
+        private void OnButtonClick(object sender, RoutedEventArgs e)
+        {
+            // TaskDialogCommandHost is a TaskDialogButtonHost, this captures everything
+            if (e.Source is IVisual v && v.FindAncestorOfType<TaskDialogButtonHost>(true) is TaskDialogButtonHost b)
+            {
+                // DataContext for the hosts are the user defined buttons/commands, get the dialog from that
+                if (b.DataContext is TaskDialogControl tdb)
+                {
+                    if (tdb is TaskDialogCommand com && !com.ClosesOnInvoked)
+                        return;
+
+                    Hide(tdb.DialogResult);
+                }
+            }
+        }
+
+        public void SetProgressBarState(double value, TaskDialogProgressState state)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_progressBar != null)
+                {
+                    _progressBar.Value = value;
+
+                    _progressBar.IsIndeterminate = (state & TaskDialogProgressState.Indeterminate) == TaskDialogProgressState.Indeterminate;
+
+                    if (_currentProgressState != state)
+                    {
+                        _currentProgressState = state;
+
+                        PseudoClasses.Set(":progressError", (state & TaskDialogProgressState.Error) == TaskDialogProgressState.Error);
+                        PseudoClasses.Set(":progressSuspend", (state & TaskDialogProgressState.Suspended) == TaskDialogProgressState.Suspended);
+                    }
+                }                
+            });
+        }
+
+        private void MoreDetailsButtonClick(object sender, RoutedEventArgs e)
+        {
+            IsFooterExpanded = !IsFooterExpanded;
+        }
+
+        private void SetButtons()
+        {
+            List<TaskDialogButtonHost> buttons = new List<TaskDialogButtonHost>();
+            bool foundDefault = false;
+            for (int i = 0; i < _buttons.Count; i++)
+            {
+                var b = new TaskDialogButtonHost
+                {
+                    [!ContentProperty] = _buttons[i][!TaskDialogControl.TextProperty],
+                    [!TaskDialogButtonHost.IconSourceProperty] = _buttons[i][!TaskDialogButton.IconSourceProperty],
+                    DataContext = _buttons[i],
+                    [!IsEnabledProperty] = _buttons[i][!TaskDialogControl.IsEnabledProperty],
+                    [!AvButton.CommandParameterProperty] = _buttons[i][!TaskDialogButton.CommandParameterProperty],
+                    [!AvButton.CommandProperty] = _buttons[i][!TaskDialogButton.CommandProperty]
+                };
+
+                if (_buttons[i].IsDefault)
+                {
+                    if (foundDefault)
+                        throw new InvalidOperationException("Cannot set 'IsDefault' property on more than one item in a TaskDialog");
+
+                    foundDefault = true;
+                    b.Classes.Add("accent");
+                    _defaultButton = b;
+                }
+                buttons.Add(b);
+            }
+            _buttonsHost.Items = buttons;            
+        }
+
+        private void SetCommands()
+        {
+            List<Control> commands = new List<Control>();
+
+            bool foundDefault = _defaultButton != null;
+            for (int i = 0; i < _commands.Count; i++)
+            {
+                if (_commands[i] is TaskDialogCheckBox tdcb)
+                {
+                    var com = new CheckBox
+                    {
+                        [!ContentProperty] = tdcb[!TaskDialogControl.TextProperty],
+                        DataContext = tdcb,
+                        [!IsEnabledProperty] = tdcb[!TaskDialogControl.IsEnabledProperty],
+                        [!CheckBox.IsCheckedProperty] = tdcb[!TaskDialogRadioButton.IsCheckedProperty]
+                    };
+
+                    com.Classes.Add("FA_TaskDialogCommand");
+
+                    commands.Add(com);
+                }
+                else if (_commands[i] is TaskDialogRadioButton tdrb)
+                {
+                    var com = new RadioButton
+                    {
+                        [!ContentProperty] = tdrb[!TaskDialogControl.TextProperty],
+                        DataContext = tdrb,
+                        [!IsEnabledProperty] = tdrb[!TaskDialogControl.IsEnabledProperty],
+                        [!RadioButton.IsCheckedProperty] = tdrb[!TaskDialogRadioButton.IsCheckedProperty]
+                    };
+
+                    com.Classes.Add("FA_TaskDialogCommand");
+
+                    commands.Add(com);
+                }
+                else if (_commands[i] is TaskDialogCommand tdc)
+                {
+                    var com = new TaskDialogCommandHost
+                    {
+                        [!ContentProperty] = tdc[!TaskDialogControl.TextProperty],
+                        DataContext = tdc,
+                        [!IsEnabledProperty] = tdc[!TaskDialogControl.IsEnabledProperty],
+                        [!AvButton.CommandParameterProperty] = tdc[!TaskDialogButton.CommandParameterProperty],
+                        [!AvButton.CommandProperty] = tdc[!TaskDialogButton.CommandProperty],
+                        [!TaskDialogButtonHost.IconSourceProperty] = tdc[!TaskDialogButton.IconSourceProperty]
+                    };
+
+                    if (tdc.IsDefault)
+                    {
+                        if (foundDefault)
+                            throw new InvalidOperationException("Cannot set 'IsDefault' property on more than one item in a TaskDialog");
+
+                        foundDefault = true;
+                        com.Classes.Add("accent");
+                        _defaultButton = com;
+                    }
+
+                    commands.Add(com);
+                }
+            }
+
+            _commandsHost.Items = commands;
+        }
+
+        private ItemsPresenter _buttonsHost;
+        private ItemsPresenter _commandsHost;
+        private ProgressBar _progressBar;
+        private AvButton _moreDetailsButton;
+
+        private TaskDialogProgressState _currentProgressState = TaskDialogProgressState.Normal;
+
+        private AvButton _defaultButton;
+
+        public IControl _xamlOwner;
+        private int _xamlOwnerChildIndex;
+        private IControl _host;
+        private TaskCompletionSource<object> _tcs;
+    }
+
+    internal class TaskDialogWindowHost : CoreWindow
+    {
+        public TaskDialogWindowHost(TaskDialog dialog)
+        {
+            CanResize = false;
+            SizeToContent = SizeToContent.WidthAndHeight;
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            ShowAsDialog = true;
+
+            Content = dialog;
+            MinWidth = 100;
+            MinHeight = 100;
+
+#if DEBUG
+            this.AttachDevTools();
+#endif
+        }
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -178,6 +178,7 @@ namespace FluentAvalonia.UI.Controls
 
                 overlayLayer.Children.Add(host);
                 PseudoClasses.Set(":hosted", true);
+                IsVisible = true;
 
                 OnOpened();
 
@@ -330,6 +331,7 @@ namespace FluentAvalonia.UI.Controls
                 await Task.Delay(200);
 
                 IsHitTestVisible = true;
+                IsVisible = false;
 
                 dh.Content = null;
                 ReturnDialogToParent();

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -233,7 +233,7 @@ namespace FluentAvalonia.UI.Controls
         {
             Opened?.Invoke(this, EventArgs.Empty);
 
-            _defaultButton.Focus();
+            _defaultButton?.Focus();
         }
 
         protected virtual void OnClosing(TaskDialogClosingEventArgs args)

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -353,6 +353,7 @@ namespace FluentAvalonia.UI.Controls
             }
 
             OnClosed();
+            _host = null;
         }
 
         private void OnButtonClick(object sender, RoutedEventArgs e)

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls.Templates;
+using Avalonia.VisualTree;
+using FluentAvalonia.Core;
+
+namespace FluentAvalonia.UI.Controls
+{
+    public partial class TaskDialog
+    {
+        /// <summary>
+        /// Defines the <see cref="Title"/> property
+        /// </summary>
+        public static readonly StyledProperty<string> TitleProperty =
+            AvaloniaProperty.Register<TaskDialog, string>(nameof(Title));
+
+        /// <summary>
+        /// Defines the <see cref="Header"/> property
+        /// </summary>
+        public static readonly StyledProperty<string> HeaderProperty =
+            AvaloniaProperty.Register<TaskDialog, string>(nameof(Header));
+
+        /// <summary>
+        /// Defines the <see cref="SubHeader"/> property
+        /// </summary>
+        public static readonly StyledProperty<string> SubHeaderProperty =
+            AvaloniaProperty.Register<TaskDialog, string>(nameof(SubHeader));
+
+        /// <summary>
+        /// Defines the <see cref="IconSource"/> property
+        /// </summary>
+        public static readonly StyledProperty<IconSource> IconSourceProperty =
+            AvaloniaProperty.Register<TaskDialog, IconSource>(nameof(IconSource));
+        
+        /// <summary>
+        /// Defines the <see cref="Buttons"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialog, IList<TaskDialogButton>> ButtonsProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialog, IList<TaskDialogButton>>(nameof(Buttons),
+                x => x.Buttons);
+
+        /// <summary>
+        /// Defines the <see cref="Commands"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialog, IList<TaskDialogCommand>> CommandsProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialog, IList<TaskDialogCommand>>(nameof(Commands),
+                x => x.Commands);
+
+        /// <summary>
+        /// Defines the <see cref="FooterVisibility"/> property
+        /// </summary>
+        public static readonly StyledProperty<TaskDialogFooterVisibility> FooterVisibilityProperty =
+            AvaloniaProperty.Register<TaskDialog, TaskDialogFooterVisibility>(nameof(FooterVisibility));
+
+        /// <summary>
+        /// Defines the <see cref="IsFooterExpanded"/> property
+        /// </summary>
+        public static readonly StyledProperty<bool> IsFooterExpandedProperty =
+            AvaloniaProperty.Register<TaskDialog, bool>(nameof(IsFooterExpanded));
+        
+        /// <summary>
+        /// Defines the <see cref="Footer"/> property
+        /// </summary>
+        public static readonly StyledProperty<object> FooterProperty =
+            AvaloniaProperty.Register<TaskDialog, object>(nameof(Footer));
+        
+        /// <summary>
+        /// Defines the <see cref="FooterTemplate"/> property
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> FooterTemplateProperty =
+            AvaloniaProperty.Register<TaskDialog, IDataTemplate>(nameof(FooterTemplate));
+        
+        /// <summary>
+        /// Defines the <see cref="ShowProgressBar"/> property
+        /// </summary>
+        public static readonly StyledProperty<bool> ShowProgressBarProperty =
+            AvaloniaProperty.Register<TaskDialog, bool>(nameof(ShowProgressBar));
+
+        /// <summary>
+        /// Gets or sets the title of the dialog
+        /// </summary>
+        /// <remarks>
+        /// This is the window caption of the dialog displayed in the title bar. For platforms 
+        /// where windowing is not supported, this property has no effect.
+        /// </remarks>
+        public string Title
+        {
+            get => GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the dialog header text
+        /// </summary>
+        public string Header
+        {
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the dialog sub header text
+        /// </summary>
+        public string SubHeader
+        {
+            get => GetValue(SubHeaderProperty);
+            set => SetValue(SubHeaderProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the dialog Icon
+        /// </summary>
+        public IconSource IconSource
+        {
+            get => GetValue(IconSourceProperty);
+            set => SetValue(IconSourceProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the list of buttons that display at the bottom of the TaskDialog
+        /// </summary>
+        public IList<TaskDialogButton> Buttons
+        {
+            get => _buttons;
+        }
+
+        /// <summary>
+        /// Gets the list of Commands displayed in the TaskDialog
+        /// </summary>
+        public IList<TaskDialogCommand> Commands
+        {
+            get => _commands;
+        }
+
+        /// <summary>
+        /// Gets or sets the visibility of the Footer area
+        /// </summary>
+        public TaskDialogFooterVisibility FooterVisibility 
+        { 
+            get => GetValue(FooterVisibilityProperty); 
+            set => SetValue(FooterVisibilityProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether the footer is visible
+        /// </summary>
+        public bool IsFooterExpanded
+        {
+            get => GetValue(IsFooterExpandedProperty);
+            set => SetValue(IsFooterExpandedProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the footer content
+        /// </summary>
+        public object Footer
+        {
+            get => GetValue(FooterProperty);
+            set => SetValue(FooterProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the IDataTemplate for the footer content
+        /// </summary>
+        public IDataTemplate FooterTemplate
+        {
+            get => GetValue(FooterTemplateProperty);
+            set => SetValue(FooterTemplateProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether this TaskDialog shows a progress bar
+        /// </summary>
+        public bool ShowProgressBar
+        {
+            get => GetValue(ShowProgressBarProperty);
+            set => SetValue(ShowProgressBarProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the root visual that should host this dialog
+        /// </summary>
+        /// <remarks>
+        /// For TaskDialogs declared in Xaml, this is automatically set. If you declare a 
+        /// TaskDialog in C#, you MUST set this property before showing the dialog to prevent
+        /// and error. For desktop platforms, set it to the Window that should own the dialog.
+        /// For others, set it to the root TopLevel.
+        /// </remarks>
+        public IVisual XamlRoot { get; set; }
+
+        /// <summary>
+        /// Raised when the TaskDialog is beginning to open, but is not yet visible
+        /// </summary>
+        public event TypedEventHandler<TaskDialog, EventArgs> Opening;
+
+        /// <summary>
+        /// Raised when the TaskDialog is opened and ready to be shown on screen
+        /// </summary>
+        public event TypedEventHandler<TaskDialog, EventArgs> Opened;
+
+        /// <summary>
+        /// Raised when the TaskDialog is beginning to close
+        /// </summary>
+        public event TypedEventHandler<TaskDialog, TaskDialogClosingEventArgs> Closing;
+
+        /// <summary>
+        /// Raised when the TaskDialog is closed
+        /// </summary>
+        public event TypedEventHandler<TaskDialog, EventArgs> Closed;
+                
+        private IList<TaskDialogButton> _buttons;
+        private IList<TaskDialogCommand> _commands;
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogButton.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogButton.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Windows.Input;
+using Avalonia;
+using FluentAvalonia.Core;
+
+namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Represents a button in <see cref="TaskDialog"/>
+    /// </summary>
+    /// <remarks>
+    /// This type is an abstraction of a button and is used to create the actual button
+    /// hosted in the TaskDialog.
+    /// </remarks>
+    public class TaskDialogButton : TaskDialogControl
+    {
+        public TaskDialogButton() { }
+
+        public TaskDialogButton(string text, object result)
+            : base(text, result) { }
+
+        private TaskDialogButton(string text, object result, bool isStandard)
+            : this(text, result)
+        {
+            _isStandard = true;
+        }
+
+        /// <summary>
+        /// Defines the <see cref="IconSource"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogButton, IconSource> IconSourceProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogButton, IconSource>(nameof(IconSource),
+                x => x.IconSource, (x, v) => x.IconSource = v);
+       
+        /// <summary>
+        /// Defines the <see cref="Command"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogButton, ICommand> CommandProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogButton, ICommand>(nameof(Command),
+                x => x.Command, (x, v) => x.Command = v);
+        
+        /// <summary>
+        /// Defines the <see cref="CommandParameter"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogButton, object> CommandParameterProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogButton, object>(nameof(CommandParameter),
+                x => x.CommandParameter, (x, v) => x.CommandParameter = v);
+
+        /// <summary>
+        /// Gets or sets the icon displayed in the button
+        /// </summary>
+        public IconSource IconSource
+        {
+            get => _iconSource;
+            set
+            {
+                if (_isStandard)
+                    throw new InvalidOperationException("Cannot add icon to a predefined TaskDialogButton");
+
+                SetAndRaise(IconSourceProperty, ref _iconSource, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the command that is invoked when the button is clicked
+        /// </summary>
+        public ICommand Command
+        {
+            get => _command;
+            set
+            {
+                if (_isStandard)
+                    throw new InvalidOperationException("Cannot add Command to a predefined TaskDialogButton");
+
+                SetAndRaise(CommandProperty, ref _command, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the command parameter for the <see cref="Command"/>
+        /// </summary>
+        public object CommandParameter
+        {
+            get => _commandParameter;
+            set
+            {
+                if (_isStandard)
+                    throw new InvalidOperationException("Cannot add icon to a predefined TaskDialogButton");
+
+                SetAndRaise(CommandParameterProperty, ref _commandParameter, value);
+            }
+        }
+
+        /// <summary>
+        /// Raised when the button is clicked
+        /// </summary>
+        public event TypedEventHandler<TaskDialogButton, EventArgs> Click;
+
+        internal void RaiseClick()
+        {
+            // Can't really stop event handler attaching, so to prevent ugliness we just won't fire
+            // the event here
+            if (_isStandard)
+                return;
+
+            Click?.Invoke(this, EventArgs.Empty);
+        }
+
+        private IconSource _iconSource;
+        private ICommand _command;
+        private object _commandParameter;
+        private bool _isStandard;
+
+        /// <summary>
+        /// Predefined button for 'OK'. Note that predefined buttons cannot have command, icons,
+        /// or click handlers attached - they are meant for simple purposes
+        /// </summary>
+        public static readonly TaskDialogButton OKButton = new TaskDialogButton("OK", TaskDialogStandardResult.OK);
+
+        /// <summary>
+        /// Predefined button for 'Cancel'. Note that predefined buttons cannot have command, icons,
+        /// or click handlers attached - they are meant for simple purposes
+        /// </summary>
+        public static readonly TaskDialogButton CancelButton = new TaskDialogButton("Cancel", TaskDialogStandardResult.Cancel);
+
+        /// <summary>
+        /// Predefined button for 'Yes'. Note that predefined buttons cannot have command, icons,
+        /// or click handlers attached - they are meant for simple purposes
+        /// </summary>
+        public static readonly TaskDialogButton YesButton = new TaskDialogButton("Yes", TaskDialogStandardResult.Yes);
+
+        /// <summary>
+        /// Predefined button for 'No'. Note that predefined buttons cannot have command, icons,
+        /// or click handlers attached - they are meant for simple purposes
+        /// </summary>
+        public static readonly TaskDialogButton NoButton = new TaskDialogButton("No", TaskDialogStandardResult.No);
+
+        /// <summary>
+        /// Predefined button for 'Retry'. Note that predefined buttons cannot have command, icons,
+        /// or click handlers attached - they are meant for simple purposes
+        /// </summary>
+        public static readonly TaskDialogButton RetryButton = new TaskDialogButton("Retry", TaskDialogStandardResult.Retry);
+
+        /// <summary>
+        /// Predefined button for 'Close'. Note that predefined buttons cannot have command, icons,
+        /// or click handlers attached - they are meant for simple purposes
+        /// </summary>
+        public static readonly TaskDialogButton CloseButton = new TaskDialogButton("Close", TaskDialogStandardResult.Close);
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogButtonsPanel.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogButtonsPanel.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace FluentAvalonia.UI.Controls.Primitives
+{
+    /// <summary>
+    /// Represents a panel that arranges the buttons in a <see cref="TaskDialog"/>
+    /// </summary>
+    public class TaskDialogButtonsPanel : Panel
+    {
+        /// <summary>
+        /// Defines the <see cref="Spacing"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogButtonsPanel, double> SpacingProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogButtonsPanel, double>(nameof(Spacing),
+                x => x.Spacing, (x, v) => x.Spacing = v);
+
+        /// <summary>
+        /// Gets or sets the spacing between the buttons
+        /// </summary>
+        public double Spacing
+        {
+            get => _spacing;
+            set => SetAndRaise(SpacingProperty, ref _spacing, value);
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            double wid = 0;
+            double hgt = 0;
+            var ct = Children.Count;
+            for (int i = 0; i < ct; i++)
+            {
+                Children[i].Measure(Size.Infinity);
+
+                var size = Children[i].DesiredSize;
+                wid += size.Width;
+                hgt = Math.Max(hgt, size.Height);
+            }
+
+            wid += _spacing * (ct - 1);
+
+            return new Size(wid, hgt);
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            var ct = Children.Count;
+
+            if (ct != 0)
+            {
+                if (ct == 1)
+                {
+                    var halfWid = finalSize.Width / 2;
+                    var rc = new Rect(halfWid, 0, halfWid, finalSize.Height);
+                    Children[0].Arrange(rc);
+                }
+                else
+                {
+                    var spacingSpace = _spacing * (ct - 1);
+
+                    var buttonWidth = (finalSize.Width - spacingSpace) / ct;
+                    Rect rc;
+                    double x = 0;
+                    for (int i = 0; i < ct; i++)
+                    {
+                        rc = new Rect(x, 0, buttonWidth, finalSize.Height);
+                        Children[i].Arrange(rc);
+
+                        x += rc.Width + _spacing;
+                    }
+                }                
+            }
+
+            return finalSize;
+        }
+
+        private double _spacing;
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogCheckBox.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogCheckBox.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Represents a CheckBox in a <see cref="TaskDialog"/>
+    /// </summary>
+    public class TaskDialogCheckBox : TaskDialogRadioButton
+    {
+
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogClosingEventArgs.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogClosingEventArgs.cs
@@ -1,0 +1,67 @@
+﻿using System;
+
+namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Provides data for the closing event.
+    /// </summary>
+    public class TaskDialogClosingEventArgs : EventArgs
+    {
+        internal TaskDialogClosingEventArgs(TaskDialog owner, object res)
+        {
+            Result = res;
+            _owner = owner;
+        }
+
+        /// <summary>
+        /// Gets or sets a value that can cancel the closing of the dialog.
+        /// A true value for Cancel cancels the default behavior.
+        /// </summary>
+        public bool Cancel { get; set; }
+
+        /// <summary>
+        /// Gets the result of the closing event.
+        /// </summary>
+        public object Result { get; }
+
+        internal bool IsDeferred => _deferral != null;
+
+        /// <summary>
+        /// Gets a <see cref="TaskDialogClosingDeferral"/> that the app can use to 
+        /// respond asynchronously to the closing event.
+        /// </summary>
+        /// <returns></returns>
+        public TaskDialogClosingDeferral GetDeferral()
+        {
+            _deferral = new TaskDialogClosingDeferral(_owner, Result);
+            return _deferral;
+        }
+
+        private TaskDialog _owner;
+        private TaskDialogClosingDeferral _deferral;
+    }
+
+    /// <summary>
+    /// Represents a deferral that can be used by an app to respond asyncronously to
+    /// a <see cref="TaskDialog"/> closing
+    /// </summary>
+    public class TaskDialogClosingDeferral
+    {
+        internal TaskDialogClosingDeferral(TaskDialog owner, object result)
+        {
+            _owner = owner;
+            _result = result;
+        }
+
+        /// <summary>
+        /// Notifies the system that the app has finished processing the closing event.
+        /// </summary>
+        public void Complete()
+        {
+            _owner.CompleteClosingDeferral(_result);
+        }
+
+        private TaskDialog _owner;
+        private object _result;
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogCommand.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogCommand.cs
@@ -1,0 +1,33 @@
+﻿using Avalonia;
+
+namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Represents a command item in a <see cref="TaskDialog"/>
+    /// </summary>
+    public class TaskDialogCommand : TaskDialogButton
+    {
+        /// <summary>
+        /// Defines the <see cref="Description"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogCommand, string> DescriptionProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogCommand, string>(nameof(Description),
+                x => x.Description, (x, v) => x.Description = v);
+
+        /// <summary>
+        /// Gets or sets whether invoking this command should also close the dialog
+        /// </summary>
+        public bool ClosesOnInvoked { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the TaskDialogCommand
+        /// </summary>
+        public string Description
+        {
+            get => _description;
+            set => SetAndRaise(DescriptionProperty, ref _description, value);
+        }
+
+        private string _description;
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogCommand.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogCommand.cs
@@ -17,7 +17,7 @@ namespace FluentAvalonia.UI.Controls
         /// <summary>
         /// Gets or sets whether invoking this command should also close the dialog
         /// </summary>
-        public bool ClosesOnInvoked { get; set; }
+        public bool ClosesOnInvoked { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the description of the TaskDialogCommand

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogControl.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogControl.cs
@@ -1,0 +1,103 @@
+﻿using Avalonia;
+
+namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Represents the base class for all items in a <see cref="TaskDialog"/>
+    /// </summary>
+    public abstract class TaskDialogControl : AvaloniaObject
+    {
+        public TaskDialogControl() { }
+
+        /// <summary>
+        /// Creates a new TaskDialog control with the specified text and dialog result
+        /// </summary>
+        /// <param name="text">The text the button/command should display</param>
+        /// <param name="result">The dialog result the button should return if invoked. Can 
+        /// be any of <see cref="TaskDialogStandardResult"/> or any custom name.
+        /// </param>
+        public TaskDialogControl(string text, object result)
+        {
+            _text = text;
+            _dialogResult = result;
+        }
+
+        /// <summary>
+        /// Defines the <see cref="Text"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogControl, string> TextProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogControl, string>(nameof(Text),
+                x => x.Text, (x, v) => x.Text = v);
+        
+        /// <summary>
+        /// Defines the <see cref="DialogResult"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogControl, object> DialogResultProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogControl, object>(nameof(DialogResult),
+                x => x.DialogResult, (x, v) => x.DialogResult = v);
+       
+        /// <summary>
+        /// Defines the <see cref="IsEnabled"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogControl, bool> IsEnabledProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogControl, bool>(nameof(IsEnabled),
+                x => x.IsEnabled, (x, v) => x.IsEnabled = v);
+
+        /// <summary>
+        /// Defines the <see cref="IsDefault"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogControl, bool> IsDefaultProperty =
+            AvaloniaProperty.RegisterDirect<TaskDialogControl, bool>(nameof(IsDefault),
+                x => x.IsDefault, (x, v) => x.IsDefault = v);
+
+        /// <summary>
+        /// Gets or sets the Text associated with the TaskDialog control
+        /// </summary>
+        public string Text
+        {
+            get => _text;
+            set => SetAndRaise(TextProperty, ref _text, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the dialog result associated with the control
+        /// </summary>
+        /// <remarks>
+        /// Can be any of <see cref="TaskDialogStandardResult"/> or any custom name. NOTE:
+        /// that 'null' is not a valid result and will be converted to <see cref="TaskDialogStandardResult.None"/>
+        /// </remarks>
+        public object DialogResult
+        {
+            get => _dialogResult;
+            set => SetAndRaise(DialogResultProperty, ref _dialogResult, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether the control is enabled
+        /// </summary>
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set => SetAndRaise(IsEnabledProperty, ref _isEnabled, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether the control is the default button/command.
+        /// </summary>
+        /// <remarks>
+        /// This can only be set on one button/command in a TaskDialog or an error will be thrown.
+        /// The desired button will be invoked upon 'Enter' key press and receives first focus
+        /// </remarks>
+        public bool IsDefault
+        {
+            get => _isDefault;
+            set => SetAndRaise(IsDefaultProperty, ref _isDefault, value);
+        }
+
+
+        private string _text;
+        private object _dialogResult = TaskDialogStandardResult.None;
+        private bool _isEnabled = true;
+        private bool _isDefault;
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogFooterVisibility.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogFooterVisibility.cs
@@ -1,0 +1,24 @@
+﻿namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Defines constants that specify how the footer area is shown
+    /// in a <see cref="TaskDialog"/>
+    /// </summary>
+    public enum TaskDialogFooterVisibility
+    {
+        /// <summary>
+        /// The footer is never shown
+        /// </summary>
+        Never,
+
+        /// <summary>
+        /// The footer is hidden by default, but can be expanded open
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// The footer is always visible
+        /// </summary>
+        Always // Footer is always visible and the footer title is hidden
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogProgressState.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogProgressState.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Defines constants (flags) that describe the state of a progress 
+    /// <see cref="TaskDialog"/>. Note that these are just visual indicators,
+    /// and actual state behavior is up to you
+    /// </summary>
+    [Flags]
+    public enum TaskDialogProgressState
+    {
+        /// <summary>
+        /// Progress bar is in a normal state
+        /// </summary>
+        Normal = 0,
+
+        /// <summary>
+        /// Progress bar is shown in an error state
+        /// </summary>
+        Error = 1,
+
+        /// <summary>
+        /// Progress bar is shown in a suspended state
+        /// </summary>
+        Suspended = 4,
+
+        /// <summary>
+        /// Progress bar is shown as indeterminate
+        /// </summary>
+        Indeterminate = 10,
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogRadioButton.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogRadioButton.cs
@@ -1,0 +1,29 @@
+﻿using Avalonia;
+using Avalonia.Controls.Primitives;
+
+namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Represents a RadioButton in a <see cref="TaskDialog"/>
+    /// </summary>
+    public class TaskDialogRadioButton : TaskDialogCommand
+    {
+        /// <summary>
+        /// Defines the <see cref="IsChecked"/> property
+        /// </summary>
+        public static readonly DirectProperty<TaskDialogRadioButton, bool?> IsCheckedProperty =
+            ToggleButton.IsCheckedProperty.AddOwner<TaskDialogRadioButton>(x => x.IsChecked,
+                (x, v) => x.IsChecked = v);
+
+        /// <summary>
+        /// Gets or sets whether this RadioButton is checked
+        /// </summary>
+        public bool? IsChecked
+        {
+            get => _isChecked;
+            set => SetAndRaise(IsCheckedProperty, ref _isChecked, value);
+        }
+
+        private bool? _isChecked = false;
+    }
+}

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogStandardResult.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialogStandardResult.cs
@@ -1,0 +1,16 @@
+﻿namespace FluentAvalonia.UI.Controls
+{
+    /// <summary>
+    /// Defines constants that for standardized results from a <see cref="TaskDialog"/>
+    /// </summary>
+    public enum TaskDialogStandardResult
+    {
+        None,
+        OK,
+        Cancel,
+        Yes,
+        No,
+        Retry,
+        Close
+    }
+}

--- a/FluentAvaloniaSamples/Assets/FAControlsGroups.json
+++ b/FluentAvaloniaSamples/Assets/FAControlsGroups.json
@@ -58,6 +58,12 @@
         "Description": "Base class of a special flyout that presents with confirm/dismiss buttons",
         "PreviewImageSource": "/Assets/PageIcons/PickerFlyoutBase.jpg",
         "PageType": "PickerFlyoutBasePage"
+      },
+      {
+        "Header": "TaskDialog",
+        "Description": "An advanced dialog box",
+        "PreviewImageSource": "/Assets/PageIcons/ContentDialog.jpg",
+        "PageType": "TaskDialogPage"
       }
     ]
   },

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,10 +11,6 @@
     <AvaloniaResource Include="Pages\SampleCode\**" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Pages\SampleCode\CoreWindow3.cs.txt" />
-    <None Remove="Pages\SampleCode\CoreWindow3.xaml.txt" />
-  </ItemGroup>  
-  <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.10.12" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.12.1" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
@@ -22,5 +18,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/FluentAvaloniaSamples/Pages/FAControlPages/TaskDialogPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/TaskDialogPage.axaml
@@ -1,0 +1,218 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="using:FluentAvalonia.UI.Controls"
+             xmlns:ctrls="using:FluentAvaloniaSamples.Controls"
+             xmlns:spg="using:FluentAvaloniaSamples.Pages.NVSamplePages"
+             xmlns:vm="using:FluentAvaloniaSamples.ViewModels"
+             xmlns:core="using:FluentAvalonia.Core"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="3000"
+             x:Class="FluentAvaloniaSamples.Pages.TaskDialogPage"
+             PreviewImage="/Assets/PageIcons/ContentDialog.jpg">
+    <StackPanel Spacing="8">
+        <ctrls:ControlExample TargetType="ui:TaskDialog"
+                              Name="FirstExample"
+                              Header="A TaskDialog API in Action"
+                              XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/TaskDialog1.xaml.txt"
+                              CSharpSource="avares://FluentAvaloniaSamples/Pages/SampleCode/TaskDialog1.cs.txt">
+            <StackPanel>
+                <TextBlock Text="Preview" />
+                <TextBlock Name="LastResultText" />
+                <Panel IsHitTestVisible="False"
+                       MinWidth="{DynamicResource TaskDialogMinWidth}"
+                       MaxWidth="{DynamicResource TaskDialogMaxWidth}"
+                       MinHeight="{DynamicResource TaskDialogMinHeight}"
+                       MaxHeight="{DynamicResource TaskDialogMaxHeight}">
+                    <!-- 
+                    NOTE to any who browse this source file:
+                    core:VisualStateHelper.ForcedClassesProperty is an internal thing that attempts to
+                    force pseudoclasses for debugging. This should NOT be used in general outside of this
+                    project as undesired affects may apply
+                    I'm only using it here so we can preview the dialog changes from options
+                    without launching the dialog
+                    -->
+                    <ui:TaskDialog Name="TaskDialog1"
+                                   IsVisible="True"
+                                   Title="FluentAvalonia"
+                                   Header="Header Here"
+                                   SubHeader="SubHeader"
+                                   Content="This is some sample text, but you can put more advanced content here if you like"                                   
+                                   core:VisualStateHelper.ForcedClassesProperty=":open,:hosted,:hidden!"
+                                   FooterVisibility="{Binding #FooterVisCB.SelectedItem.Content}">
+                        <ui:TaskDialog.Commands>
+                            <ui:TaskDialogCommand Text="{Binding #CommandText.Text}"
+                                                  Description="{Binding #DescText.Text}"
+                                                  IsEnabled="{Binding #CommandEnabledCheck.IsChecked}"
+                                                  DialogResult="{Binding #CommandDialogResult.Text}"/>
+                        </ui:TaskDialog.Commands>
+
+                        <ui:TaskDialog.Buttons>
+                            <ui:TaskDialogButton Text="OK" DialogResult="OK" />
+                            <ui:TaskDialogButton Text="Cancel" DialogResult="Cancel" />
+                        </ui:TaskDialog.Buttons>
+
+                        <ui:TaskDialog.Footer>
+                            <CheckBox Content="Never show me this again" />
+                        </ui:TaskDialog.Footer>
+                    </ui:TaskDialog>
+                </Panel>
+               
+                
+                
+            </StackPanel>
+
+            <ctrls:ControlExample.Options>
+                <StackPanel Spacing="8" MaxWidth="225">
+                    <Button Content="Launch Dialog"
+                            Click="LaunchAPIInActionTaskDialog"/>
+                    <CheckBox Content="Show Windowed"
+                              IsChecked="True"
+                              Name="ShowWindowedCheck" />
+                    <Expander Header="Headers">
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Title (Windowed mode only)"/>
+                            <TextBox Text="{Binding #TaskDialog1.Title}" />
+
+                            <TextBlock Text="Header" />
+                            <TextBox Text="{Binding #TaskDialog1.Header}" />
+
+                            <TextBlock Text="SubHeader" />
+                            <TextBox Text="{Binding #TaskDialog1.SubHeader}" />
+
+                            <CheckBox Content="Show Icon"
+                                      Checked="TaskDialog1ShowIconChecked"
+                                      Unchecked="TaskDialog1ShowIconUnchecked"/>
+                        </StackPanel>
+                    </Expander>
+                    <Expander Header="Progress Bar">
+                        <StackPanel Spacing="4">
+                            <CheckBox Content="Show Progress Bar"
+                                      IsChecked="{Binding #TaskDialog1.ShowProgressBar}"
+                                      Name="ShowProgCheck"/>
+                            <CheckBox Content="Is Indeterminate"
+                                      Name="IndeterminateCheck"
+                                      Checked="TaskDialog1ProgressIndetChecked"
+                                      Unchecked="TaskDialog1ProgressIndetUnchecked"
+                                      IsEnabled="{Binding #ShowProgCheck.IsChecked}"/>
+                            <RadioButton Content="Normal State"
+                                         IsChecked="True"
+                                         Name="NormalCheck"
+                                         Checked="TaskDialog1ProgressNormalChecked"
+                                         Unchecked="TaskDialog1ProgressNormalUnchecked"
+                                         IsEnabled="{Binding #ShowProgCheck.IsChecked}"/>
+                            <RadioButton Content="Error State"
+                                         Name="ErrorCheck"
+                                         Checked="TaskDialog1ProgressErrorChecked"
+                                         Unchecked="TaskDialog1ProgressErrorUnchecked"
+                                         IsEnabled="{Binding #ShowProgCheck.IsChecked}"/>
+                            <RadioButton Content="Suspended State"
+                                         Name="SuspendedCheck"
+                                         Checked="TaskDialog1ProgressSuspendedChecked"
+                                         Unchecked="TaskDialog1ProgressSuspendedUnchecked"
+                                         IsEnabled="{Binding #ShowProgCheck.IsChecked}"/>
+                        </StackPanel>
+                    </Expander>
+                    <Expander Header="Footer">
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Footer Visibility" />
+                            <ComboBox Name="FooterVisCB" MinWidth="125"
+                                      SelectedIndex="2">
+                                <ComboBoxItem Content="{x:Static ui:TaskDialogFooterVisibility.Never}" />
+                                <ComboBoxItem Content="{x:Static ui:TaskDialogFooterVisibility.Auto}" />
+                                <ComboBoxItem Content="{x:Static ui:TaskDialogFooterVisibility.Always}" />
+                            </ComboBox>
+                            <CheckBox IsChecked="{Binding #TaskDialog1.IsFooterExpanded}"
+                                      Content="Footer Expanded" />
+                        </StackPanel>
+                    </Expander>
+                    <Expander Header="Commands">
+                        <StackPanel Spacing="4" MaxWidth="175">
+                            <TextBlock Text="Text" />
+                            <TextBox Name="CommandText" Text="Sample Command" />
+                            <TextBlock Text="Description" />
+                            <TextBox Name="DescText" Text="This is a description of the Sample Command" />
+                            <TextBlock Text="Dialog Result" />
+                            <TextBox Name="CommandDialogResult" Text="CommandResult" />
+                            <CheckBox Content="IsEnabled"
+                                      IsChecked="True"
+                                      Name="CommandEnabledCheck"/>
+                            <CheckBox Content="ShowIcon"
+                                      Checked="TaskDialog1CommandShowIconChecked"
+                                      Unchecked="TaskDialog1CommandShowIconUnchecked"/>
+                        </StackPanel>
+                    </Expander>
+                    <Expander Header="Buttons">
+                        <StackPanel>
+                            <TextBlock Text="No limit exists on the number of buttons, but you should generally have no more than three (3)."
+                                       TextWrapping="Wrap"
+                                       MaxWidth="175"
+                                       HorizontalAlignment="Left"/>
+                            <WrapPanel>
+                                <CheckBox Content="OK" Name="OKCheck"
+                                          IsChecked="True"
+                                          Checked="TaskDialog1UpdateButtons"
+                                          Unchecked="TaskDialog1UpdateButtons" />
+                                <CheckBox Content="Cancel" Name="CancelCheck"
+                                          IsChecked="True"
+                                          Checked="TaskDialog1UpdateButtons"
+                                          Unchecked="TaskDialog1UpdateButtons" />
+                                <CheckBox Content="Yes" Name="YesCheck"
+                                          Checked="TaskDialog1UpdateButtons"
+                                          Unchecked="TaskDialog1UpdateButtons" />
+                                <CheckBox Content="No" Name="NoCheck"
+                                          Checked="TaskDialog1UpdateButtons"
+                                          Unchecked="TaskDialog1UpdateButtons" />
+                                <CheckBox Content="Retry" Name="RetryCheck"
+                                          Checked="TaskDialog1UpdateButtons"
+                                          Unchecked="TaskDialog1UpdateButtons" />
+                                <CheckBox Content="Close" Name="CloseCheck"
+                                          Checked="TaskDialog1UpdateButtons"
+                                          Unchecked="TaskDialog1UpdateButtons" />
+                                <CheckBox Content="Custom" Name="CustomCheck"
+                                          Checked="TaskDialog1UpdateButtons"
+                                          Unchecked="TaskDialog1UpdateButtons" />
+                            </WrapPanel>
+                        </StackPanel>
+                    </Expander>
+                </StackPanel>
+            </ctrls:ControlExample.Options>
+
+            <ctrls:ControlExample.Substitutions>
+                <ctrls:ControlExampleSubstitution Key="title" Value="{Binding #TaskDialog1.Title}" />
+                <ctrls:ControlExampleSubstitution Key="header" Value="{Binding #TaskDialog1.Header}" />
+                <ctrls:ControlExampleSubstitution Key="subheader" Value="{Binding #TaskDialog1.Subheader}" />
+                <ctrls:ControlExampleSubstitution Key="content" Value="{Binding #TaskDialog1.Content}" />
+                <ctrls:ControlExampleSubstitution Key="footervisibility" Value="{Binding #TaskDialog1.FooterVisibility}" />
+                <ctrls:ControlExampleSubstitution Key="footerexpanded" Value="{Binding #TaskDialog1.IsFooterExpanded}" />
+                <ctrls:ControlExampleSubstitution Key="commandText" Value="{Binding #CommandText.Text}" />
+                <ctrls:ControlExampleSubstitution Key="commandDesc" Value="{Binding #DescText.Text}" />
+                <ctrls:ControlExampleSubstitution Key="commandEnabled" Value="{Binding #CommandEnabledCheck.IsChecked}" />
+                <ctrls:ControlExampleSubstitution Key="commandResult" Value="{Binding #CommandDialogResult.Text}" />
+                <ctrls:ControlExampleSubstitution Key="showProg" Value="{Binding #TaskDialog1.ShowProgressBar}" />
+            </ctrls:ControlExample.Substitutions>
+         
+        </ctrls:ControlExample>
+
+        <ctrls:ControlExample Header="A Progress TaskDialog"
+                              CSharpSource="avares://FluentAvaloniaSamples/Pages/SampleCode/TaskDialog2.cs.txt">
+            <StackPanel Spacing="4">
+                <Button Name="ProgDiaogButton"
+                        Content="Download File"
+                        Click="LaunchProgressDialog"/>
+                <TextBlock Text="(Don't worry, nothing is actually downloaded)" />
+                <TextBlock Name="ProgressTaskResultText" />
+            </StackPanel>
+        </ctrls:ControlExample>
+
+        <ctrls:ControlExample Header="TaskDialog with Closing Deferral"
+                              CSharpSource="avares://FluentAvaloniaSamples/Pages/SampleCode/TaskDialog3.cs.txt">
+            <StackPanel Spacing="4">
+                <TextBlock Text="A deferral is a way to delay the closing of the dialog while async tasks are performed"
+                           TextWrapping="Wrap"/>
+                <Button Content="Launch Sample"
+                        Click="LaunchDeferralDialog"/>                
+            </StackPanel>
+        </ctrls:ControlExample>
+    </StackPanel>
+</UserControl>

--- a/FluentAvaloniaSamples/Pages/FAControlPages/TaskDialogPage.axaml.cs
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/TaskDialogPage.axaml.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+using FluentAvalonia.UI.Controls;
+
+namespace FluentAvaloniaSamples.Pages
+{
+    public partial class TaskDialogPage : FAControlsPageBase
+    {
+        public TaskDialogPage()
+        {
+            InitializeComponent();
+            TargetType = typeof(TaskDialog);
+            Description = "TaskDialog provides an asynchronous dialog to display advanced content to the user";
+
+            _apiInActionTD = this.FindControl<TaskDialog>("TaskDialog1");
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        private async void LaunchAPIInActionTaskDialog(object sender, RoutedEventArgs args)
+        {
+            var td = new TaskDialog
+            {
+                Title = _apiInActionTD.Title,
+                Header = _apiInActionTD.Header,
+                SubHeader = _apiInActionTD.SubHeader,
+                Content = _apiInActionTD.Content,
+                IconSource = _apiInActionTD.IconSource,
+                ShowProgressBar = _apiInActionTD.ShowProgressBar,
+                FooterVisibility = _apiInActionTD.FooterVisibility,
+                IsFooterExpanded = _apiInActionTD.IsFooterExpanded,
+                Footer = new CheckBox { Content = "Never show me this again" }
+            };
+
+            if (_apiInActionTD.ShowProgressBar)
+            {
+                td.SetProgressBarState(50, _progressFlags);
+            }
+
+            td.Commands.Add(_apiInActionTD.Commands[0]);
+
+            for (int i = 0; i < _apiInActionTD.Buttons.Count; i++)
+            {
+                td.Buttons.Add(_apiInActionTD.Buttons[i]);
+            }
+            
+            td.XamlRoot = VisualRoot;
+            var result = await td.ShowAsync(this.FindControl<CheckBox>("ShowWindowedCheck").IsChecked == false);
+
+            this.FindControl<TextBlock>("LastResultText").Text = $"Last Dialog Result: {result}";
+        }
+
+        private void TaskDialog1ShowIconChecked(object sender, RoutedEventArgs args)
+        {
+            _apiInActionTD.IconSource =
+                new PathIconSource { Data = StreamGeometry.Parse("M 24,4 A 1.8865337,1.8865337 0 0 0 22.351562,4.9707031 L 2.2363281,41.197266 A 1.8865337,1.8865337 0 0 0 3.8867188,44 H 44.113281 A 1.8865337,1.8865337 0 0 0 45.763672,41.197266 L 25.648438,4.9707031 A 1.8865337,1.8865337 0 0 0 24,4 Z M 22.28125,11.119141 H 25.621094 L 25.269531,31.236328 H 22.632812 Z M 24,35.025391 C 24.638021,35.025391 25.171875,35.240235 25.601562,35.669922 26.044271,36.099609 26.265625,36.626953 26.265625,37.251953 26.265625,37.876953 26.044271,38.404296 25.601562,38.833984 25.171875,39.263672 24.638021,39.478516 24,39.478516 23.361979,39.478516 22.821615,39.263672 22.378906,38.833984 21.949219,38.404296 21.734375,37.876953 21.734375,37.251953 21.734375,36.626953 21.949219,36.099609 22.378906,35.669922 22.821615,35.240235 23.361979,35.025391 24,35.025391 Z") };
+        }
+
+        private void TaskDialog1ShowIconUnchecked(object sender, RoutedEventArgs args)
+        {
+            _apiInActionTD.IconSource = null;
+        }
+
+        private void TaskDialog1CommandShowIconChecked(object sender, RoutedEventArgs args)
+        {
+            _apiInActionTD.Commands[0].IconSource =
+                new SymbolIconSource { Symbol = Symbol.MapPinFilled };
+        }
+
+        private void TaskDialog1CommandShowIconUnchecked(object sender, RoutedEventArgs args)
+        {
+            _apiInActionTD.Commands[0].IconSource = null;
+        }
+
+        private void TaskDialog1ProgressIndetChecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags |= TaskDialogProgressState.Indeterminate;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1ProgressIndetUnchecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags &= ~TaskDialogProgressState.Indeterminate;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1ProgressNormalChecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags |= TaskDialogProgressState.Normal;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1ProgressNormalUnchecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags &= ~TaskDialogProgressState.Normal;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1ProgressErrorChecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags |= TaskDialogProgressState.Error;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1ProgressErrorUnchecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags &= ~TaskDialogProgressState.Error;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1ProgressSuspendedChecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags |= TaskDialogProgressState.Suspended;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1ProgressSuspendedUnchecked(object sender, RoutedEventArgs args)
+        {
+            _progressFlags &= ~TaskDialogProgressState.Suspended;
+            _apiInActionTD.SetProgressBarState(50, _progressFlags);
+        }
+
+        private void TaskDialog1UpdateButtons(object sender, RoutedEventArgs args)
+        {
+            var l = new List<TaskDialogButton>();
+            if (this.FindControl<CheckBox>("OKCheck") is CheckBox b && b.IsChecked == true)
+            {
+                l.Add(TaskDialogButton.OKButton);
+            }
+            if (this.FindControl<CheckBox>("CancelCheck") is CheckBox b2 && b2.IsChecked == true)
+            {
+                l.Add(TaskDialogButton.CancelButton);
+            }
+            if (this.FindControl<CheckBox>("YesCheck") is CheckBox b3 && b3.IsChecked == true)
+            {
+                l.Add(TaskDialogButton.YesButton);
+            }
+            if (this.FindControl<CheckBox>("NoCheck") is CheckBox b4 && b4.IsChecked == true)
+            {
+                l.Add(TaskDialogButton.NoButton);
+            }
+            if (this.FindControl<CheckBox>("RetryCheck") is CheckBox b5 && b5.IsChecked == true)
+            {
+                l.Add(TaskDialogButton.RetryButton);
+            }
+            if (this.FindControl<CheckBox>("CloseCheck") is CheckBox b6 && b6.IsChecked == true)
+            {
+                l.Add(TaskDialogButton.CloseButton);
+            }
+            if (this.FindControl<CheckBox>("CustomCheck") is CheckBox b7 && b7.IsChecked == true)
+            {
+                l.Add(new TaskDialogButton("Custom", "CustomButtonResult"));
+            }
+
+            _apiInActionTD.Buttons.Clear();
+            for (int i = 0; i < l.Count; i++)
+            {
+                _apiInActionTD.Buttons.Add(l[i]);
+            }
+
+            typeof(TaskDialog).GetMethod("SetButtons", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(_apiInActionTD, null);
+
+        }
+
+
+        private async void LaunchProgressDialog(object sender, RoutedEventArgs args)
+        {
+            var td = new TaskDialog
+            {
+                Title = "FluentAvalonia",
+                ShowProgressBar = true,
+                IconSource = new SymbolIconSource { Symbol = Symbol.Download },
+                SubHeader = "Downloading",
+                Content = "Please wait while your file downloads",
+                Buttons =
+                {
+                    TaskDialogButton.CancelButton
+                }
+            };
+
+            td.Opened += async (s, e) =>
+            {
+                // We immediately begin the progress task as soon as the dialog opens
+                await Task.Run(async () =>
+                {
+                    int progress = 0;
+                    TaskDialogProgressState state = TaskDialogProgressState.Normal;
+                    int delay = 100;
+                    while (progress < 100)
+                    {
+                        await Task.Delay(delay);
+                        progress++;
+
+                        if (progress == 50)
+                        {
+                            state = TaskDialogProgressState.Indeterminate | TaskDialogProgressState.Suspended;
+
+                            // If you update the TaskDialog - remember we're not on the UI Thread, post via dispatcher
+                            Dispatcher.UIThread.Post(() => { td.Content = "Experiencing network connectivitiy issues. Download speed reduced"; });
+                            delay = 1000;
+                        }
+                        else if (progress == 60)
+                        {
+                            state = TaskDialogProgressState.Normal;
+
+                            Dispatcher.UIThread.Post(() => { td.Content = "All good. Resuming normal downloading."; });
+                            delay = 100;
+                        }
+
+                        // This automatically does UIThread invoking, so just call this normally
+                        td.SetProgressBarState(progress, state);
+                    }
+                    Debug.WriteLine("FINISHED");
+                    // All done, auto close the dialog here
+                    Dispatcher.UIThread.Post(() => { td.Hide(TaskDialogStandardResult.OK); });
+                });
+            };
+
+            // Don't forget to set the XamlRoot!!
+            td.XamlRoot = VisualRoot;
+            var result = await td.ShowAsync();
+
+            this.FindControl<TextBlock>("ProgressTaskResultText").Text = $"File Download Status: {result}";
+        }
+
+        private async void LaunchDeferralDialog(object sender, RoutedEventArgs args)
+        {
+            var td = new TaskDialog
+            {
+                Title = "FluentAvalonia",
+                ShowProgressBar = false,
+                Content = "Are you sure you want to delete the file?\n" +
+                @"../Directory/One/file.txt",
+                Buttons =
+                {
+                    TaskDialogButton.YesButton,
+                    TaskDialogButton.NoButton
+                }
+            };
+
+            // Use the closing event to grab a deferral
+            // You can also cancel closing here if you like
+            td.Closing += (s, e) =>
+            {
+                // We only want to use the deferral on the 'Yes' Button
+                if ((TaskDialogStandardResult)e.Result == TaskDialogStandardResult.Yes)
+                {
+                    var deferral = e.GetDeferral();
+
+                    td.ShowProgressBar = true;
+                    int value = 0;
+                    DispatcherTimer timer = null;
+                    void Tick(object s, EventArgs e)
+                    {
+                        td.SetProgressBarState(++value, TaskDialogProgressState.Normal);
+                        if (value == 100)
+                        {
+                            timer.Stop();
+
+                            // Call this when you're done. It will signal the dialog to resume closing
+                            deferral.Complete();
+                        }
+                    }
+                    timer = new DispatcherTimer(TimeSpan.FromMilliseconds(75), DispatcherPriority.Normal, Tick);
+
+                    timer.Start();
+                }
+            };
+
+            // Don't forget to set the XamlRoot!!
+            td.XamlRoot = VisualRoot;
+            _ = await td.ShowAsync();
+        }
+
+        private TaskDialogProgressState _progressFlags = TaskDialogProgressState.Normal;
+        private TaskDialog _apiInActionTD;
+    }
+}

--- a/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog1.cs.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog1.cs.txt
@@ -1,0 +1,66 @@
+﻿// If your TaskDialog is declared in Xaml, just reference it and call ShowAsync()
+// TaskDialog can launch in either windowed or hosted mode. Windowed mode presents the dialog in a 
+// top level window (using CoreWindow), thus it has a titlebar and an additional property Title
+// Hosted mode uses the OverlayLayer.
+
+this.FindControl<TaskDialog>("TaskDialog1").ShowAsync();
+
+// Declaring a TaskDialog from C#:
+var td = new TaskDialog
+{
+    // Title property only applies on Windowed dialogs
+    Title = "FluentAvalonia",
+    Header = "Header",
+    Subheader = "Subheader",
+    Content = "This is some sample text, but you can put more advanced content here if you like",
+    IconSource = new SymbolIconSource { Symbol = Symbol.Save },
+    FooterVisibility = TaskDialogFooterVisibility.Auto,
+    Footer = new CheckBox { Content = "Never show me this again" },
+    Commands = 
+    {
+        new TaskDialogCommand
+        {
+            Text = "Command Text",
+            Description = "Description",
+            DialogResult = "CommandResult",
+            // ClosesOnInvoked property lets you choose if invoking this command closes the dialog
+            // automatically (default true)
+            ClosesOnInvoked = true,
+            // Can also set IconSource
+            // Can also set IsEnabled
+        }
+    },
+    Buttons = 
+    {
+        // For more advanced scenarios, you can create your own buttons
+        // Custom buttons allow you to attach icons, custom results,
+        // command and click handlers to fully customize your experience
+        // Note: 'null' is not a valid dialog result and is automatically
+        // converted to TaskDialogStandardResult.None when the dialog closes
+        new TaskDialogButton("OK" /* text */, "myResult" /* dialogResult */)
+        
+        
+        // There are some default buttons for simple cases provided
+        // These have predefinded text and results that correspond to
+        // TaskDialogStandardResult enum
+        // Note that built in buttons cannot have Commands, Icons, or 
+        // click handlers attached to them
+        TaskDialogButton.OKButton,
+        TaskDialogButton.CancelButton,
+        TaskDialogButton.YesButton,
+        TaskDialogButton.NoButton,
+        TaskDialogButton.RetryButton,
+        TaskDialogButton.CloseButton
+    }
+};
+
+// Before showing a dialog declared in C#, you MUST set the XamlRoot property
+// Using the VisualRoot is fine, if the VisualRoot is a Window, the dialog automatically launches in
+// Windowed mode, otherwise, it tries to find the OverlayLayer and will launch in hosted mode
+// If your TaskDialog is declared in Xaml, this is automatically handled for you
+td.XamlRoot = this.VisualRoot;
+
+var result = await td.ShowAsync();
+
+// If you want to force hosted mode, ShowAsync accepts a parameter 'showHosted' to force this mode
+var result = await td.ShowAsync(true);

--- a/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog1.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog1.xaml.txt
@@ -1,0 +1,26 @@
+﻿<!-- TaskDialog can be declared in Xaml -->
+<!-- However, it must still be launched in C# -->
+<ui:TaskDialog Name="TaskDialog1"
+                Title="$(title)"
+                Header="$(header)"
+                SubHeader="$(subheader)"
+                Content="$(content)"                                   
+                FooterVisibility="$(footervisibility)"
+                IsFooterExpanded="$(footerexpanded)"
+                ShowProgressBar="$(showProg)">
+    <ui:TaskDialog.Commands>
+        <ui:TaskDialogCommand Text="$(commandText)"
+                                Description="$(commandDesc)"
+                                IsEnabled="$(commandEnabled)"
+                                DialogResult="$(commandResult)"/>
+    </ui:TaskDialog.Commands>
+
+    <ui:TaskDialog.Buttons>
+        <ui:TaskDialogButton Text="OK" DialogResult="OK" />
+        <ui:TaskDialogButton Text="Cancel" DialogResult="Cancel" />
+    </ui:TaskDialog.Buttons>
+
+    <ui:TaskDialog.Footer>
+        <CheckBox Content="Never show me this again" />
+    </ui:TaskDialog.Footer>
+</ui:TaskDialog>

--- a/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog2.cs.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog2.cs.txt
@@ -1,0 +1,57 @@
+﻿var td = new TaskDialog
+{
+    Title = "FluentAvalonia",
+    ShowProgressBar = true,
+    IconSource = new SymbolIconSource { Symbol = Symbol.Download },
+    SubHeader = "Downloading",
+    Content = "Please wait while your file downloads",
+    Buttons =
+    {
+        TaskDialogButton.CancelButton
+    }
+};
+
+td.Opened += async (s, e) =>
+{
+    // We immediately begin the progress task as soon as the dialog opens
+
+    // NOTE: Cancelling the dialog while this is running won't stop this this async process, you should
+    //       use a CancellationToken and monitor the dialog result to cancel this task
+    await Task.Run(async () =>
+    {
+        int progress = 0;
+        TaskDialogProgressState state = TaskDialogProgressState.Normal;
+        int delay = 100;
+        while (progress < 100)
+        {
+            await Task.Delay(delay);
+            progress++;
+
+            if (progress == 50)
+            {
+                state = TaskDialogProgressState.Indeterminate | TaskDialogProgressState.Suspended;
+
+                // If you update the TaskDialog - remember we're not on the UI Thread, post via dispatcher
+                Dispatcher.UIThread.Post(() => { td.Content = "Experiencing network connectivitiy issues. Download speed reduced"; });
+                delay = 1000;
+            }
+            else if (progress == 60)
+            {
+                state = TaskDialogProgressState.Normal;
+
+                Dispatcher.UIThread.Post(() => { td.Content = "All good. Resuming normal downloading."; });
+                delay = 100;
+            }
+
+            // This automatically does UIThread invoking, so just call this normally
+            td.SetProgressBarState(progress, state);
+        }
+
+        // All done, auto close the dialog here
+        Dispatcher.UIThread.Post(() => { td.Hide(TaskDialogStandardResult.OK); });
+    });
+};
+
+// Don't forget to set the XamlRoot!!
+td.XamlRoot = VisualRoot;
+var result = await td.ShowAsync();

--- a/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog3.cs.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/TaskDialog3.cs.txt
@@ -1,0 +1,45 @@
+﻿var td = new TaskDialog
+{
+    Title = "FluentAvalonia",
+    ShowProgressBar = false,
+    Content = "Are you sure you want to delete the file?\n" +
+    @"../Directory/One/file.txt",
+    Buttons =
+    {
+        TaskDialogButton.YesButton,
+        TaskDialogButton.NoButton
+    }
+};
+
+// Use the closing event to grab a deferral
+// You can also cancel closing here if you like
+td.Closing += (s, e) =>
+{
+    // We only want to use the deferral on the 'Yes' Button
+    if ((TaskDialogStandardResult)e.Result == TaskDialogStandardResult.Yes)
+    {
+        var deferral = e.GetDeferral();
+
+        td.ShowProgressBar = true;
+        int value = 0;
+        DispatcherTimer timer = null;
+        void Tick(object s, EventArgs e)
+        {
+            td.SetProgressBarState(++value, TaskDialogProgressState.Normal);
+            if (value == 100)
+            {
+                timer.Stop();
+
+                // Call this when you're done. It will signal the dialog to resume closing
+                deferral.Complete();
+            }
+        }
+        timer = new DispatcherTimer(TimeSpan.FromMilliseconds(75), DispatcherPriority.Normal, Tick);
+
+        timer.Start();
+    }
+};
+
+// Don't forget to set the XamlRoot!!
+td.XamlRoot = VisualRoot;
+_ = await td.ShowAsync();

--- a/FluentAvaloniaTests/ControlTests/TaskDialogTests.cs
+++ b/FluentAvaloniaTests/ControlTests/TaskDialogTests.cs
@@ -1,0 +1,381 @@
+﻿using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using FluentAvalonia.UI.Controls;
+using FluentAvalonia.UI.Controls.Primitives;
+using FluentAvaloniaTests.Helpers;
+using Xunit;
+using Button = Avalonia.Controls.Button;
+
+namespace FluentAvaloniaTests.ControlTests
+{
+    public class TaskDialogTestContext : IDisposable
+    {
+        public TaskDialogTestContext()
+        {
+            _appDisposable = UnitTestApplication.Start();
+
+            Setup();
+            Root.LayoutManager.ExecuteInitialLayoutPass();
+            Root.LayoutManager.ExecuteLayoutPass();
+        }
+
+        //public TaskDialog Dialog { get; }
+
+        public TestRoot Root { get; private set; }
+
+        public IVisual VisualRoot { get; private set; }
+
+        private void Setup()
+        {
+            Root = new TestRoot(new Avalonia.Size(1280, 720));
+            var vlm = new VisualLayerManager();
+            Root.Child = vlm;
+
+            VisualRoot = new Decorator();
+            vlm.Child = VisualRoot as IControl;
+            
+            Root.StylingParent = UnitTestApplication.Current;
+            
+            UnitTestApplication.Current.Styles.Add(
+               (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/OverlayPopupHostStyles.axaml")));
+            UnitTestApplication.Current.Styles.Add(
+               (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/Controls/TaskDialog/TaskDialogStyles.axaml")));
+            UnitTestApplication.Current.Styles.Add(
+                (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/ScrollBarStyles.axaml")));
+            UnitTestApplication.Current.Styles.Add(
+                (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/ScrollViewerStyles.axaml")));
+            UnitTestApplication.Current.Styles.Add(
+               (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/ButtonStyles.axaml")));
+        }
+
+        public void Dispose()
+        {
+            _appDisposable.Dispose();
+        }
+
+        private IDisposable _appDisposable;
+    }
+    public class TaskDialogTests : IClassFixture<TaskDialogTestContext>
+    {
+        public TaskDialogTests(TaskDialogTestContext ctx)
+        {
+            Context = ctx;
+        }
+
+        public TaskDialogTestContext Context { get; }
+
+        [Fact(Timeout = 5000)]
+        public async void OpeningEventsFire()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            bool opening = false;
+            bool opened = false;
+
+            void OnOpening(object sender, EventArgs e)
+            {
+                opening = true;
+            }
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                opened = true;
+                td.Hide();
+            }
+
+            td.Opening += OnOpening;
+            td.Opened += OnOpened;
+
+            await td.ShowAsync(true);
+
+            Assert.True(opening);
+            Assert.True(opened);
+
+            td.Opening -= OnOpening;
+            td.Opened -= OnOpened;
+        }
+
+        [Fact(Timeout = 5000)]
+        public async void ClosingEventsFire()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            bool closing = false;
+            bool closed = false;
+
+            void OnClosing(object sender, TaskDialogClosingEventArgs e)
+            {
+                closing = true;
+            }
+
+            void OnClosed(object sender, EventArgs e)
+            {
+                closed = true;
+                td.Hide();
+            }
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                td.Hide();
+            }
+
+            td.Opened += OnOpened;
+            td.Closing += OnClosing;
+            td.Closed += OnClosed;
+
+            await td.ShowAsync(true);
+
+            Assert.True(closing);
+            Assert.True(closed);
+
+            td.Opened -= OnOpened;
+            td.Closing -= OnClosing;
+            td.Closed -= OnClosed;
+        }
+
+        [Fact(Timeout = 5000)]
+        public async void CustomButtonResultWorks()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            var button = new TaskDialogButton("Button", "CustomResult");
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                Context.Root.LayoutManager.ExecuteLayoutPass();
+
+                var actualButton = td.FindDescendantOfType<TaskDialogButtonHost>();
+
+                actualButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, actualButton));
+            }
+
+            td.Opened += OnOpened;
+
+            td.Buttons.Add(button);
+
+            var result = await td.ShowAsync(true);
+
+            Assert.Equal("CustomResult", result);
+
+            td.Buttons.Clear();
+
+            td.Opened -= OnOpened;
+        }
+
+        [Fact(Timeout = 5000)]
+        public async void CustomButtonClickAndCommandHandlersWork()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            var button = new TaskDialogButton("Button", "CustomResult");
+
+            bool clickFired = false;
+            button.Click += (s, e) =>
+            {
+                clickFired = true;
+            };
+
+            bool commandFired = false;
+            button.Command = new TestCommand((x) =>
+            {
+                commandFired = true;
+            });
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                Context.Root.LayoutManager.ExecuteLayoutPass();
+
+                var actualButton = td.FindDescendantOfType<TaskDialogButtonHost>();
+
+                //actualButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, actualButton));
+                // Have to trigger pointer event to properly get click/command to work
+                // But having trouble getting fake pointer events to pass the 
+                // GetVisualsAt test Button does in PointerReleased, so will invoke via reflection
+                var clickMethod =
+                    actualButton.GetType().GetMethod("OnClick",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+                clickMethod?.Invoke(actualButton, null);
+            }
+
+            td.Opened += OnOpened;
+
+            td.Buttons.Add(button);
+
+            _ = await td.ShowAsync(true);
+
+            Assert.True(clickFired);
+            Assert.True(commandFired);
+
+            td.Buttons.Clear();
+
+            td.Opened -= OnOpened;
+        }
+
+        [Fact(Timeout = 5000)]
+        public async void CommandReturnsItsDialogResult()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            var button = new TaskDialogCommand
+            {
+                Text = "Command",
+                DialogResult = "CommandResult"
+            };
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                Context.Root.LayoutManager.ExecuteInitialLayoutPass();
+                Context.Root.LayoutManager.ExecuteLayoutPass();
+
+                var actualButton = td.FindDescendantOfType<TaskDialogCommandHost>();
+
+                actualButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, actualButton));
+            }
+
+            td.Opened += OnOpened;
+
+            td.Commands.Add(button);
+
+            var result = await td.ShowAsync(true);
+
+            Assert.Equal("CommandResult", result);
+
+            td.Commands.Clear();
+
+            td.Opened -= OnOpened;
+        }
+
+        [Fact(Timeout = 5000)]
+        public async void CommandClickAndCommandHandlersWork()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            var button = new TaskDialogCommand
+            {
+                Text = "Command",
+                DialogResult = "CommandResult"
+            };
+
+            bool clickFired = false;
+            button.Click += (s, e) =>
+            {
+                clickFired = true;
+            };
+
+            bool commandFired = false;
+            button.Command = new TestCommand((x) =>
+            {
+                commandFired = true;
+            });
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                Context.Root.LayoutManager.ExecuteLayoutPass();
+
+                var actualButton = td.FindDescendantOfType<TaskDialogCommandHost>();
+
+                //actualButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, actualButton));
+                // Have to trigger pointer event to properly get click/command to work
+                // But having trouble getting fake pointer events to pass the 
+                // GetVisualsAt test Button does in PointerReleased, so will invoke via reflection
+                var clickMethod =
+                    actualButton.GetType().GetMethod("OnClick",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+                clickMethod?.Invoke(actualButton, null);
+            }
+
+            td.Opened += OnOpened;
+
+            td.Commands.Add(button);
+
+            _ = await td.ShowAsync(true);
+
+            Assert.True(clickFired);
+            Assert.True(commandFired);
+
+            td.Commands.Clear();
+
+            td.Opened -= OnOpened;
+        }
+
+        [Fact(Timeout = 5000)]
+        public async void EscapeKeyCancelsDialogWithNoneResult()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                td.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent, 
+                    Route = RoutingStrategies.Tunnel,
+                    Key = Key.Escape
+                });
+            }
+
+            td.Opened += OnOpened;
+
+            var result = await td.ShowAsync(true);
+
+            Assert.Equal(TaskDialogStandardResult.None, result);
+
+            td.Opened -= OnOpened;
+        }
+
+        [Fact(Timeout = 5000)]
+        public async void EnterKeyClosesDialogWithDefaultButtonResult()
+        {
+            var td = new TaskDialog { XamlRoot = Context.VisualRoot };
+
+            td.Buttons.Add(new TaskDialogButton("Button", "result")
+            {
+                IsDefault = true
+            });
+            td.Buttons.Add(new TaskDialogButton("Cancel", TaskDialogStandardResult.Cancel));
+
+            bool clickFired = false;
+            td.Buttons[0].Click += (s, e) =>
+            {
+                clickFired = true;
+            };
+
+            bool commandFired = false;
+            td.Buttons[0].Command = new TestCommand(x =>
+            {
+                commandFired = true;
+            });
+
+            void OnOpened(object sender, EventArgs e)
+            {
+                // Force apply template - otherwise it isn't done yet and buttons aren't
+                // created yet
+                td.ApplyTemplate();
+
+                td.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent,
+                    Route = RoutingStrategies.Tunnel,
+                    Key = Key.Enter
+                });
+            }
+
+            td.Opened += OnOpened;
+
+            var result = await td.ShowAsync(true);
+
+            Assert.Equal("result", result);
+            Assert.True(commandFired);
+            Assert.True(clickFired);
+
+            td.Opened -= OnOpened;
+        }
+    }
+}

--- a/FluentAvaloniaTests/Helpers/TestRoot.cs
+++ b/FluentAvaloniaTests/Helpers/TestRoot.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace FluentAvaloniaTests
 {
-	public class TestRoot : Decorator, IFocusScope, ILayoutRoot, IInputRoot, IRenderRoot, IStyleHost, ILogicalRoot
+    public class TestRoot : Decorator, IFocusScope, ILayoutRoot, IInputRoot, IRenderRoot, IStyleHost, ILogicalRoot
 	{
 		public TestRoot()
 		{


### PR DESCRIPTION
As spec'd out in #94, TaskDialogs are coming soon to FluentAvalonia! There have been some design changes from the original spec, but I think you'll like them - some changes came from the from the proposal in WinUI's repo linked to in the original issue. I've focused on customization with the dialogs to ensure they allow you to easily do what you need them to, without making them a nightmare.

One big change compared to ContentDialogs, is that TaskDialogs can launch in their own modal dialog window. This utilizes CoreWindow, which now has some additional features to properly handle the caption buttons for dialog states (i.e., the min and max/restore buttons are hidden). Unfortunately for Mac/Linux, you'll get the default behavior for dialog windows in Avalonia, which may still show the minimize button. The benefit for this though is you're no longer bound to the app window dimensions.
For platforms that don't support windows, TaskDialog falls back to the ContentDialog behavior and uses the OverlayLayer. I've included the ContentDialog animation and shadows for this scenario too. You can also force this behavior on windowing platforms if you'd like.

Here's what they look like:
![image](https://user-images.githubusercontent.com/40413319/155227860-20a1b205-57d6-4026-8ec8-a6a1e36bc951.png)

Yes, that is a ProgressBar built into the dialog - it supports normal and indeterminate, and can be set to show an error state (turns red) or suspended state (turns yellow).

The footer area has a few visibility options (never, auto, and always). Never is self-explanatory. Always means the footer content shows without the "More Details" button. Auto means the footer area can be expanded open with the "More Details" button. The labels "More Details" and "Less Details" are resources, thus you can easily change them by just overriding that resource

TaskDialog buttons and commands are created by you using abstractions (TaskDialog creates the actual controls), but just about everything is able to be updated while the dialog is showing - thus you can react and dynamically change the content as needed. The only thing you can't do is add or remove buttons/commands after showing. That is not supported and will not be.

It does support a default button (which can either be a button or a command), and the Enter key will respond to that. Escape will also close the dialog. Keyboard navigation within the dialog though is limited to default Tab behavior for now. 

Known issues / design decisions:
- I know the icons in the buttons are mis-aligned with the text. There's a couple issues with the symbol font I need to look at (alignment, anti-aliasing) that I think is behind this - just need the time.
- Despite having the icon and description properties (inherited), checkboxes and radiobuttons in the command area ignore these. This was a design decision and will not change at this time. 

