### PR TITLE
FATheme add support for getting system theme/accent for Mac/Linux

### DIFF
--- a/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
+++ b/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
@@ -55,12 +55,41 @@ namespace FluentAvalonia.Styling
         /// <remarks>
         /// If false, this defaults to SlateBlue as SystemAccentColor unless overridden
         /// </remarks>
-        public bool UseUserAccentColorOnWindows { get; set; } = true;
+        [Obsolete("Use PreferUserAccentColor instead")]
+        public bool UseUserAccentColorOnWindows
+        {
+            get => PreferUserAccentColor;
+            set => PreferUserAccentColor = value;
+        }
 
         /// <summary>
         /// Gets or sets whether to use the current Windows system theme. Respects Light, Dark, and HighContrast modes
         /// </summary>
-        public bool UseSystemThemeOnWindows { get; set; } = true;
+        [Obsolete("Use PreferSystemTheme instead")]
+        public bool UseSystemThemeOnWindows
+        {
+            get => PreferSystemTheme;
+            set => PreferSystemTheme = value;
+        }
+
+        /// <summary>
+        /// Gets or sets whether to use the current system theme (light or dark mode).
+        /// </summary>
+        /// <remarks>
+        /// This property is respected on Windows, MacOS, and Linux. However, on linux,
+        /// it requires 'gtk-theme' setting to work and the current theme to be appended
+        /// with '-dark'.
+        /// Also note, that high contrast theme will only resolve here on Windows.
+        /// </remarks>
+        public bool PreferSystemTheme { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to use the current user's accent color as the resource SystemAccentColor
+        /// </summary>
+        /// <remarks>
+        /// This property has no effect on Linux
+        /// </remarks>
+        public bool PreferUserAccentColor { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a semi-colon (;) delimited string of controls that should be skipped when loading the control templates
@@ -240,29 +269,28 @@ namespace FluentAvalonia.Styling
         /// </summary>
         public void InvalidateThemingFromSystemThemeChanged()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (PreferUserAccentColor)
             {
-                if (UseUserAccentColorOnWindows)
-                {                   
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
                     try
                     {
                         IUISettings3 settings = WinRTInterop.CreateInstance<IUISettings3>("Windows.UI.ViewManagement.UISettings");
 
                         TryLoadWindowsAccentColor(settings);
                     }
-                    catch
-                    {
-
-                    }                   
+                    catch { }
                 }
-
-                if (UseSystemThemeOnWindows)
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    Refresh(null);
+                    TryLoadMacOSAccentColor();
                 }
-            }
+            }           
 
-            // Ignore this on non-Windows OSs as it has no effect
+            if (PreferSystemTheme)
+            {
+                Refresh(null);
+            }
         }
 
         /// <summary>
@@ -417,46 +445,77 @@ namespace FluentAvalonia.Styling
         private string ResolveThemeAndInitializeSystemResources()
         {
             string theme = _requestedTheme;
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                IAccessibilitySettings accessibility = null;
-                try
-                {
-                    accessibility = WinRTInterop.CreateInstance<IAccessibilitySettings>("Windows.UI.ViewManagement.AccessibilitySettings");
-                }
-                catch
-                {
-                    Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
-                            .Log("FluentAvaloniaTheme", "Unable to create instance of ComObject IAccessibilitySettings");
-                }
+                theme = ResolveWindowsSystemSettings();
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                theme = ResolveLinuxSystemSettings();               
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                theme = ResolveMacOSSystemSettings();
+            }
+            else
+            {
+                theme = string.IsNullOrEmpty(theme) ? LightModeString : theme;
+            }
 
