### PR TITLE
Don't include Avalonia.Diagnostics in release

### DIFF
--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -43,7 +43,8 @@
 	<ItemGroup>
 		<PackageReference Include="Avalonia" Version="0.10.14" />
 		<PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.14" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.14" />
 		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.4" />
 		<PackageReference Include="MicroCom.Runtime" Version="0.10.4" />
         <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />


### PR DESCRIPTION
Avalonia.Diagnostics is unneeded for release builds and its inclusion results in Microsoft.CodeAnalysis dlls being included in any project that references FluentAvalonia, resulting in an inflated output size. However without Avalonia.Diagnostics included FluentAvalonia would fail to build because it also depends on Avalonia.Controls.DataGrid, which is an included dependency in Avalonia.Diagnostics. Let's only include Avalonia.Diagnostics in Debug configurations, and include Avalonia.Controls.DataGrid no matter what so that builds can succeed.