### PR TITLE
Use InvariantCulture for StringBuilder in TabViewItem

### DIFF
--- a/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Text;
@@ -257,7 +258,7 @@ namespace FluentAvalonia.UI.Controls
 
             var builder = new StringBuilder();
             // WinUI 6644
-            builder.AppendFormat(data, height,
+            builder.AppendFormat(CultureInfo.InvariantCulture, data, height,
                     leftCorner, leftCorner, leftCorner, leftCorner, leftCorner,
                     Bounds.Width - (leftCorner + rightCorner),
                     rightCorner, rightCorner, rightCorner, rightCorner,


### PR DESCRIPTION
Finally fixes #97.
When building the geometry for `TabViewItem` the `StringBuilder` was using the current culture when formatting double values, leading to a crash for cultures that use `,` instead of `.` as the decimal since the path markup parser expects the invariant culture and `.` for decimals. This PR changes the StringBuilder to use the InvariantCulture when formatting the path string.