### PR TITLE
[WIP] FluentAvalonia v1.3

### DIFF
--- a/FASandbox/FASandbox.csproj
+++ b/FASandbox/FASandbox.csproj
@@ -7,10 +7,10 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
+    <PackageReference Include="Avalonia" Version="0.10.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.13" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -5,6 +5,8 @@
     <Nullable>disable</Nullable>
 	<RepositoryUrl>https://github.com/amwx/FluentAvalonia</RepositoryUrl>
 	<PackageId>FluentAvaloniaUI</PackageId>
+    <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
+    <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <MicroComGeneratorRuntimeNamespace>MicroCom.Runtime</MicroComGeneratorRuntimeNamespace>
 </PropertyGroup>
 
@@ -18,8 +20,8 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.3.0-beta1</Version>
-        <AssemblyVersion>1.2.1.999</AssemblyVersion>
+        <Version>1.3.0</Version>
+        <AssemblyVersion>1.3.0.0</AssemblyVersion>        
     </PropertyGroup>
 
 

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -41,9 +41,9 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="0.10.12" />
-		<PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.12" />
+		<PackageReference Include="Avalonia" Version="0.10.13" />
+		<PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
 		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.4" />
 		<PackageReference Include="MicroCom.Runtime" Version="0.10.4" />
         <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />

--- a/FluentAvalonia/Styling/BasicControls/DataGridStyles.axaml
+++ b/FluentAvalonia/Styling/BasicControls/DataGridStyles.axaml
@@ -1,67 +1,71 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 		xmlns:ui="using:FluentAvalonia.UI.Controls">
-	
-	<Style Selector="DataGridCell">
-		<Setter Property="Background" Value="{DynamicResource DataGridCellBackgroundBrush}" />
-		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
-		<Setter Property="VerticalContentAlignment" Value="Stretch" />
-		<Setter Property="FontSize" Value="15" />
-		<Setter Property="MinHeight" Value="32" />
-		<Setter Property="Focusable" Value="False" />
-		<Setter Property="Template">
-			<ControlTemplate>
-				<Grid x:Name="PART_CellRoot"
-					  ColumnDefinitions="*,Auto"
-					  Background="{TemplateBinding Background}">
 
-					<Rectangle x:Name="CurrencyVisual"
-							   HorizontalAlignment="Stretch"
-							   VerticalAlignment="Stretch"
-							   Fill="Transparent"
-							   IsHitTestVisible="False"
-							   Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
-							   StrokeThickness="1" />
-					<Grid x:Name="FocusVisual"
-						  IsHitTestVisible="False">
-						<Rectangle HorizontalAlignment="Stretch"
-								   VerticalAlignment="Stretch"
-								   Fill="Transparent"
-								   IsHitTestVisible="False"
-								   Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
-								   StrokeThickness="2" />
-						<Rectangle Margin="2"
-								   HorizontalAlignment="Stretch"
-								   VerticalAlignment="Stretch"
-								   Fill="Transparent"
-								   IsHitTestVisible="False"
-								   Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
-								   StrokeThickness="1" />
-					</Grid>
+    <Styles.Resources>
+        <Thickness x:Key="DataGridTextColumnCellTextBlockMargin">12 0</Thickness>
+    </Styles.Resources>
 
-					<ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}"
-									  Content="{TemplateBinding Content}"
-									  Margin="{TemplateBinding Padding}"
-									  TextBlock.Foreground="{TemplateBinding Foreground}"
-									  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-									  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+    <Style Selector="DataGridCell">
+        <Setter Property="Background" Value="{DynamicResource DataGridCellBackgroundBrush}" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="FontSize" Value="15" />
+        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Grid x:Name="PART_CellRoot"
+                        ColumnDefinitions="*,Auto"
+                        Background="{TemplateBinding Background}">
 
-					<Rectangle x:Name="InvalidVisualElement"
-							   HorizontalAlignment="Stretch"
-							   VerticalAlignment="Stretch"
-							   IsHitTestVisible="False"
-							   Stroke="{DynamicResource DataGridCellInvalidBrush}"
-							   StrokeThickness="1" />
+                    <Rectangle x:Name="CurrencyVisual"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                Fill="Transparent"
+                                IsHitTestVisible="False"
+                                Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
+                                StrokeThickness="1" />
+                    <Grid x:Name="FocusVisual"
+                            IsHitTestVisible="False">
+                        <Rectangle HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    Fill="Transparent"
+                                    IsHitTestVisible="False"
+                                    Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
+                                    StrokeThickness="2" />
+                        <Rectangle Margin="2"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    Fill="Transparent"
+                                    IsHitTestVisible="False"
+                                    Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
+                                    StrokeThickness="1" />
+                    </Grid>
 
-					<Rectangle Name="PART_RightGridLine"
-							   Grid.Column="1"
-							   VerticalAlignment="Stretch"
-							   Width="1"
-							   Fill="{DynamicResource DataGridFillerColumnGridLinesBrush}" />
-				</Grid>
-			</ControlTemplate>
-		</Setter>
-	</Style>
+                    <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        Content="{TemplateBinding Content}"
+                                        Margin="{TemplateBinding Padding}"
+                                        TextBlock.Foreground="{TemplateBinding Foreground}"
+                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+                    <Rectangle x:Name="InvalidVisualElement"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                IsHitTestVisible="False"
+                                Stroke="{DynamicResource DataGridCellInvalidBrush}"
+                                StrokeThickness="1" />
+
+                    <Rectangle Name="PART_RightGridLine"
+                                Grid.Column="1"
+                                VerticalAlignment="Stretch"
+                                Width="1"
+                                Fill="{DynamicResource DataGridFillerColumnGridLinesBrush}" />
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+    </Style>
 
 	<Style Selector="DataGridCell /template/ Rectangle#CurrencyVisual">
 		<Setter Property="IsVisible" Value="False" />
@@ -85,6 +89,11 @@
 		<Setter Property="Template" Value="{DynamicResource TooltipDataValidationContentTemplate}" />
 		<Setter Property="ErrorTemplate" Value="{DynamicResource TooltipDataValidationErrorTemplate}" />
 	</Style>
+
+    <Style Selector="DataGridCell > TextBlock#CellTextBlock">
+        <Setter Property="Margin" Value="{DynamicResource DataGridTextColumnCellTextBlockMargin}" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
 
 
 	<!-- DATA GRID COLUMN HEADER -->

--- a/FluentAvalonia/Styling/Controls/MenuFlyoutItemStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/MenuFlyoutItemStyles.axaml
@@ -62,7 +62,7 @@
 						<TextBlock Name="KeyboardAcceleratorTextBlock"
 									Grid.Column="1"
 									Classes="CaptionTextBlockStyle"
-									Text="{TemplateBinding HotKey, Converter={StaticResource KeyGestureConverter}}"
+									Text="{TemplateBinding InputGesture, Converter={StaticResource KeyGestureConverter}}"
 									Margin="24,0,0,0"
 									HorizontalAlignment="Right"
 								   VerticalAlignment="Center"/>

--- a/FluentAvalonia/Styling/Controls/RadioMenuFlyoutItemStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/RadioMenuFlyoutItemStyles.axaml
@@ -63,7 +63,7 @@
 						<TextBlock Name="KeyboardAcceleratorTextBlock"
 									Grid.Column="2"
 									Classes="CaptionTextBlockStyle"
