### PR TITLE
CoreWindow Improvements

### DIFF
--- a/FASandbox/FASandbox.csproj
+++ b/FASandbox/FASandbox.csproj
@@ -7,10 +7,10 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.13" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
+    <PackageReference Include="Avalonia" Version="0.10.14" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.13" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.14" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -41,9 +41,9 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="0.10.13" />
-		<PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
+		<PackageReference Include="Avalonia" Version="0.10.14" />
+		<PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
 		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.4" />
 		<PackageReference Include="MicroCom.Runtime" Version="0.10.4" />
         <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />

--- a/FluentAvalonia/Interop/Win32Interop.cs
+++ b/FluentAvalonia/Interop/Win32Interop.cs
@@ -49,7 +49,26 @@ namespace FluentAvalonia.Interop
 		[DllImport("dwmapi.dll", PreserveSig = true, SetLastError = true)]
 		public static extern int DwmSetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE attr, ref int value, int attrSize);
 
-		public static bool GetSystemTheme(OSVERSIONINFOEX osInfo)
+        [DllImport("user32.dll")]
+        public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+
+        [DllImport("user32.dll")]
+        public static extern bool SetMenuItemInfo(IntPtr hMenu, uint item, bool fByPosition, ref MENUITEMINFO lpmii);
+
+        [DllImport("user32.dll")]
+        public static extern bool SetMenuDefaultItem(IntPtr hMenu, uint uItem, uint fByPos);
+
+        [DllImport("user32.dll")]
+        public static extern unsafe bool TrackPopupMenu(IntPtr hMenu, uint uFlags,
+            int x, int y, int nReserved, IntPtr hWnd, RECT* prcRect);
+
+        public static bool GetSystemTheme(OSVERSIONINFOEX osInfo)
 		{
 			if (osInfo.MajorVersion < 10 || osInfo.BuildNumber < 17763) //1809
 				return false;
@@ -149,7 +168,42 @@ namespace FluentAvalonia.Interop
 			public int bottomHeight;
 		}
 
-		[DllImport("user32.dll")]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct MENUITEMINFO
+        {
+            public MENUITEMINFO(MIIM pfMask)
+            {
+                cbSize = Marshal.SizeOf<MENUITEMINFO>();
+                dwTypeData = null;
+                fMask = pfMask;
+
+                fType = default;
+                fState = default;
+                wID = default;
+                hSubMenu = default;
+                hbmpChecked = default;
+                hbmpUnchecked = default;
+                dwItemData = default;
+                dwTypeData = default;
+                cch = default;
+                hbmpItem = default;
+            }
+
+            public int cbSize = Marshal.SizeOf(typeof(MENUITEMINFO));
+            public MIIM fMask;
+            public uint fType;
+            public uint fState;
+            public uint wID;
+            public IntPtr hSubMenu;
+            public IntPtr hbmpChecked;
+            public IntPtr hbmpUnchecked;
+            public IntPtr dwItemData;
+            public string dwTypeData;
+            public uint cch; // length of dwTypeData
+            public IntPtr hbmpItem;
+        }
+
+        [DllImport("user32.dll")]
 		public static extern IntPtr DefWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 	}
 
@@ -282,6 +336,48 @@ namespace FluentAvalonia.Interop
 		NCLBUTTONUP = 0x00A2,
 		NCHITTEST = 0x0084,
 		NCCALCSIZE = 0x0083,
-        ACTIVATE = 0x0006
-	}
+        ACTIVATE = 0x0006,
+        NCRBUTTONDOWN = 0x00A4,
+        NCRBUTTONDBLCLK = 0x00A6,
+        NCRBUTTONUP = 0x00A5,
+        SYSCOMMAND = 0x0112,
+        RBUTTONUP = 0x0205
+    }
+
+    public enum SC : uint
+    {
+        CLOSE = 0xF060,
+        CONTEXTHELP = 0xF180,
+        DEFAULT = 0xF160,
+        HOTKEY = 0xF150,
+        HSCROLL = 0xF080,
+        ISSECURE = 0x00000001,
+        KEYMENU = 0xF100,
+        MAXIMIZE = 0xF030,
+        MINIMIZE = 0xF020,
+        MONITORPOWER = 0xF170,
+        MOUSEMENU = 0xF090,
+        MOVE = 0xF010,
+        NEXTWINDOW = 0xF040,
+        PREVWINDOW = 0xF050,
+        RESTORE = 0xF120,
+        SCREENSAVE = 0xF140,
+        SIZE = 0xF000,
+        TASKLIST = 0xF130,
+        VSCROLL = 0xF070
+    }
+
+    [Flags]
+    public enum MIIM
+    {
+        BITMAP = 0x00000080,
+        CHECKMARKS = 0x00000008,
+        DATA = 0x00000020,
+        FTYPE = 0x00000100,
+        ID = 0x00000002,
+        STATE = 0x00000001,
+        STRING = 0x00000040,
+        SUBMENU = 0x00000004,
+        TYPE = 0x00000010
+    }
 }

