### PR TITLE
Fix for PathIcon wrong aspect ratio 

### DIFF
--- a/FluentAvalonia/Styling/Controls/PathIconStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/PathIconStyles.axaml
@@ -1,0 +1,21 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls">
+    <Design.PreviewWith>
+        <StackPanel Spacing="50" Margin="20">
+            <ui:PathIcon Height="NaN" Data="M 10 0 20 10 17 2 4 5 z" />
+            <ui:PathIcon Height="50" Data="M 10 0 20 10 17 2 4 5 z" />
+            <ui:PathIcon Height="8" Data="M 10 0 20 10 17 2 4 5 z" />
+        </StackPanel>
+    </Design.PreviewWith>
+
+    <Style Selector="ui|PathIcon">
+        <Setter Property="StretchDirection" Value="Both" />
+    </Style>
+    
+    <Style Selector="ui|PathIcon[Height=NaN]">
+        <Setter Property="StretchDirection" Value="DownOnly" />
+    </Style>
+    
+</Styles>
+

--- a/FluentAvalonia/Styling/StylesV2/Controls.txt
+++ b/FluentAvalonia/Styling/StylesV2/Controls.txt
@@ -67,6 +67,7 @@
 /Styling/Controls/PickerFlyoutPresenterStyles.axaml
 /Styling/Controls/HyperlinkButtonStyles.axaml
 /Styling/Controls/InfoBarStyles.axaml
+/Styling/Controls/PathIconStyles.axaml
 /Styling/Controls/CommandBar/CommandBarStyles.axaml
 /Styling/Controls/CommandBar/CommandBarOverflowPresenterStyles.axaml
 /Styling/Controls/CommandBar/CommandBarButtonStyles.axaml

