### PR TITLE
Don't unnecessarily remove page from frame cache

### DIFF
--- a/FluentAvalonia/UI/Controls/Frame/Frame.cs
+++ b/FluentAvalonia/UI/Controls/Frame/Frame.cs
@@ -523,9 +523,7 @@ namespace FluentAvalonia.UI.Controls
             {
                 if (_cache[i].GetType() == srcPageType)
                 {
-                    var item = _cache[i];
-                    _cache.RemoveAt(i);
-                    return item;
+                    return _cache[i];
                 }
             }
 


### PR DESCRIPTION
The frame cache is already pruned when a new entry is added that would have caused it to exceed the cache size limit.

Perhaps there was a reason that this was done that I am missing, but I think the current behavior doesn't make sense as if an app has only, say, two pages, and the user goes back and forth between the two pages, the page instances will constantly be remade needlessly.