-									Text="{TemplateBinding HotKey, Converter={StaticResource KeyConv}}"
+									Text="{TemplateBinding InputGesture, Converter={StaticResource KeyConv}}"
 									Margin="24,0,0,0"
 									HorizontalAlignment="Right"
 								   VerticalAlignment="Center"/>

--- a/FluentAvalonia/Styling/Controls/ToggleMenuFlyoutItemStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/ToggleMenuFlyoutItemStyles.axaml
@@ -56,7 +56,7 @@
 						<TextBlock Name="KeyboardAcceleratorTextBlock"
 									Grid.Column="2"
 									Classes="CaptionTextBlockStyle"
-									Text="{TemplateBinding HotKey, Converter={StaticResource KeyConv}}"
+									Text="{TemplateBinding InputGesture, Converter={StaticResource KeyConv}}"
 									Margin="24,0,0,0"
 									HorizontalAlignment="Right"
 								   VerticalAlignment="Center"/>

--- a/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
@@ -78,10 +78,11 @@
     <Color x:Key="LayerOnAcrylicFillColorDefault">#09FFFFFF</Color>
     <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#09FFFFFF</Color>
 
-    <Color x:Key="LayerOnMicaAltFillColorDefault">#733A3A3A</Color>
-    <Color x:Key="LayerOnMicaAltFillColorSecondary">#0FFFFFFF</Color>
-    <Color x:Key="LayerOnMicaAltFillColorTertiary">#2C2C2C</Color>
-    <Color x:Key="LayerOnMicaAltFillColorTransparent">#00FFFFFF</Color>
+    <!-- Color names changed as in WinUI 6763 -->
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#733A3A3A</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0FFFFFFF</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#2C2C2C</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#00FFFFFF</Color>
 
     <Color x:Key="SolidBackgroundFillColorBase">#202020</Color>
     <Color x:Key="SolidBackgroundFillColorSecondary">#1C1C1C</Color>
@@ -190,10 +191,11 @@
     <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
     <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
 
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaAltFillColorDefault}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaAltFillColorSecondary}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaAltFillColorTertiary}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaAltFillColorTransparent}" />
+    <!-- Brush names changed WinUI 6763 -->
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTransparent}" />
 
     <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
     <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
@@ -1878,11 +1880,13 @@
 
     <!-- TAB VIEW -->
     <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SubtleFillColorTransparentBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaAltFillColorSecondaryBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
+    <!-- Colors adjusted for next 5 items from WinUI #6763 -->
+    <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+    
     <StaticResource x:Key="TabViewItemHeaderForeground"                             ResourceKey="TextFillColorSecondaryBrush" />
     <StaticResource x:Key="TabViewItemHeaderForegroundPressed"                      ResourceKey="TextFillColorTertiaryBrush" />
     <StaticResource x:Key="TabViewItemHeaderForegroundSelected"                     ResourceKey="TextFillColorPrimaryBrush" />

--- a/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
@@ -98,10 +98,11 @@
     <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{DynamicResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{DynamicResource SystemColorWindowColor}"/>
 
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorDefaultBrush" Color="{DynamicResource SystemColorHighlightColor}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorSecondaryBrush" Color="{DynamicResource SystemColorHighlightColor}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorTertiaryBrush" Color="{DynamicResource SystemColorHighlightColor}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorTransparentBrush" Color="{DynamicResource SystemColorButtonFaceColor}" />
+    <!-- Brush names changed WinUI 6763 -->
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{DynamicResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{DynamicResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{DynamicResource SystemColorHighlightColor}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{DynamicResource SystemColorButtonFaceColor}" />
 
     <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{DynamicResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{DynamicResource SystemColorWindowColor}" />

--- a/FluentAvalonia/Styling/StylesV2/LightResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/LightResources.axaml
@@ -80,10 +80,10 @@
     <Color x:Key="LayerOnAcrylicFillColorDefault">#40FFFFFF</Color>
     <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#40FFFFFF</Color>
 
-    <Color x:Key="LayerOnMicaAltFillColorDefault">#B3FFFFFF</Color>
-    <Color x:Key="LayerOnMicaAltFillColorSecondary">#0A000000</Color>
-    <Color x:Key="LayerOnMicaAltFillColorTertiary">#F9F9F9</Color>
-    <Color x:Key="LayerOnMicaAltFillColorTransparent">#00000000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#B3FFFFFF</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0A000000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#F9F9F9</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#00000000</Color>
 
     <Color x:Key="SolidBackgroundFillColorBase">#F3F3F3</Color>
     <Color x:Key="SolidBackgroundFillColorSecondary">#EEEEEE</Color>
@@ -192,11 +192,12 @@
     <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
     <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
 
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaAltFillColorDefault}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaAltFillColorSecondary}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaAltFillColorTertiary}" />
-    <SolidColorBrush x:Key="LayerOnMicaAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaAltFillColorTransparent}" />
-
+    <!-- Brush names changed WinUI 6763 -->
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
+    <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTransparent}" />
+    
     <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
     <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
     <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
@@ -1943,11 +1944,13 @@
 
     <!-- TABVIEW -->
     <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SubtleFillColorTransparentBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaAltFillColorSecondaryBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-    <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
+    <!-- Colors adjusted for next 5 items from WinUI #6763 -->
+    <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
+    <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+    
     <StaticResource x:Key="TabViewItemHeaderForeground"                             ResourceKey="TextFillColorSecondaryBrush" />
     <StaticResource x:Key="TabViewItemHeaderForegroundPressed"                      ResourceKey="TextFillColorTertiaryBrush" />
     <StaticResource x:Key="TabViewItemHeaderForegroundSelected"                     ResourceKey="TextFillColorPrimaryBrush" />

--- a/FluentAvalonia/UI/Controls/Frame/Frame.properties.cs
+++ b/FluentAvalonia/UI/Controls/Frame/Frame.properties.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using FluentAvalonia.UI.Navigation;
 using System;
 using System.Collections.Generic;
@@ -158,7 +159,8 @@ namespace FluentAvalonia.UI.Controls
                     if (!value)
                     {
                         _backStack.Clear();
-                        _forwardStack.Clear();                     
+                        _forwardStack.Clear();
+                        _cache.Clear();
                     }
                 }
             }
@@ -187,6 +189,29 @@ namespace FluentAvalonia.UI.Controls
         /// </summary>
         public event NavigationStoppedEventHandler NavigationStopped;
 
+        /// <summary>
+        /// Indicates to a page that it is being navigated away from. Takes the place of 
+        /// Microsoft.UI.Xaml.Controls.Page.OnNavigatingFrom() method
+        /// </summary>
+        public static readonly RoutedEvent<NavigatingCancelEventArgs> NavigatingFromEvent =
+            RoutedEvent.Register<Control, NavigatingCancelEventArgs>("NavigatingFrom", 
+                RoutingStrategies.Direct);
+
+        /// <summary>
+        /// Indiates to a page that it has been navigated away from. Takes the place of
+        /// Microsoft.UI.Xaml.Controls.Page.OnNavigatedFrom() method
+        /// </summary>
+        public static readonly RoutedEvent<NavigationEventArgs> NavigatedFromEvent =
+            RoutedEvent.Register<Control, NavigationEventArgs>("NavigatedFrom",
+                RoutingStrategies.Direct);
+
+        /// <summary>
+        /// Indiates to a page that it is being navigated to. Takes the place of
+        /// Microsoft.UI.Xaml.Controls.Page.OnNavigatedTo() method
+        /// </summary>
+        public static readonly RoutedEvent<NavigationEventArgs> NavigatedToEvent =
+            RoutedEvent.Register<Control, NavigationEventArgs>("NavigatedTo",
+                RoutingStrategies.Direct);
 
         private Type _sourcePageType;
         private int _cacheSize = 10;

