### PR TITLE
Check ShouldShowConfirmationButtons when opening PickerFlyoutBase

### DIFF
--- a/FluentAvalonia/UI/Controls/Flyouts/ColorPickerFlyout.cs
+++ b/FluentAvalonia/UI/Controls/Flyouts/ColorPickerFlyout.cs
@@ -50,7 +50,6 @@ namespace FluentAvalonia.UI.Controls
 		protected override void OnOpening(CancelEventArgs args)
 		{
 			base.OnOpening(args);
-			(Popup.Child as PickerFlyoutPresenter).ShowHideButtons(ShouldShowConfirmationButtons());
 		}
 
 		protected override bool ShouldShowConfirmationButtons() => _showButtons;

--- a/FluentAvalonia/UI/Controls/Flyouts/PickerFlyoutBase.cs
+++ b/FluentAvalonia/UI/Controls/Flyouts/PickerFlyoutBase.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Controls.Primitives;
+﻿using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 
 namespace FluentAvalonia.UI.Controls.Primitives
 {
@@ -16,5 +18,15 @@ namespace FluentAvalonia.UI.Controls.Primitives
 		/// Determines if the Accept and Dismiss buttons should be shown
 		/// </summary>
 		protected virtual bool ShouldShowConfirmationButtons() => true;
-	}
+
+        protected override void OnOpening(CancelEventArgs args)
+        {
+            base.OnOpening(args);
+
+            if (Popup.Child is PickerFlyoutPresenter pfp)
+            {
+                pfp.ShowHideButtons(ShouldShowConfirmationButtons());
+            }
+        }
+    }
 }

--- a/FluentAvalonia/UI/Controls/Flyouts/PickerFlyoutPresenter.cs
+++ b/FluentAvalonia/UI/Controls/Flyouts/PickerFlyoutPresenter.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using FluentAvalonia.Core;
+using FluentAvalonia.UI.Controls.Primitives;
 using System;
 
 namespace FluentAvalonia.UI.Controls
@@ -16,10 +17,10 @@ namespace FluentAvalonia.UI.Controls
 			PseudoClasses.Add(":acceptdismiss");
 		}
 
-		/// <summary>
-		/// Raised when the Confirmed button is tapped indicating the new Color should be applied
-		/// </summary>
-		public event TypedEventHandler<PickerFlyoutPresenter, object> Confirmed;
+        /// <summary>
+        /// Raised when the Confirmed button is tapped indicating the new Color should be applied
+        /// </summary>
+        public event TypedEventHandler<PickerFlyoutPresenter, object> Confirmed;
 
 		/// <summary>
 		/// Raised when the Dismiss button is tapped, indicating the new color should not be applied
@@ -66,7 +67,7 @@ namespace FluentAvalonia.UI.Controls
 			PseudoClasses.Set(":acceptdismiss", show);
 		}
 
-		private Button _acceptButton;
+        private Button _acceptButton;
 		private Button _dismissButton;
 	}
 }


### PR DESCRIPTION
Fixes #137 

Previously, if building a custom `PickerFlyout`, overriding the virtual `ShouldShowConfirmationButtons` method had no effect. PR fixes that by checking that method when opening the Flyout 