--- a/FluentAvalonia/Interop/Win32Interop.cs
+++ b/FluentAvalonia/Interop/Win32Interop.cs
@@ -65,7 +65,7 @@ namespace FluentAvalonia.Interop
         public static extern bool SetMenuDefaultItem(IntPtr hMenu, uint uItem, uint fByPos);
 
         [DllImport("user32.dll")]
-        public static extern unsafe bool TrackPopupMenu(IntPtr hMenu, uint uFlags,
+        public static extern unsafe int TrackPopupMenu(IntPtr hMenu, uint uFlags,
             int x, int y, int nReserved, IntPtr hWnd, RECT* prcRect);
 
         public static bool GetSystemTheme(OSVERSIONINFOEX osInfo)

--- a/FluentAvalonia/Interop/Win32Interop.cs
+++ b/FluentAvalonia/Interop/Win32Interop.cs
@@ -189,7 +189,7 @@ namespace FluentAvalonia.Interop
                 hbmpItem = default;
             }
 
-            public int cbSize = Marshal.SizeOf(typeof(MENUITEMINFO));
+            public int cbSize;
             public MIIM fMask;
             public uint fType;
             public uint fState;

--- a/FluentAvalonia/Interop/Win32Interop.cs
+++ b/FluentAvalonia/Interop/Win32Interop.cs
@@ -282,5 +282,6 @@ namespace FluentAvalonia.Interop
 		NCLBUTTONUP = 0x00A2,
 		NCHITTEST = 0x0084,
 		NCCALCSIZE = 0x0083,
+        ACTIVATE = 0x0006
 	}
 }

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
@@ -45,8 +45,12 @@ namespace FluentAvalonia.UI.Controls
                     cwi.WindowOpened += WindowOpened_Windows;
 				}
 
-				ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.NoChrome;
-				ExtendClientAreaToDecorationsHint = true;
+                // NOTE FOR FUTURE: 
+                // Do NOT enable these properties, doing so causes a clash of logic between here and
+                // the actual window logic within avalonia leading to the window shrinking when restoring
+                // from maximized or minimized state. 
+				//ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.NoChrome;
+				//ExtendClientAreaToDecorationsHint = true;
 				PseudoClasses.Add(":windows");
 
                 PlatformImpl.Closed += WindowClosed_Windows;

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
@@ -32,6 +32,10 @@ namespace FluentAvalonia.UI.Controls
 		{
 			switch ((WM)msg)
 			{
+                case WM.ACTIVATE:
+                    EnsureExtended();
+                    break;
+
 				case WM.NCCALCSIZE:
 					// Weirdness: 
 					// Windows Terminal only handles WPARAM = TRUE & only adjusts the top of the
@@ -75,7 +79,7 @@ namespace FluentAvalonia.UI.Controls
 					return HandleNCHitTest(lParam);
 
 				case WM.SIZE:
-					EnsureExtended();
+					//EnsureExtended();
 
 					if (_fakingMaximizeButton)
 					{
@@ -162,6 +166,10 @@ namespace FluentAvalonia.UI.Controls
 
 			marg.topHeight = -frame.top;
 			Win32Interop.DwmExtendFrameIntoClientArea(Handle.Handle, ref marg);
+
+            Win32Interop.SetWindowPos(Handle.Handle, IntPtr.Zero, 0, 0, 0, 0, 
+                0x0020 /*SWP_FRAMECHANGED*/ | 0x0002 /*SWP_NOMOVE*/ | 0x0200 /*SWP_NOREPOSITION*/ 
+                | 0x0001 /*SWP_NOSIZE*/ | 0x0004 /*SWP_NOZORDER*/);
 		}
 
 		protected IntPtr HandleNCHitTest(IntPtr lParam)

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindowImpl.cs
@@ -150,9 +150,9 @@ namespace FluentAvalonia.UI.Controls
                                 var scPt = PointToScreen(pt.ToPoint(1));
 
                                 var ret = Win32Interop.TrackPopupMenu(sysMenu, 0x0100, scPt.X, scPt.Y, 0, hWnd, (RECT*)null);
-                                if (ret)
+                                if (ret != 0)
                                 {
-                                    Win32Interop.PostMessage(hWnd, (uint)WM.SYSCOMMAND, new IntPtr(ret ? 1 : 0), IntPtr.Zero);
+                                    Win32Interop.PostMessage(hWnd, (uint)WM.SYSCOMMAND, new IntPtr(ret), IntPtr.Zero);
                                 }
                             }   
                         }

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,10 +11,10 @@
     <AvaloniaResource Include="Pages\SampleCode\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.13" />
+    <PackageReference Include="Avalonia" Version="0.10.14" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.12.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />


### PR DESCRIPTION
A couple improvements to `CoreWindow`
First, the issue where the window would size down after restoring \*should\* now be fixed. Turns out the cause was a clash of logic in this lib and the extended frame logic in Avalonia. The fix was to not use the `ExtendClientAreaToDecorationsHint` property on Avalonia and manage the extended frame myself. Issue appears fixed, I'm hoping there's no unintended side effects I've yet to notice (fixes #115)

Second, I've added support for right-clicking the titlebar region and using Alt+Space to open the System context menu, right clicking also respects custom titlebar regions. 

Avalonia package reference is also upped to 0.10.14 as part of this change