--- a/FluentAvalonia/UI/Controls/Frame/FrameNavigationOptions.cs
+++ b/FluentAvalonia/UI/Controls/Frame/FrameNavigationOptions.cs
@@ -9,12 +9,12 @@ namespace FluentAvalonia.UI.Navigation
     public class FrameNavigationOptions
     {
         /// <summary>
-        /// Gets or sets a value that indicates whether navigation is recorded in the Frame's ForwardStack or BackStack.
+        /// Gets or sets a value that indicates the animated transition associated with the navigation.
         /// </summary>
         public NavigationTransitionInfo TransitionInfoOverride { get; set; }
 
         /// <summary>
-        /// Gets or sets a value that indicates the animated transition associated with the navigation.
+        /// Gets or sets a value that indicates whether navigation is recorded in the Frame's ForwardStack or BackStack.
         /// </summary>
         public bool IsNavigationStackEnabled { get; set; }
     }

--- a/FluentAvalonia/UI/Controls/Frame/NavigatingCancelEventArgs.cs
+++ b/FluentAvalonia/UI/Controls/Frame/NavigatingCancelEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using FluentAvalonia.UI.Media.Animation;
+﻿using Avalonia.Interactivity;
+using FluentAvalonia.UI.Media.Animation;
 using System;
 
 namespace FluentAvalonia.UI.Navigation
@@ -13,7 +14,7 @@ namespace FluentAvalonia.UI.Navigation
     /// <summary>
     /// Provides data for the OnNavigatingFrom callback that can be used to cancel a navigation request from origination.
     /// </summary>
-    public class NavigatingCancelEventArgs : EventArgs
+    public class NavigatingCancelEventArgs : RoutedEventArgs
     {
         internal NavigatingCancelEventArgs(NavigationMode mode, NavigationTransitionInfo info,
             object param, Type srcType)

--- a/FluentAvalonia/UI/Controls/Frame/NavigationEventArgs.cs
+++ b/FluentAvalonia/UI/Controls/Frame/NavigationEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using FluentAvalonia.UI.Media.Animation;
+﻿using Avalonia.Interactivity;
+using FluentAvalonia.UI.Media.Animation;
 using System;
 
 namespace FluentAvalonia.UI.Navigation
@@ -20,7 +21,7 @@ namespace FluentAvalonia.UI.Navigation
     /// <summary>
     /// Provides data for navigation methods and event handlers that cannot cancel the navigation request.
     /// </summary>
-    public class NavigationEventArgs : EventArgs
+    public class NavigationEventArgs : RoutedEventArgs
     {
         internal NavigationEventArgs(object content, NavigationMode mode,
             NavigationTransitionInfo navInfo, object param,

--- a/FluentAvalonia/UI/Controls/IconElement/BitmapIconSource.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/BitmapIconSource.cs
@@ -75,7 +75,10 @@ namespace FluentAvalonia.UI.Controls
             Dispose();
 
             if (src == null)
+            {
+                OnBitmapChanged?.Invoke(this, null);
                 return;
+            }
 
             if (src.IsAbsoluteUri && src.IsFile)
             {

--- a/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
@@ -1,4 +1,7 @@
-﻿using Avalonia.Controls;
+﻿using System.Reactive.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
 
 namespace FluentAvalonia.UI.Controls
 {
@@ -15,9 +18,15 @@ namespace FluentAvalonia.UI.Controls
                 [!FontIcon.GlyphProperty] = fis[!FontIconSource.GlyphProperty]
             };
 
-            if (fis.IsSet(TextBlock.ForegroundProperty))
+            if (fis.IsSet(IconSource.ForegroundProperty))
             {
-                fi[!TextBlock.ForegroundProperty] = fis[!TextBlock.ForegroundProperty];
+                fi.Bind(TextBlock.ForegroundProperty, fis.GetBindingObservable(IconSource.ForegroundProperty),
+                    priority: BindingPriority.LocalValue);
+            }
+            else
+            {
+                fi.Bind(TextBlock.ForegroundProperty, fis.GetBindingObservable(IconSource.ForegroundProperty).Skip(1),
+                    priority: BindingPriority.LocalValue);
             }
 
             return fi;
@@ -30,9 +39,15 @@ namespace FluentAvalonia.UI.Controls
                 [!PathIcon.DataProperty] = pis[!PathIconSource.DataProperty]
             };
 
-            if (pis.IsSet(TextBlock.ForegroundProperty))
+            if (pis.IsSet(IconSource.ForegroundProperty))
             {
-                pi[!TextBlock.ForegroundProperty] = pis[!TextBlock.ForegroundProperty];
+                pi.Bind(TextBlock.ForegroundProperty, pis.GetBindingObservable(IconSource.ForegroundProperty),
+                    priority: BindingPriority.LocalValue);
+            }
+            else
+            {
+                pi.Bind(TextBlock.ForegroundProperty, pis.GetBindingObservable(IconSource.ForegroundProperty).Skip(1),
+                    priority: BindingPriority.LocalValue);
             }
 
             return pi;
@@ -46,11 +61,17 @@ namespace FluentAvalonia.UI.Controls
                 [!TextBlock.FontSizeProperty] = sis[!TextBlock.FontSizeProperty]
             };
 
-            if (sis.IsSet(TextBlock.ForegroundProperty))
+            if (sis.IsSet(IconSource.ForegroundProperty))
             {
-                si[!TextBlock.ForegroundProperty] = sis[!TextBlock.ForegroundProperty];
+                si.Bind(TextBlock.ForegroundProperty, sis.GetBindingObservable(IconSource.ForegroundProperty),
+                    priority: BindingPriority.LocalValue);
             }
-
+            else
+            {
+                si.Bind(TextBlock.ForegroundProperty, sis.GetBindingObservable(IconSource.ForegroundProperty).Skip(1),
+                    priority: BindingPriority.LocalValue);
+            }
+           
             return si;
         }
 
@@ -62,9 +83,15 @@ namespace FluentAvalonia.UI.Controls
             BitmapIcon bi = new BitmapIcon();
             bi.LinkToBitmapIconSource(bis);
 
-            if (bi.IsSet(TextBlock.ForegroundProperty))
+            if (bis.IsSet(IconSource.ForegroundProperty))
             {
-                bi[!TextBlock.ForegroundProperty] = bis[!TextBlock.ForegroundProperty];
+                bi.Bind(TextBlock.ForegroundProperty, bis.GetBindingObservable(IconSource.ForegroundProperty),
+                    priority: BindingPriority.LocalValue);
+            }
+            else
+            {
+                bi.Bind(TextBlock.ForegroundProperty, bis.GetBindingObservable(IconSource.ForegroundProperty).Skip(1),
+                    priority: BindingPriority.LocalValue);
             }
 
             return bi;
@@ -77,9 +104,15 @@ namespace FluentAvalonia.UI.Controls
 				[!ImageIcon.SourceProperty] = iis[!ImageIconSource.SourceProperty]
 			};
 