-                IUISettings3 uiSettings3 = null;
+            // Load the SymbolThemeFontFamily
+            AddOrUpdateSystemResource("SymbolThemeFontFamily", new FontFamily(new Uri("avares://FluentAvalonia"), "/Fonts/#Symbols"));
+
+            // If not on Windows or if not using the system them, we default to LightMode
+            // if user didn't specify the theme to use
+            return theme;
+        }
+
+        private string ResolveWindowsSystemSettings()
+        {
+            string theme = LightModeString;
+            IAccessibilitySettings accessibility = null;
+            try
+            {
+                accessibility = WinRTInterop.CreateInstance<IAccessibilitySettings>("Windows.UI.ViewManagement.AccessibilitySettings");
+            }
+            catch
+            {
+                Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
+                        .Log("FluentAvaloniaTheme", "Unable to create instance of ComObject IAccessibilitySettings");
+            }
+
+            IUISettings3 uiSettings3 = null;
+            try
+            {
+                uiSettings3 = WinRTInterop.CreateInstance<IUISettings3>("Windows.UI.ViewManagement.UISettings");
+            }
+            catch
+            {
+                Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
+                        .Log("FluentAvaloniaTheme", "Unable to create instance of ComObject IUISettings");
+            }
+
+            if (PreferSystemTheme)
+            {
+                bool isHighContrast = false;
                 try
                 {
-                    uiSettings3 = WinRTInterop.CreateInstance<IUISettings3>("Windows.UI.ViewManagement.UISettings");
-                }
-                catch
-                {
-                    Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
-                            .Log("FluentAvaloniaTheme", "Unable to create instance of ComObject IUISettings");
-                }
-                
-                if (UseSystemThemeOnWindows)
-                {
-                    try
-                    {                        
-                        int isUsingHighContrast = accessibility.HighContrast;
-                        if (isUsingHighContrast == 1)
-                        {
-                            theme = HighContrastModeString;
-                        }
-                    }
-                    catch
+                    int isUsingHighContrast = accessibility.HighContrast;
+                    if (isUsingHighContrast == 1)
                     {
-                        Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
-                            .Log("FluentAvaloniaTheme", "Unable to retrieve High contrast settings.");
+                        theme = HighContrastModeString;
+                        isHighContrast = true;
                     }
+                }
+                catch
+                {
+                    Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
+                        .Log("FluentAvaloniaTheme", "Unable to retrieve High contrast settings.");
+                }
 
+                if (!isHighContrast)
+                {
                     try
                     {
                         var background = (Color2)uiSettings3.GetColorValue(UIColorType.Background);
@@ -475,72 +534,146 @@ namespace FluentAvalonia.Styling
 
                         theme = LightModeString;
                     }
-                }
-                else
-                {
-                    theme = string.IsNullOrEmpty(theme) ? LightModeString : theme;
-                }
-                
-                if (CustomAccentColor != null)
-                {
-                    LoadCustomAccentColor();
-                }
-                else if (UseUserAccentColorOnWindows)
-                {
-                    TryLoadWindowsAccentColor(uiSettings3);
-                }
-                else
-                {
-                    LoadDefaultAccentColor();
-                }
-
-                if (UseSystemFontOnWindows)
-                {
-                    try
-                    {
-                        Win32Interop.OSVERSIONINFOEX osInfo = new Win32Interop.OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(Win32Interop.OSVERSIONINFOEX)) };
-                        Win32Interop.RtlGetVersion(ref osInfo);
-
-                        if (osInfo.BuildNumber >= 22000) // Windows 11
-                        {
-                            AddOrUpdateSystemResource("ContentControlThemeFontFamily", new FontFamily("Segoe UI Variable Text"));
-                        }
-                        else // Windows 10
-                        {
-                            //This is defined in the BaseResources.axaml file
-                            AddOrUpdateSystemResource("ContentControlThemeFontFamily", new FontFamily("Segoe UI"));
-                        }
-                    }
-                    catch
-                    {
-                        Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
-                        .Log("FluentAvaloniaTheme", "Error in detecting Windows system font.");
-
-                        AddOrUpdateSystemResource("ContentControlThemeFontFamily", FontFamily.Default);
-                    }
-                }
+                }                
             }
             else
             {
                 theme = string.IsNullOrEmpty(theme) ? LightModeString : theme;
-
-                if (CustomAccentColor != null)
-                {
-                    LoadCustomAccentColor();
-                }
-                else
-                {
-                    LoadDefaultAccentColor();
-                }
-               
-                AddOrUpdateSystemResource("ContentControlThemeFontFamily", FontFamily.Default);
             }
 
-            // Load the SymbolThemeFontFamily
-            AddOrUpdateSystemResource("SymbolThemeFontFamily", new FontFamily(new Uri("avares://FluentAvalonia"), "/Fonts/#Symbols"));
 