--- a/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
@@ -36,7 +36,9 @@ namespace FluentAvalonia.UI.Controls
         {
             var pi = new PathIcon
             {
-                [!PathIcon.DataProperty] = pis[!PathIconSource.DataProperty]
+                [!PathIcon.DataProperty] = pis[!PathIconSource.DataProperty],
+                [!PathIcon.StretchProperty] = pis[!PathIconSource.StretchProperty],
+                [!PathIcon.StretchDirectionProperty] = pis[!PathIconSource.StretchDirectionProperty]
             };
 
             if (pis.IsSet(IconSource.ForegroundProperty))

--- a/FluentAvalonia/UI/Controls/IconElement/PathIcon.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/PathIcon.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System;
+using Avalonia;
 using Avalonia.Media;
 using System.Collections.Generic;
 
@@ -50,10 +51,19 @@ namespace FluentAvalonia.UI.Controls
             //the bounds specified
             var bounds = data.Bounds;
             var destRect = new Rect(Bounds.Size);
-            var scale = Matrix.CreateScale(
-                destRect.Width / bounds.Width,
-                destRect.Height / bounds.Height);
-            var translate = Matrix.CreateTranslation(-(Vector)bounds.Position);
+
+            // Prevent divide by zero exception
+            if (bounds.Width == 0 || bounds.Height == 0 || destRect.Width == 0 || destRect.Height == 0) return;
+            
+            var scaleFactor = Math.Min(destRect.Width / bounds.Width, destRect.Height / bounds.Height);
+            
+            var offsetCenter = new Vector(
+                (bounds.Width - destRect.Width / scaleFactor) / 2,
+                (bounds.Height - destRect.Height / scaleFactor) / 2);
+            
+            var scale = Matrix.CreateScale(scaleFactor, scaleFactor);
+
+            var translate = Matrix.CreateTranslation(-(Vector)bounds.Position - offsetCenter);
 
             using (context.PushClip(destRect))
             using (context.PushPreTransform(translate * scale))

--- a/FluentAvalonia/UI/Controls/IconElement/PathIcon.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/PathIcon.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using Avalonia;
 using Avalonia.Media;
 using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 
 namespace FluentAvalonia.UI.Controls
 {
@@ -10,6 +12,18 @@ namespace FluentAvalonia.UI.Controls
     /// </summary>
     public class PathIcon : IconElement
     {
+        private Matrix _transform = Matrix.Identity;
+        private Geometry _renderedGeometry;
+
+        static PathIcon()
+        {
+            StretchProperty.OverrideDefaultValue<PathIcon>(Stretch.Uniform);
+            StretchDirectionProperty.OverrideDefaultValue<PathIcon>(StretchDirection.DownOnly);
+           
+            AffectsMeasure<Shape>(StretchProperty, StretchDirectionProperty, DataProperty);
+            AffectsRender<Shape>(StretchProperty, DataProperty);
+        }
+
         /// <summary>
         /// Defines the <see cref="Data"/> property
         /// </summary>
@@ -26,50 +40,234 @@ namespace FluentAvalonia.UI.Controls
 			set => SetValue(DataProperty, value);
         }
 
-		protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
-		{
-			base.OnPropertyChanged(change);
-			if (change.Property == DataProperty)
-			{
-				InvalidateMeasure();
-				InvalidateVisual();
-			}
-		}
+        /// <summary>
+        /// Defines the <see cref="Stretch"/> property.
+        /// </summary>
+        public static readonly StyledProperty<Stretch> StretchProperty =
+            Shape.StretchProperty.AddOwner<PathIcon>();
 
-		protected override Size MeasureOverride(Size availableSize)
+        /// <summary>
+        /// Gets or sets a <see cref="Stretch"/> enumeration value that describes how the shape fills its allocated space.
+        /// </summary>
+        public Stretch Stretch
         {
-            return Data?.Bounds.Size ?? base.MeasureOverride(availableSize);
+            get { return GetValue(StretchProperty); }
+            set { SetValue(StretchProperty, value); }
+        }
+
+        /// <summary>
+        /// Defines the <see cref="StretchDirection"/> property.
+        /// </summary>
+        public static readonly StyledProperty<StretchDirection> StretchDirectionProperty =
+            Viewbox.StretchDirectionProperty.AddOwner<Avalonia.Controls.PathIcon>();
+        
+        /// <summary>
+        /// Gets or sets a value controlling in what direction contents will be stretched.
+        /// </summary>
+        public StretchDirection StretchDirection
+        {
+            get => GetValue(StretchDirectionProperty);
+            set => SetValue(StretchDirectionProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets a value that represents the final rendered <see cref="Geometry"/> of the shape.
+        /// </summary>
+        private Geometry RenderedGeometry
+        {
+            get
+            {
+                if (_renderedGeometry == null && Data != null)
+                {
+                    if (_transform == Matrix.Identity)
+                    {
+                        _renderedGeometry = Data;
+                    }
+                    else
+                    {
+                        _renderedGeometry = Data.Clone();
+
+                        if (_renderedGeometry.Transform == null ||
+                            _renderedGeometry.Transform.Value == Matrix.Identity)
+                        {
+                            _renderedGeometry.Transform = new MatrixTransform(_transform);
+                        }
+                        else
+                        {
+                            _renderedGeometry.Transform = new MatrixTransform(
+                                _renderedGeometry.Transform.Value * _transform);
+                        }
+                    }
+                }
+
+                return _renderedGeometry;
+            }
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            if (Data is null)
+            {
+                return base.MeasureOverride(availableSize);
+            }
+
+            return CalculateSizeAndTransform(availableSize, Data.Bounds, Stretch, StretchDirection).size;
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            if (Data != null)
+            {
+                var (_, transform) = CalculateSizeAndTransform(finalSize, Data.Bounds, Stretch, StretchDirection);
+
+                if (_transform != transform)
+                {
+                    _transform = transform;
+                    _renderedGeometry = null;
+                }
+
+                return finalSize;
+            }
+
+            return Size.Empty;
+        }
+
+        private static (Size size, Matrix transform) CalculateSizeAndTransform(Size availableSize, Rect shapeBounds,
+            Stretch stretch, StretchDirection stretchDirection)
+        {
+            Size shapeSize = new Size(shapeBounds.Right, shapeBounds.Bottom);
+            Matrix translate = Matrix.Identity;
+            double desiredX = availableSize.Width;
+            double desiredY = availableSize.Height;
+            double sx = 0.0;
+            double sy = 0.0;
+
+            if (stretch != Stretch.None)
+            {
+                shapeSize = shapeBounds.Size;
+            }
+
+            if (double.IsInfinity(availableSize.Width))
+            {
+                desiredX = shapeSize.Width;
+            }
+
+            if (double.IsInfinity(availableSize.Height))
+            {
+                desiredY = shapeSize.Height;
+            }
+
+            if (shapeBounds.Width > 0)
+            {
+                sx = desiredX / shapeSize.Width;
+            }
+
+            if (shapeBounds.Height > 0)
+            {
+                sy = desiredY / shapeSize.Height;
+            }
+
+            if (double.IsInfinity(availableSize.Width))
+            {
+                sx = sy;
+            }
+
+            if (double.IsInfinity(availableSize.Height))
+            {
+                sy = sx;
+            }
+            
+            switch (stretch)
+            {
+                case Stretch.Uniform:
+                    sx = sy = Math.Min(sx, sy);
+                    break;
+                case Stretch.UniformToFill:
+                    sx = sy = Math.Max(sx, sy);
+                    break;
+                case Stretch.Fill:
+                    if (double.IsInfinity(availableSize.Width))
+                    {
+                        sx = 1.0;
+                    }
+
+                    if (double.IsInfinity(availableSize.Height))
+                    {
+                        sy = 1.0;
+                    }
+
+                    break;
+                default:
+                    sx = sy = 1;
+                    break;
+            }
+            
+            // Apply stretch direction by bounding scales.
+            switch (stretchDirection)
+            {
+                case StretchDirection.UpOnly:
+                    if (sx < 1.0)
+                        sx = 1.0;
+                    if (sy < 1.0)
+                        sy = 1.0;
+                    break;
+
+                case StretchDirection.DownOnly:
+                    if (sx > 1.0)
+                        sx = 1.0;
+                    if (sy > 1.0)
+                        sy = 1.0;
+                    break;
+
+                case StretchDirection.Both:
+                    break;
+
+                default:
+                    break;
+            }
+
+            // Calculate translation in order to center the Icon
+            switch (stretch)
+            {
+                case Stretch.None:
+                    translate = Matrix.CreateTranslation(
+                        -shapeBounds.Position.X - (shapeBounds.Width - desiredX) / 2,
+                        -shapeBounds.Position.Y - (shapeBounds.Height - desiredY) / 2);
+                    break;
+
+                case Stretch.Uniform:
+                case Stretch.UniformToFill:
+                    if (sx != 0 && sy != 0)
+                    {
+                        translate = Matrix.CreateTranslation(
+                            -shapeBounds.Position.X - (shapeBounds.Width * sx - desiredX) / sx / 2,
+                            -shapeBounds.Position.Y - (shapeBounds.Height * sy - desiredY) / sy / 2);
+                    }
+                    else
+                    {
+                        translate = Matrix.CreateTranslation(-(Vector)shapeBounds.Position);
+                    }
+                    
+                    break;
+                case Stretch.Fill:
+                    translate = Matrix.CreateTranslation(-(Vector)shapeBounds.Position);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(Stretch), stretch, null);
+            }
+
+            var transform = translate * Matrix.CreateScale(sx, sy);
+            var size = new Size(shapeSize.Width * sx, shapeSize.Height * sy);
+            return (size, transform);
         }
 
         public override void Render(DrawingContext context)
         {
-			var data = Data;
-            if (data == null)
+            var geometry = RenderedGeometry;
+            if (geometry == null)
                 return;
 
-            //Create scale & clip to make sure path is always drawn inside
-            //the bounds specified
-            var bounds = data.Bounds;
-            var destRect = new Rect(Bounds.Size);
-
-            // Prevent divide by zero exception
-            if (bounds.Width == 0 || bounds.Height == 0 || destRect.Width == 0 || destRect.Height == 0) return;
-            
-            var scaleFactor = Math.Min(destRect.Width / bounds.Width, destRect.Height / bounds.Height);
-            
-            var offsetCenter = new Vector(
-                (bounds.Width - destRect.Width / scaleFactor) / 2,
-                (bounds.Height - destRect.Height / scaleFactor) / 2);
-            
-            var scale = Matrix.CreateScale(scaleFactor, scaleFactor);
-
-            var translate = Matrix.CreateTranslation(-(Vector)bounds.Position - offsetCenter);
-
-            using (context.PushClip(destRect))
-            using (context.PushPreTransform(translate * scale))
-            {
-                context.DrawGeometry(Foreground, null, data);
-            }
+            context.DrawGeometry(Foreground, null, geometry);
         }
 
         /// <summary>

--- a/FluentAvalonia/UI/Controls/IconElement/PathIcon.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/PathIcon.cs
@@ -18,8 +18,9 @@ namespace FluentAvalonia.UI.Controls
         static PathIcon()
         {
             StretchProperty.OverrideDefaultValue<PathIcon>(Stretch.Uniform);
-            StretchDirectionProperty.OverrideDefaultValue<PathIcon>(StretchDirection.DownOnly);
-           
+            StretchDirectionProperty.OverrideDefaultValue<PathIcon>(StretchDirection.Both);
+            ClipToBoundsProperty.OverrideDefaultValue<PathIcon>(true);
+            
             AffectsMeasure<Shape>(StretchProperty, StretchDirectionProperty, DataProperty);
             AffectsRender<Shape>(StretchProperty, DataProperty);
         }
@@ -51,8 +52,8 @@ namespace FluentAvalonia.UI.Controls
         /// </summary>
         public Stretch Stretch
         {
-            get { return GetValue(StretchProperty); }
-            set { SetValue(StretchProperty, value); }
+            get => GetValue(StretchProperty);
+            set => SetValue(StretchProperty, value);
         }
 
         /// <summary>

--- a/FluentAvalonia/UI/Controls/IconElement/PathIconSource.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/PathIconSource.cs
@@ -35,8 +35,8 @@ namespace FluentAvalonia.UI.Controls
         /// </summary>
         public Stretch Stretch
         {
-            get { return GetValue(StretchProperty); }
-            set { SetValue(StretchProperty, value); }
+            get => GetValue(StretchProperty);
+            set => SetValue(StretchProperty, value);
         }
 
         /// <summary>

--- a/FluentAvalonia/UI/Controls/IconElement/PathIconSource.cs
+++ b/FluentAvalonia/UI/Controls/IconElement/PathIconSource.cs
@@ -23,5 +23,35 @@ namespace FluentAvalonia.UI.Controls
             get => GetValue(DataProperty);
 			set => SetValue(DataProperty, value);
         }
+        
+        /// <summary>
+        /// Defines the <see cref="Stretch"/> property.
+        /// </summary>
+        public static readonly StyledProperty<Stretch> StretchProperty =
+            PathIcon.StretchProperty.AddOwner<PathIcon>();
+
+        /// <summary>
+        /// Gets or sets a <see cref="Stretch"/> enumeration value that describes how the shape fills its allocated space.
+        /// </summary>
+        public Stretch Stretch
+        {
+            get { return GetValue(StretchProperty); }
+            set { SetValue(StretchProperty, value); }
+        }
+
+        /// <summary>
+        /// Defines the <see cref="StretchDirection"/> property.
+        /// </summary>
+        public static readonly StyledProperty<StretchDirection> StretchDirectionProperty =
+            PathIcon.StretchDirectionProperty.AddOwner<Avalonia.Controls.PathIcon>();
+        
+        /// <summary>
+        /// Gets or sets a value controlling in what direction contents will be stretched.
+        /// </summary>
+        public StretchDirection StretchDirection
+        {
+            get => GetValue(StretchDirectionProperty);
+            set => SetValue(StretchDirectionProperty, value);
+        }
     }
 }


### PR DESCRIPTION
Hi @awmx, 

this PR should close #135 . I hope that this does not break anything, but I can't promise. Someone may want to get the icon streched and not take aspect ratio into account. 

Fixes #135 

Result: 
![image](https://user-images.githubusercontent.com/47110241/165706138-70b082fd-f2a6-4874-b4f9-91600e32dfd4.png)


Happy coding
Tim 