-            if (iis.IsSet(TextBlock.ForegroundProperty))
+            if (iis.IsSet(IconSource.ForegroundProperty))
             {
-                ii[!TextBlock.ForegroundProperty] = iis[!TextBlock.ForegroundProperty];
+                ii.Bind(TextBlock.ForegroundProperty, iis.GetBindingObservable(IconSource.ForegroundProperty),
+                    priority: BindingPriority.LocalValue);
+            }
+            else
+            {
+                ii.Bind(TextBlock.ForegroundProperty, iis.GetBindingObservable(IconSource.ForegroundProperty).Skip(1),
+                    priority: BindingPriority.LocalValue);
             }
 
             return ii;

--- a/FluentAvalonia/UI/Controls/IconElement/IconSource.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/IconSource.cs
@@ -10,16 +10,12 @@ namespace FluentAvalonia.UI.Controls
     [TypeConverter(typeof(IconSourceConverter))]
     public abstract class IconSource : AvaloniaObject
     {
-        static IconSource()
-        {
-        }
-
         /// <summary>
         /// Defines the <see cref="Foreground"/> property
         /// </summary>
-        public static readonly AttachedProperty<IBrush> ForegroundProperty =
-            TextBlock.ForegroundProperty.AddOwner<IconSource>();
-
+        public static readonly StyledProperty<IBrush> ForegroundProperty =
+            AvaloniaProperty.Register<IconSource, IBrush>(nameof(Foreground));
+            
         /// <summary>
         /// Gets or sets a brush that describes the foreground color.
         /// </summary>

--- a/FluentAvalonia/UI/Controls/IconElement/IconSourceElement.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/IconSourceElement.cs
@@ -29,14 +29,6 @@ namespace FluentAvalonia.UI.Controls
 		{
 			base.OnPropertyChanged(change);
 
-   //         if (change.Property == ForegroundProperty)
-			//{
-   //             if (IconSource != null)
-   //             {
-   //                 IconSource.Foreground = change.NewValue.GetValueOrDefault<IBrush>();
-   //             }
-   //         }
-   //         else
             if (change.Property == IconSourceProperty)
 			{
                 OnIconSourceChanged(change);

--- a/FluentAvalonia/UI/Controls/IconElement/IconSourceElement.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/IconSourceElement.cs
@@ -29,14 +29,15 @@ namespace FluentAvalonia.UI.Controls
 		{
 			base.OnPropertyChanged(change);
 
-            if (change.Property == ForegroundProperty)
-			{
-                if (IconSource != null)
-                {
-                    IconSource.Foreground = change.NewValue.GetValueOrDefault<IBrush>();
-                }
-            }
-            else if (change.Property == IconSourceProperty)
+   //         if (change.Property == ForegroundProperty)
+			//{
+   //             if (IconSource != null)
+   //             {
+   //                 IconSource.Foreground = change.NewValue.GetValueOrDefault<IBrush>();
+   //             }
+   //         }
+   //         else
+            if (change.Property == IconSourceProperty)
 			{
                 OnIconSourceChanged(change);
                 InvalidateMeasure();

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyout.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyout.cs
@@ -72,6 +72,11 @@ namespace FluentAvalonia.UI.Controls
 				SetPresenterClasses(Popup.Child, FlyoutPresenterClasses);
 			}
 			base.OnOpened();
+
+            if (Popup.Child is MenuFlyoutPresenter mfp)
+            {
+                mfp.RaiseMenuOpened();
+            }
 		}
 
 		private static void SetPresenterClasses(IControl presenter, Classes classes)

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
@@ -14,7 +15,7 @@ namespace FluentAvalonia.UI.Controls
 	/// </summary>
 	public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSource
 	{
-		protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+        protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
 		{
 			if (_hotkey != null)
 			{
@@ -50,6 +51,10 @@ namespace FluentAvalonia.UI.Controls
 		{
 			base.OnPropertyChanged(change);
 
+            // For this, we make assumption that if you set Hotkey or assign a XamlUICommand,
+            // you won't also set the InputGesture to something different, so setting HotKey
+            // or using a XamlUICommand will automatically set the InputGesture property
+
 			if (change.Property == CommandProperty)
 			{
 				var oldCommand = change.OldValue.GetValueOrDefault() as ICommand;
@@ -67,7 +72,7 @@ namespace FluentAvalonia.UI.Controls
 						Icon = null;
 					}
 
-					if (HotKey == oldXaml.HotKey)
+					if (InputGesture == oldXaml.HotKey)
 					{
 						HotKey = null;
 					}
@@ -85,7 +90,7 @@ namespace FluentAvalonia.UI.Controls
 						Icon = new IconSourceElement { IconSource = newXaml.IconSource };
 					}
 
-					if (HotKey == null)
+					if (InputGesture == null)
 					{
 						HotKey = newXaml.HotKey;
 					}
@@ -110,10 +115,15 @@ namespace FluentAvalonia.UI.Controls
 			{
 				CanExecuteChanged(this, null);
 			}
-			else if (change.Property == HotKeyProperty)
+			else if (change.Property == InputGestureProperty)
 			{
 				PseudoClasses.Set(":hotkey", change.NewValue.GetValueOrDefault() != null);
 			}
+            else if (change.Property == HotKeyProperty)
+            {
+                var kg = change.NewValue.GetValueOrDefault<KeyGesture>();
+                InputGesture = kg;
+            }
 		}
 
 		protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -169,7 +169,7 @@ namespace FluentAvalonia.UI.Controls
 
 		void IMenuItem.RaiseClick() => OnClick();
 
-		void ICommandSource.CanExecuteChanged(object sender, EventArgs e) => this.CanExecuteChanged(sender, e);
+		void ICommandSource.CanExecuteChanged(object sender, EventArgs e) => CanExecuteChanged(sender, e);
 		
 		void IMenuElement.Close() { }
 		

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
@@ -42,7 +42,13 @@ namespace FluentAvalonia.UI.Controls
 		public static readonly StyledProperty<KeyGesture> HotKeyProperty =
 			Button.HotKeyProperty.AddOwner<MenuFlyoutItem>();
 
-		/// <summary>
+        /// <summary>
+        /// Defines the <see cref="InputGesture"/> property
+        /// </summary>
+        public static readonly StyledProperty<KeyGesture> InputGestureProperty =
+            AvaloniaProperty.Register<MenuFlyoutItem, KeyGesture>(nameof(InputGesture));
+        
+        /// <summary>
 		/// Gets or sets the text content of a MenuFlyoutItem.
 		/// </summary>
 		public string Text
@@ -68,6 +74,20 @@ namespace FluentAvalonia.UI.Controls
 			get => GetValue(HotKeyProperty);
 			set => SetValue(HotKeyProperty, value);
 		}
+
+        /// <summary>
+        /// Gets or sets the input gesture displayed by the MenuFlyoutItem
+        /// </summary>
+        /// <remarks>
+        /// This property is equivalent to WinUI's KeyboardAcceleratorTextOverride
+        /// property. It allows you to specify a key gesture without mapping to 
+        /// a hotkey. This property takes priority over <see cref="HotKey"/>
+        /// </remarks>
+        public KeyGesture InputGesture
+        {
+            get => GetValue(InputGestureProperty);
+            set => SetValue(InputGestureProperty, value);
+        }
 
 		/// <summary>
 		/// Gets or sets the command to invoke when the item is pressed.

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
@@ -1,9 +1,7 @@
-﻿using Avalonia.Controls.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 
 namespace FluentAvalonia.UI.Controls
 {
@@ -13,5 +11,29 @@ namespace FluentAvalonia.UI.Controls
 		{
 			FocusableProperty.OverrideDefaultValue<MenuFlyoutItemBase>(true);
 		}
-	}
+
+        protected override void OnPointerEnter(PointerEventArgs e)
+        {
+            base.OnPointerEnter(e);
+            var point = e.GetCurrentPoint(null);
+            RaiseEvent(new PointerEventArgs(MenuItem.PointerEnterItemEvent, this, e.Pointer, VisualRoot, point.Position,
+                e.Timestamp, point.Properties, e.KeyModifiers));
+        }
+
+        protected override void OnPointerLeave(PointerEventArgs e)
+        {
+            base.OnPointerLeave(e);
+            var point = e.GetCurrentPoint(null);
+            RaiseEvent(new PointerEventArgs(MenuItem.PointerLeaveItemEvent, this, e.Pointer, VisualRoot, point.Position,
+                e.Timestamp, point.Properties, e.KeyModifiers));
+        }
+
+        protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+            base.OnPointerCaptureLost(e);
+
+            RaiseEvent(new PointerEventArgs(MenuItem.PointerLeaveItemEvent, this, e.Pointer, VisualRoot, new Point(),
+                0, null, KeyModifiers.None));
+        }
+    }
 }

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutPresenter.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutPresenter.cs
@@ -1,79 +1,92 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Styling;
 using System;
 
 namespace FluentAvalonia.UI.Controls
 {
-	/// <summary>
-	/// Displays the content of a <see cref="MenuFlyout"/> control.
-	/// </summary>
-	public class MenuFlyoutPresenter : MenuBase, IStyleable
-	{
-		public MenuFlyoutPresenter()
-			: base(new MenuFlyoutInteractionHandler(true))
-		{
-            AddHandler(MenuFlyoutItem.ClickEvent, (s, e) =>
+    /// <summary>
+    /// Displays the content of a <see cref="MenuFlyout"/> control.
+    /// </summary>
+    public class MenuFlyoutPresenter : MenuBase, IStyleable
+    {
+        public MenuFlyoutPresenter()
+            : base(new MenuFlyoutInteractionHandler(true))
+        {
+            KeyboardNavigation.SetTabNavigation(this, KeyboardNavigationMode.Cycle);
+        }
+
+        public MenuFlyoutPresenter(IMenuInteractionHandler handler)
+            : base(handler) { }
+
+        Type IStyleable.StyleKey => typeof(Avalonia.Controls.MenuFlyoutPresenter);
+
+        /// <summary>
+        /// Closes the MenuFlyout.
+        /// </summary>
+        /// <remarks>
+        /// This method should generally not be called directly and is present for the
+        /// MenuInteractionHandler. Close Flyouts by calling Hide() on the Flyout object directly.
+        /// </remarks>
+        public override void Close()
+        {
+            // DefaultMenuInteractionHandler calls this
+            var host = this.FindLogicalAncestorOfType<Popup>();
+            if (host != null)
             {
-                int x = 0;
-            });
-		}
+                for (int i = 0; i < LogicalChildren.Count; i++)
+                {
+                    if (LogicalChildren[i] is IMenuItem item)
+                    {
+                        item.IsSubMenuOpen = false;
+                    }
+                }
 
-		public MenuFlyoutPresenter(IMenuInteractionHandler handler)
-			: base(handler) { }
+                SelectedIndex = -1;
+                host.IsOpen = false;
 
-		Type IStyleable.StyleKey => typeof(Avalonia.Controls.MenuFlyoutPresenter);
+                RaiseMenuClosed();
+            }
+        }
 
-		/// <summary>
-		/// Closes the MenuFlyout.
-		/// </summary>
-		/// <remarks>
-		/// This method should generally not be called directly and is present for the
-		/// MenuInteractionHandler. Close Flyouts by calling Hide() on the Flyout object directly.
-		/// </remarks>
-		public override void Close()
-		{
-			// DefaultMenuInteractionHandler calls this
-			var host = this.FindLogicalAncestorOfType<Popup>();
-			if (host != null)
-			{
-				for (int i = 0; i < LogicalChildren.Count; i++)
-				{
-					if (LogicalChildren[i] is IMenuItem item)
-					{
-						item.IsSubMenuOpen = false;
-					}
-				}
+        /// <summary>
+        /// This method has no functionality
+        /// </summary>
+        /// <exception cref="NotSupportedException" />
+        public override void Open()
+        {
+            throw new NotSupportedException("Use MenuFlyout.ShowAt(Control) instead");
+        }
 
-				SelectedIndex = -1;
-				host.IsOpen = false;
-			}
-		}
+        protected override IItemContainerGenerator CreateItemContainerGenerator()
+        {
+            return new MenuFlyoutPresenterItemContainerGenerator(this);
+        }
 
-		/// <summary>
-		/// This method has no functionality
-		/// </summary>
-		/// <exception cref="NotSupportedException" />
-		public override void Open()
-		{
-			throw new NotSupportedException("Use MenuFlyout.ShowAt(Control) instead");
-		}
+        internal void RaiseMenuOpened()
+        {
+            RaiseEvent(new RoutedEventArgs(MenuOpenedEvent) { Source = this });
+        }
 
-		protected override IItemContainerGenerator CreateItemContainerGenerator()
-		{
-			return new MenuFlyoutPresenterItemContainerGenerator(this);
-		}
+        internal void RaiseMenuClosed()
+        {
+            RaiseEvent(new RoutedEventArgs(MenuClosedEvent) { Source = this });
+        }
 
-		internal bool InternalMoveSelection(NavigationDirection dir, bool wrap) => MoveSelection(dir, wrap);
-
+        internal bool InternalMoveSelection(NavigationDirection dir, bool wrap) =>
+            MoveSelection(dir, wrap);
+        
 		protected override void OnContainersMaterialized(ItemContainerEventArgs e)
 		{
 			base.OnContainersMaterialized(e);
-			for (int i = 0; i <e.Containers.Count; i++)
+
+			for (int i = 0; i < e.Containers.Count; i++)
 			{
 				if (e.Containers[i].ContainerControl is ToggleMenuFlyoutItem tmfi)
 				{
@@ -82,8 +95,8 @@ namespace FluentAvalonia.UI.Controls
 						_iconCount++;
 					}
 
-					_toggleCount++;
-				}
+					_toggleCount++;                    
+                }
 				else if (e.Containers[i].ContainerControl is MenuFlyoutItem mfi)
 				{
 					if (mfi.Icon != null)

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using System;
 
 namespace FluentAvalonia.UI.Controls
@@ -41,6 +42,7 @@ namespace FluentAvalonia.UI.Controls
 		{
 			InitPopup();
 			_subMenu.IsOpen = true;
+            _presenter.RaiseMenuOpened();
 		}
 
 		/// <summary>
@@ -52,7 +54,10 @@ namespace FluentAvalonia.UI.Controls
 			    _subMenu.IsOpen = false;
 
             if (_presenter != null)
-			    _presenter.SelectedIndex = -1;
+            {
+                _presenter.SelectedIndex = -1;
+                _presenter.RaiseMenuClosed();
+            }            
 		}
 				
 		private void InitPopup()
@@ -93,37 +98,8 @@ namespace FluentAvalonia.UI.Controls
 			PseudoClasses.Set(":submenuopen", false);
 		}
 
-		bool IMenuElement.MoveSelection(NavigationDirection direction, bool wrap)
-		{
-			if (_presenter.SelectedIndex == -1)
-			{
-				int index = 0;
-				var ct = _presenter.ItemCount;
-				for (int i = 0; i < ct; i++)
-				{
-					if (_presenter.ItemContainerGenerator.ContainerFromIndex(i).Focusable)
-					{
-						index = i;
-						break;
-					}
-				}
-
-				FocusManager.Instance.Focus(_presenter.ItemContainerGenerator.ContainerFromIndex(index), NavigationMethod.Directional);
-				_presenter.SelectedIndex = index;
-
-				return true;
-			}
-
-			var sel = _presenter?.InternalMoveSelection(direction, wrap) ?? false;
-			if (sel)
-			{
-				FocusManager.Instance.Focus(_presenter.ItemContainerGenerator.ContainerFromIndex(_presenter.SelectedIndex), NavigationMethod.Directional);
-			}
-
-			return sel;
-		}
-
-
+        bool IMenuElement.MoveSelection(NavigationDirection direction, bool wrap) => false;
+		
 		private Popup _subMenu;
 		private MenuFlyoutPresenter _presenter;
 	}

--- a/FluentAvalonia/UI/Controls/MenuFlyout/ToggleMenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/ToggleMenuFlyoutItem.cs
@@ -16,7 +16,8 @@ namespace FluentAvalonia.UI.Controls
 		/// Defines the <see cref="IsChecked"/> Property
 		/// </summary>
 		public static readonly StyledProperty<bool> IsCheckedProperty =
-			AvaloniaProperty.Register<ToggleMenuFlyoutItem, bool>(nameof(IsChecked), defaultBindingMode: BindingMode.TwoWay);
+			AvaloniaProperty.Register<ToggleMenuFlyoutItem, bool>(nameof(IsChecked), 
+                defaultBindingMode: BindingMode.TwoWay);
 
 		/// <summary>
 		/// Gets or sets whether the ToggleMenuFlyoutItem is checked.

--- a/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -11,6 +11,7 @@ using Avalonia.Diagnostics;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 namespace FluentAvalonia.UI.Controls
@@ -255,18 +256,20 @@ namespace FluentAvalonia.UI.Controls
             const string data = "F1 M0,{0}  a 4,4 0 0 0 4,-4  L 4,{1}  a {2},{3} 0 0 1 {4},-{5}  l {6},0  a {7},{8} 0 0 1 {9},{10}  l 0,{11}  a 4,4 0 0 0 4,4 Z";
 
             var builder = new StringBuilder();
-            builder.AppendFormat(data, height - 1,
+            // WinUI 6644
+            builder.AppendFormat(data, height,
                     leftCorner, leftCorner, leftCorner, leftCorner, leftCorner,
                     Bounds.Width - (leftCorner + rightCorner),
                     rightCorner, rightCorner, rightCorner, rightCorner,
-                    height - (4 + rightCorner + 1));
+                    height - (4 + rightCorner));
 
             TabViewTemplateSettings.TabGeometry = StreamGeometry.Parse(builder.ToString());
         }
 
         private void OnSizeChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
         {
-            UpdateTabGeometry();
+            // WinUI #6748
+            Dispatcher.UIThread.Post(() => UpdateTabGeometry());
         }
 
         private void OnIsSelectedPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)