-            // If not on Windows or if not using the system them, we default to LightMode
-            // if user didn't specify the theme to use
+            if (CustomAccentColor != null)
+            {
+                LoadCustomAccentColor();
+            }
+            else if (PreferUserAccentColor)
+            {
+                TryLoadWindowsAccentColor(uiSettings3);
+            }
+            else
+            {
+                LoadDefaultAccentColor();
+            }
+
+            if (UseSystemFontOnWindows)
+            {
+                try
+                {
+                    Win32Interop.OSVERSIONINFOEX osInfo = new Win32Interop.OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(Win32Interop.OSVERSIONINFOEX)) };
+                    Win32Interop.RtlGetVersion(ref osInfo);
+
+                    if (osInfo.BuildNumber >= 22000) // Windows 11
+                    {
+                        AddOrUpdateSystemResource("ContentControlThemeFontFamily", new FontFamily("Segoe UI Variable Text"));
+                    }
+                    else // Windows 10
+                    {
+                        //This is defined in the BaseResources.axaml file
+                        AddOrUpdateSystemResource("ContentControlThemeFontFamily", new FontFamily("Segoe UI"));
+                    }
+                }
+                catch
+                {
+                    Logger.TryGet(LogEventLevel.Information, "FluentAvaloniaTheme")?
+                    .Log("FluentAvaloniaTheme", "Error in detecting Windows system font.");
+
+                    AddOrUpdateSystemResource("ContentControlThemeFontFamily", FontFamily.Default);
+                }
+            }
+
+            return theme;
+        }
+
+        private string ResolveMacOSSystemSettings()
+        {
+            string theme = LightModeString;
+            try
+            {
+                // https://stackoverflow.com/questions/25207077/how-to-detect-if-os-x-is-in-dark-mode
+                var p = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        WindowStyle = ProcessWindowStyle.Hidden,
+                        CreateNoWindow = true,
+                        UseShellExecute = false,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        FileName = "defaults",
+                        Arguments = "read -g AppleInterfaceStyle"
+                    },
+                };
+
+                p.Start();
+                var str = p.StandardOutput.ReadToEnd().Trim();
+                p.WaitForExit();
+
+                if (str.Equals("Dark", StringComparison.OrdinalIgnoreCase))
+                {
+                    theme = DarkModeString;
+                }
+            }
+            catch { }
+
+            if (CustomAccentColor != null)
+            {
+                LoadCustomAccentColor();
+            }
+            else if (PreferUserAccentColor)
+            {
+                TryLoadMacOSAccentColor();
+            }
+            else
+            {
+                LoadDefaultAccentColor();
+            }
+
+            AddOrUpdateSystemResource("ContentControlThemeFontFamily", FontFamily.Default);
+
+            return theme;
+        }
+
+        private string ResolveLinuxSystemSettings()
+        {
+            string theme = LightModeString;
+            try
+            {
+                var p = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        WindowStyle = ProcessWindowStyle.Hidden,
+                        CreateNoWindow = true,
+                        UseShellExecute = false,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        FileName = "gsettings",
+                        Arguments = "get org.gnome.desktop.interface gtk-theme"
+                    },
+                };
+
+                p.Start();
+                var str = p.StandardOutput.ReadToEnd().Trim();
+                p.WaitForExit();
+
+                if (str.IndexOf("-dark", StringComparison.OrdinalIgnoreCase) != -1)
+                {
+                    theme = DarkModeString;
+                }
+            }
+            catch { }
+
+            if (CustomAccentColor != null)
+            {
+                LoadCustomAccentColor();
+            }
+            else
+            {
+                LoadDefaultAccentColor();
+            }
+
+            AddOrUpdateSystemResource("ContentControlThemeFontFamily", FontFamily.Default);
+
             return theme;
         }
 