--- a/FluentAvaloniaSamples/Assets/ChangeLog.txt
+++ b/FluentAvaloniaSamples/Assets/ChangeLog.txt
@@ -244,4 +244,38 @@
 -Fixed extra padding on MenuItems
 
 
+[1.3.0]
+*Avalonia Version
+-Upgraded Avalonia package to 0.10.13
+
+*New Controls
+-Ported TabView from WinUI
+-Added TaskDialogs
+
+*NumberBox
+-Fixed issue where icons in NumberBox popup inside ColorPicker would show invalid glyphs 
+
+*ContentDialog
+-Fixed issue where ContentDialog wouldn't size correctly if window height was smaller than dialog height
+
+*ColorPickerButton
+-Flyout events added to ColorPickerButton
+
+*Frame
+-Added support for NavigateToType(Type, object, FrameNavigationOptions) method
+-Added support for GetNavigationState()/SetNavigationState
+-Added NavigationFrom, NavigatedFrom, and NavigatedTo routed events as substitute for WinUI's methods on Page control
+
+*IconSource
+-Fixed issue where setting the Foreground on an IconSource wouldn't be respected in the actual IconElement
+
+*DataGrid
+-Fix broken DataGrid TextBlock column margin from upstream
+
+*FluentAvalonia MenuFlyout
+-Fixed weirdness with RadioMenuFlyoutItem
+-Enabled two-way binding by default on RadioMenuFlyoutItem and ToggleMenuFlyoutItem
+-Added InputGesture property to MenuFlyoutItem
+-Fixed issue where moving the mouse over a MenuFlyoutSubItem and then to another menu item would cause the sub menu to temporarily open
+-Improved Keyboard Navigation* in a MenuFlyout
 

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,10 +11,10 @@
     <AvaloniaResource Include="Pages\SampleCode\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.12" />
+    <PackageReference Include="Avalonia" Version="0.10.13" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.12.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />

--- a/FluentAvaloniaSamples/Pages/FAControlPages/TabViewPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/TabViewPage.axaml
@@ -56,6 +56,7 @@ private void TabView_TabCloseRequested(TabView sender, TabViewTabCloseRequestedE
                               Header="A TabView Bound to a Collection of Items">
 
             <ui:TabView AddTabButtonCommand="{Binding AddDocumentCommand}"
+                        AddTabButtonCommandParameter="Normal"
                         TabCloseRequested="BindingTabView_TabCloseRequested"
                         TabItems="{Binding Documents}">
                 <ui:TabView.TabItemTemplate>
@@ -75,7 +76,8 @@ private void TabView_TabCloseRequested(TabView sender, TabViewTabCloseRequestedE
                 <TextBlock Text="{Binding KeyBindingText}"
                            TextWrapping="Wrap"/>
                 
-                <ui:TabView AddTabButtonClick="TabView_AddButtonClick"
+                <ui:TabView AddTabButtonCommand="{Binding AddDocumentCommand}"
+                            AddTabButtonCommandParameter="Keyboard"
                             TabCloseRequested="TabView_TabCloseRequested"
                             TabItems="{Binding KeyBindingDocuments}"
                             MinHeight="350"

--- a/FluentAvaloniaSamples/Pages/FAControlsPageBase.cs
+++ b/FluentAvaloniaSamples/Pages/FAControlsPageBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -8,6 +9,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using FluentAvalonia.Styling;
+using FluentAvalonia.UI.Controls;
 using FluentAvaloniaSamples.Controls;
 using FluentAvaloniaSamples.Services;
 

--- a/FluentAvaloniaSamples/Styles/ControlExampleStyles.axaml
+++ b/FluentAvaloniaSamples/Styles/ControlExampleStyles.axaml
@@ -6,7 +6,9 @@
     <Design.PreviewWith>
         <Border Padding="20" Width="600" Height="450">
             <local:ControlExample Header="Sample Control"
-                                  CSharpSource="asdg">
+                                  CSharpSource="asdg"
+                                  XamlSource="xaml source"
+                                  UsageNotes="usage notes">
                 <ui:Button Content="Sample"
                            Classes.accent="{Binding #Accent.IsChecked}"/>
 
@@ -26,6 +28,12 @@
     </Style>
     <Style Selector="FlyoutPresenter.CodeSampleCopiedFlyout.Fail">
         <Setter Property="Foreground" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+    </Style>
+
+    <Style Selector="local|ControlExample /template/ Border#CodePreviewAreaHost ToggleButton.ExpanderToggleButton">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
     </Style>
 
     <Style Selector="local|ControlExample">
@@ -120,43 +128,45 @@
                             Background="{DynamicResource ControlFillColorSecondaryBrush}"
                             MinHeight="10"
                             CornerRadius="{Binding Source={StaticResource OverlayCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}">
-                        <Grid ColumnDefinitions="*,Auto"
-                              RowDefinitions="Auto,Auto,Auto,Auto">
+                        <StackPanel Spacing="4">
+                            <Expander Header="Xaml Sample Code"
+                                      Name="XamlSourceExpander">
+                                <DockPanel>
+                                    <ui:Button Name="CopyXamlButton"
+                                               DockPanel.Dock="Right"
+                                               Margin="8 16 8 8" Padding="4"
+                                               VerticalAlignment="Top">
+                                        <ui:SymbolIcon Symbol="Copy" FontSize="18" />
+                                    </ui:Button>
 
-                            <aedit:TextEditor Name="XamlTextEditor" IsReadOnly="True"
-                                              Margin="8 32 8 8"
-                                              MinHeight="50"/>
-
-                            <aedit:TextEditor Name="CSharpTextEditor" IsReadOnly="True"
-                                              Grid.Row="1" Margin="8 32 8 8" 
-                                              MinHeight="50" />
-
-                            <ui:Button Name="CopyXamlButton"
-                                       DockPanel.Dock="Right"
-                                       Grid.Column="1"
-                                       Margin="8 16 8 8" Padding="4"
-                                       VerticalAlignment="Top">
-                                <ui:SymbolIcon Symbol="Copy" FontSize="18" />
-                            </ui:Button>
-
-                            <ui:Button Name="CopyCSharpButton"
-                                       Grid.Row="1" Grid.Column="1"
-                                       Margin="8 32 8 8" Padding="4"
-                                       VerticalAlignment="Top">
-                                <ui:SymbolIcon Symbol="Copy" FontSize="18" />
-                            </ui:Button>
-
-                            <TextBlock Text="Additional Notes"
-                                       Classes="BodyStrongTextBlockStyle Notes"
-                                       Grid.Row="2"
-                                       Margin="8 24 8 16"/>
-                            
-                            <TextBlock Name="UsageNotesTextBlock"
-                                       Grid.Row="3"
-                                       Classes="Notes"
-                                       Margin="8 0 8 16"
-                                       TextWrapping="Wrap"/>
-                        </Grid>
+                                    <aedit:TextEditor Name="XamlTextEditor" IsReadOnly="True"
+                                                      Margin="8 32 8 8"
+                                                      MinHeight="50"/>
+                                </DockPanel>
+                            </Expander>
+                            <Expander Header="C# Sample Code"
+                                      Name="CSharpSourceExpander">
+                                <DockPanel>
+                                    <ui:Button Name="CopyCSharpButton"
+                                               DockPanel.Dock="Right"
+                                               Margin="8 32 8 8" Padding="4"
+                                               VerticalAlignment="Top">
+                                        <ui:SymbolIcon Symbol="Copy" FontSize="18" />
+                                    </ui:Button>
+                                    <aedit:TextEditor Name="CSharpTextEditor" IsReadOnly="True"
+                                                      Grid.Row="1" Margin="8 32 8 8"
+                                                      MinHeight="50" />
+                                </DockPanel>
+                            </Expander>
+                            <Expander Header="Additional Notes"
+                                      Name="UsageNotesExpander">
+                                <TextBlock Name="UsageNotesTextBlock"
+                                           Grid.Row="3"
+                                           Classes="Notes"
+                                           Margin="8 0 8 16"
+                                           TextWrapping="Wrap"/>
+                            </Expander>
+                        </StackPanel>
                     </Border>                            
                 </StackPanel>
             </ControlTemplate>
@@ -203,10 +213,6 @@
         <Setter Property="IsVisible" Value="False" />
     </Style>
 
-    <Style Selector="local|ControlExample /template/ TextBlock.Notes">
-        <Setter Property="IsVisible" Value="False" />
-    </Style>
-    
     <Style Selector="local|ControlExample:codepreview /template/ Border#CodePreviewAreaHost">
         <Setter Property="IsVisible" Value="True" />
     </Style>
@@ -215,39 +221,37 @@
     </Style>
 
     <!-- Xaml Source TextArea -->
-    <Style Selector="local|ControlExample /template/ aedit|TextEditor#XamlTextEditor,
-                     local|ControlExample /template/ ui|Button#CopyXamlButton">
+    <Style Selector="local|ControlExample /template/ Expander#XamlSourceExpander">
         <Setter Property="IsVisible" Value="False" />
     </Style>
-
-    <Style Selector="local|ControlExample:xamlsource /template/ aedit|TextEditor#XamlTextEditor,
-                     local|ControlExample:xamlsource /template/ ui|Button#CopyXamlButton">
-        <Setter Property="IsVisible" Value="True" />
-    </Style>
-
-
-    <!-- CSharp Source TextArea -->
-    <Style Selector="local|ControlExample /template/ aedit|TextEditor#CSharpTextEditor,
-                     local|ControlExample /template/ ui|Button#CopyCSharpButton">
-        <Setter Property="IsVisible" Value="False" />
-    </Style>
-
-    <Style Selector="local|ControlExample:csharpsource /template/ aedit|TextEditor#CSharpTextEditor,
-                     local|ControlExample:csharpsource /template/ ui|Button#CopyCSharpButton">
+    <Style Selector="local|ControlExample:xamlsource /template/ Expander#XamlSourceExpander">
         <Setter Property="IsVisible" Value="True" />
     </Style>
     
+
+    <!-- CSharp Source TextArea -->
+    <Style Selector="local|ControlExample /template/ Expander#CSharpSourceExpander">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="local|ControlExample:csharpsource /template/ Expander#CSharpSourceExpander">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+    
+
+    <!-- Usage/Additional Notes -->
+    <Style Selector="local|ControlExample /template/ Expander#UsageNotesExpander">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="local|ControlExample:usagenotes /template/ Expander#UsageNotesExpander">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+    
+
+    <!-- Options -->
     <Style Selector="local|ControlExample:options /template/ Border#OptionsHost">
         <Setter Property="IsVisible" Value="True" />
     </Style>
-
-
-    <!-- Usage/Additional Notes -->
-    <Style Selector="local|ControlExample:usagenotes /template/ TextBlock.Notes">
-        <Setter Property="IsVisible" Value="True" />
-    </Style>
-
-
+    
     <!-- AdaptiveWidth -->    
     <Style Selector="local|ControlExample:adaptiveW /template/ ContentPresenter#ExamplePresenter">
         <Setter Property="Grid.ColumnSpan" Value="2" />

--- a/FluentAvaloniaSamples/ViewModels/TabViewPageViewModel.cs
+++ b/FluentAvaloniaSamples/ViewModels/TabViewPageViewModel.cs
@@ -48,7 +48,14 @@ namespace FluentAvaloniaSamples.ViewModels
 
         private void AddDocumentExecute(object obj)
         {
-            AddDocument(Documents.Count);
+            if (obj.Equals("Keyboard"))
+            {
+                KeyBindingDocuments.Add(AddDocument(KeyBindingDocuments.Count));
+            }
+            else if (obj.Equals("Normal"))
+            {
+                Documents.Add(AddDocument(Documents.Count));
+            }
         }
 
         private void KeyBindingInvoked(object obj)

--- a/FluentAvaloniaTests/ControlTests/IconSourceTests.cs
+++ b/FluentAvaloniaTests/ControlTests/IconSourceTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using FluentAvalonia.UI.Controls;
+using FluentAvaloniaTests.Helpers;
+using Xunit;
+
+namespace FluentAvaloniaTests.ControlTests
+{
+    public class IconSourceTextContext : IDisposable
+    {
+        public IconSourceTextContext()
+        {
+            _appDisposable = UnitTestApplication.Start();
+
+            Root = new TestRoot(new Size(1280, 720));
+            Root.StylingParent = UnitTestApplication.Current;
+
+            Root.Resources.Add("SymbolIcon", new SymbolIconSource { Symbol = Symbol.Save });            
+        }
+
+        public TestRoot Root { get; private set; }
+
+        public void Dispose()
+        {
+            _appDisposable.Dispose();
+        }
+
+        private IDisposable _appDisposable;
+    }
+
+    public class IconSourceTests : IClassFixture<IconSourceTextContext>
+    {
+        public IconSourceTests(IconSourceTextContext ctx)
+        {
+            Context = ctx;
+        }
+
+        public IconSourceTextContext Context { get; }
+
+        [Fact]
+        public void IconSourceWithUnsetForegroundUsesInherited()
+        {
+            Context.Root.Child = new IconSourceElement
+            {
+                IconSource = (SymbolIconSource)(Context.Root.Resources["SymbolIcon"])
+            };
+
+            Context.Root.SetValue(TextBlock.ForegroundProperty, Brushes.Red);
+
+            var sym = Context.Root.FindDescendantOfType<SymbolIcon>();
+
+            Assert.NotNull(sym);
+
+            Assert.Equal(Brushes.Red, sym.GetValue(TextBlock.ForegroundProperty));
+
+            Context.Root.Child = null;
+        }
+
+        [Fact]
+        public void IconSourceUsesSetForeground()
+        {
+            var ico = (SymbolIconSource)(Context.Root.Resources["SymbolIcon"]);
+            ico.Foreground = Brushes.DarkSlateBlue;
+            Context.Root.Child = new IconSourceElement
+            {
+                IconSource = ico
+            };
+
+            Context.Root.SetValue(TextBlock.ForegroundProperty, Brushes.Red);
+
+            var sym = Context.Root.FindDescendantOfType<SymbolIcon>();
+
+            Assert.NotNull(sym);
+
+            Assert.Equal(Brushes.DarkSlateBlue, sym.GetValue(TextBlock.ForegroundProperty));
+
+            Context.Root.Child = null;
+        }
+
+        [Fact]
+        public void IconUpdatesForegroundIfChangedOnIconSource()
+        {
+            var ico = (SymbolIconSource)(Context.Root.Resources["SymbolIcon"]);
+            ico.Foreground = Brushes.DarkSlateBlue;
+            Context.Root.Child = new IconSourceElement
+            {
+                IconSource = ico
+            };
+
+            Context.Root.SetValue(TextBlock.ForegroundProperty, Brushes.Red);
+
+            var sym = Context.Root.FindDescendantOfType<SymbolIcon>();
+
+            Assert.NotNull(sym);
+
+            Assert.Equal(Brushes.DarkSlateBlue, sym.GetValue(TextBlock.ForegroundProperty));
+
+            ico.Foreground = Brushes.Yellow;
+
+            Assert.Equal(Brushes.Yellow, sym.GetValue(TextBlock.ForegroundProperty));
+
+            Context.Root.Child = null;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bringing more of Fluent design and WinUI controls into Avalonia.
 ![GitHub repo size](https://img.shields.io/github/repo-size/amwx/FluentAvalonia?color=%234682B4)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/amwx/FluentAvalonia?color=%23483D8B)
 
-Currently Targets: Avalonia 0.10.12 & multitargets netstandard2.0;netstandard2.1;net5.0
+Currently Targets: Avalonia 0.10.13 & multitargets netstandard2.0;netstandard2.1;net5.0
 
 Note: Windows 7, 8/8.1 are not supported by FluentAvalonia.
 


### PR DESCRIPTION
Quite a large update we have here, two new controls and a bunch of fixes:

**New Controls**
- Added `TabView` control
NOTE: As of now, `TabView` does not support HighContrast styles - they are disabled. This is because the WinUI team still uses the old Fluent v1 naming in those styles - which breaks here when those names don't exist. 
- Added `TaskDialog`s

These controls and the below fixes are available now in the v1.3.0-beta2 nuget package

**Fixes/Improvements**
- Fixed issue where icons in NumberBox popup inside ColorPicker would show invalid glyphs (#95)
- Fixed issue where ContentDialog wouldn't size correctly if window height was smaller than dialog height (#98)
- Flyout events added to ColorPickerButton (#101, thanks to RobertBeekman)

*`Frame`*
- Added support for the `NavigateToType(Type, object, FrameNavigationOptions)` method
- Added support for saving and restoring the Frame's history (`GetNavigationState`/`SetNavigationState`) - currently only save Page type and parameter (if it can be serialized into a string). 
- Added RoutedEvents to allow passing a parameter to the pages that are being Navigated to
Since we don't have a `Page` control, the methods `OnNavigatedTo()`, `OnNavigatingFrom()`, and `OnNavigatedFrom()` don't exist, and passing a parameter to the pages is quite difficult. You can now handle the events to retreive the navigation information when navigating between pages in your app. Notice the routing strategy is `Direct`, it is only posted to the page being loaded/unloaded - and does not bubble/tunnel through the tree
```C#
AddHandler(Frame.NavigatingFromEvent, Handler, RoutingStrategies.Direct);
AddHandler(Frame.NavigatedFromEvent, Handler, RoutingStrategies.Direct);
AddHandler(Frame.NavigatedToEvent, Handler, RoutingStrategies.Direct);
```
These changes just about complete `Frame` and bring it up to what it is in WinUI.

*`IconSource`*
- Fixed issue where setting the Foreground on an IconSource wouldn't be respected in the actual IconElement

*`DataGrid`*
- Fix broken DataGrid TextBlock column margin from upstream (fixes #100)

*`FluentAvalonia.UI.Controls.MenuFlyout` and related*
- Fixed weirdness with `RadioMenuFlyoutItem`
- Enabled two-way binding by default on `RadioMenuFlyoutItem` and `ToggleMenuFlyoutItem`
- Added `InputGesture` property to `MenuFlyoutItem` to enable adding a key gesture without needing a HotKey. This is essentially the equivalent of WinUI's `KeyboardAcceleratorTextOverride` property
- Fixed issue where moving the mouse over a `MenuFlyoutSubItem` and then to another menu item would cause the sub menu to temporarily open
- Fixed Keyboard Navigation* in a MenuFlyout
*=there's more to be done, but this is more related to what I'm looking into for re-writing Avalonia's FocusManager and navigation support

Still TODO:
- [ ] Fix some issues on the `TabView` sample page
- [ ] Allow expanding/collapsing the Xaml/Csharp source examples in the SampleApp

After v1.3:
Last I heard Avalonia is planning v11.0 for sometime in April - whether the current world chaos will change that timeline is unknown. However, given that v11.0 will have some significant changes (new renderer, styling system changes, etc.), I'm looking to see about getting a branch that reflects Avalonia's master branch and begin making incremental changes along the way, as I'm expecting things to break. I've applied for a free myget package feed, but they haven't gotten back to me yet, so IDK...

New controls will probably be held off until Avalonia v11.0, unless something is super pressing, to limit the overall work needed to upgrade to the major version changes