@@ -586,17 +719,29 @@ namespace FluentAvalonia.Styling
         {
             if (!_customAccentColor.HasValue)
             {
-                if (UseUserAccentColorOnWindows && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (PreferUserAccentColor)
                 {
-                    try
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        var settings = WinRTInterop.CreateInstance<IUISettings3>("Windows.UI.ViewManagement.UISettings");
-                        TryLoadWindowsAccentColor(settings);
+                        try
+                        {
+                            var settings = WinRTInterop.CreateInstance<IUISettings3>("Windows.UI.ViewManagement.UISettings");
+                            TryLoadWindowsAccentColor(settings);
+                        }
+                        catch
+                        {
+                            LoadDefaultAccentColor();
+                        }
                     }
-                    catch 
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    {
+                        TryLoadMacOSAccentColor();
+                    }
+                    else
                     {
                         LoadDefaultAccentColor();
                     }
+                    
                 }
                 else
                 {
@@ -649,6 +794,86 @@ namespace FluentAvalonia.Styling
                 AddOrUpdateSystemResource("SystemAccentColorDark1", Color.Parse("#43339C"));
                 AddOrUpdateSystemResource("SystemAccentColorDark2", Color.Parse("#33238C"));
                 AddOrUpdateSystemResource("SystemAccentColorDark3", Color.Parse("#1D115C"));
+            }
+        }
+
+        private void TryLoadMacOSAccentColor()
+        {
+            try
+            {
+                // https://stackoverflow.com/questions/51695755/how-can-i-determine-the-macos-10-14-accent-color/51695756#51695756
+                // The following assumes MacOS 11 (Big Sur) for color matching
+                var p = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        WindowStyle = ProcessWindowStyle.Hidden,
+                        CreateNoWindow = true,
+                        UseShellExecute = false,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        FileName = "defaults",
+                        Arguments = "read -g AppleAccentColor"
+                    },
+                };
+
+                p.Start();
+                var str = p.StandardOutput.ReadToEnd().Trim();
+                p.WaitForExit();
+
+                if (str.StartsWith("\'"))
+                {
+                    str = str.Substring(1, str.Length - 2);
+                }
+
+                int accentColor = int.MinValue;
+                int.TryParse(str, out accentColor);
+
+                Color2 aColor;
+                switch (accentColor)
+                {
+                    case 0: // red
+                        aColor = Color2.FromRGB(255, 82, 89);
+                        break;
+
+                    case 1: // orange
+                        aColor = Color2.FromRGB(248, 131, 28);
+                        break;
+
+                    case 2: // yellow
+                        aColor = Color2.FromRGB(253, 186, 45);
+                        break;
+
+                    case 3: // green
+                        aColor = Color2.FromRGB(99, 186, 71);
+                        break;
+
+                    case 5: //purple
+                        aColor = Color2.FromRGB(164, 82, 167);
+                        break;
+
+                    case 6: // pink
+                        aColor = Color2.FromRGB(248, 80, 158);
+                        break;
+
+                    default: // blue, multicolor (maps to blue), graphite (maps to blue)
+                        aColor = Color2.FromRGB(16, 125, 254);
+                        break;
+                }
+
+                AddOrUpdateSystemResource("SystemAccentColor", aColor);
+
+                AddOrUpdateSystemResource("SystemAccentColorLight1", (Color)aColor.LightenPercent(0.15f));
+                AddOrUpdateSystemResource("SystemAccentColorLight2", (Color)aColor.LightenPercent(0.30f));
+                AddOrUpdateSystemResource("SystemAccentColorLight3", (Color)aColor.LightenPercent(0.45f));
+
+                AddOrUpdateSystemResource("SystemAccentColorDark1", (Color)aColor.LightenPercent(-0.15f));
+                AddOrUpdateSystemResource("SystemAccentColorDark2", (Color)aColor.LightenPercent(-0.30f));
+                AddOrUpdateSystemResource("SystemAccentColorDark3", (Color)aColor.LightenPercent(-0.45f));
+            }
+            catch
+            {
+                LoadDefaultAccentColor();
             }
         }
 

--- a/FluentAvaloniaSamples/Pages/GettingStartedPage.axaml
+++ b/FluentAvaloniaSamples/Pages/GettingStartedPage.axaml
@@ -33,8 +33,6 @@ FluentAvaloniaTheme allows you to make runtime changes to Light/Dark mode, manag
 
 It is also HighContrast theme aware, and will respect the variants of HighContrast theme featured on Windows.
 
-It is heavily focused on Windows, but changes to theme and accent color are still supported on Mac/Linux. If you'd like to see properties from other OS's included, feel free to open an issue to discuss and a PR to include the feature.
-
 As of v1.2, FluentAvaloniaTheme now searches the Application level ResourceDictionary before searching the internal resources. This allows you to override resources at the app level now. Note that the Application level Styles are not search, only the ResourceDictionary.
 
 See below for more on the available properties, what they do, and how to change them in your app:

--- a/FluentAvaloniaSamples/Pages/SampleCode/GettingStarted.cs.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/GettingStarted.cs.txt
@@ -16,15 +16,28 @@ RequestedTheme = "HighContrast";
 
 // On Windows the following properties are available, which all default to true:
 
+// ** NEW
+// Resolving system theme and accent color is now supported on MacOS and Linux (only system theme). See PR #152 for the caveats as this may
+// not always work on linux (requires gsettings). If system lookup fails for whatever reason, the value of RequestedTheme is checked
+// before falling back to light mode by default.
+
+// Set the app theme to whatever the system theme is, respects HighContrast mode only on Windows
+public bool PreferSystemTheme { get; set; } = true
+
+// Use the current User System Accent Color as the Accent Color in the app (Windows/MacOS only). 
+public bool PreferUserAccentColor { get; set; } = true;
+
 // Use the System font as the primary font for the App. On Windows 10, this is Segoe UI. On Windows 11, this is Segoe UI Variable Text
 // This value is only respected on startup
 public bool UseSystemFontOnWindows { get; set; } = true;
 
 // Use the current User System Accent Color as the Accent Color in the app
+[Obsolete("PreferUserAccentColor")]
 public bool UseUserAccentColorOnWindows { get; set; } = true;
 
 // Set the app theme to whatever the Windows theme is, respects HighContrast mode
 // This value is only respected on startup
+[Obsolete("UsePreferSystemTheme")]
 public bool UseSystemThemeOnWindows { get; set; } = true;
 
 
@@ -49,7 +62,6 @@ public Color? CustomAccentColor { get; set; }
 CustomAccentColor = Colors.Orange;
 
 // To return to default, set the property to null;
-// On Mac/Linux, and Windows with (UseUserAccentColorOnWindows = false), the default color is SlateBlue. Otherwise it returns to the System defined accent.
 
 
 // NEW in v1.2, if there are controls you don't use, you can use this property to skip loading their template


### PR DESCRIPTION
Highly, highly experimental feature here... But, an attempt to allow resolving the system theme and/or accent color for MacOS and Linux.

Changes:
Added two new properties to `FluentAvaloniaTheme`
`PreferSystemTheme` and `PreferUserAccentColor`. Both default to `true`
The existing `UseSystemThemeOnWindows` and `UseUserAccentColorOnWindows` properties are now deprecated and just map to the new properties and will be removed in v2.0. 

While FATheme does not listen for system changes, `InvalidateThemeingFromSystemThemeChange` is now available for mac/linux and will update the theme and accent color accordingly (if the above properties are set to true)

A couple caveats:
1 - The checks for Mac/Linux are quite simple. On Mac, it checks the terminal command `defaults read -g AppleInterfaceStyle` and if that returns "Dark", dark mode is used. On Linux, it requires gtk to work (so things like KDE won't), and queries `gsettings get org.gnome.desktop.interface gtk-theme`. If the return value contains '-dark', dark mode is used. 

2 - Accent color retrieval does not work on linux, as no concept of accent color exists in a standardized way (as far as I'm aware). On MacOS, it queries `defaults read -g AppleAccentColor`. This either returns not found, or an integer 0 - 6. The following assumes MacOS 11 (Big Sur) mappings:
0 - red, 1 - orange, 2 - yellow, 3 - green, 5 - purple, 6 - pink,
Any other values will map to blue. Note that multicolor and graphite settings are not respected and will fall back to blue. Graphite specifically because it's grey, and that won't work well generating the light/dark shades required for the fluent theme.


I only have limited testing capabilities on Linux, and no way to test OSX, so please feel free to test this branch if you have non-Windows available (esp. Mac).
If testing on linux, remember `gtk-theme` must be available (run the above command in the terminal to check). 