### PR TITLE
CoreWindow UWP-like SplashScreen

### DIFF
--- a/FluentAvalonia/Core/ApplicationModel/IApplicationSplashScreen.cs
+++ b/FluentAvalonia/Core/ApplicationModel/IApplicationSplashScreen.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Avalonia.Media;
+
+namespace FluentAvalonia.Core.ApplicationModel
+{
+    public interface IApplicationSplashScreen
+    {
+        string AppName { get; }
+
+        IImage AppIcon { get; }
+
+        object SplashScreenContent { get; }
+
+        void RunTasks();
+
+        int MinimumShowTime { get; }
+    }
+}

--- a/FluentAvalonia/Core/ApplicationModel/IApplicationSplashScreen.cs
+++ b/FluentAvalonia/Core/ApplicationModel/IApplicationSplashScreen.cs
@@ -1,18 +1,45 @@
-﻿using System.Threading.Tasks;
-using Avalonia.Media;
+﻿using Avalonia.Media;
 
 namespace FluentAvalonia.Core.ApplicationModel
 {
+    /// <summary>
+    /// Defines a user specified UWP-like SplashScreen for CoreWindow
+    /// </summary>
     public interface IApplicationSplashScreen
     {
+        /// <summary>
+        /// Specifies the name of the Application to display during the SplashScreen
+        /// </summary>
         string AppName { get; }
 
+        /// <summary>
+        /// Specifies the desired image to be shown during the SplashScreen
+        /// </summary>
         IImage AppIcon { get; }
 
+        /// <summary>
+        /// Specifies custom content to be shown during the SplashScreen
+        /// </summary>
         object SplashScreenContent { get; }
 
+        /// <summary>
+        /// Called by CoreWindow to run necessary background tasks during the splashscreen
+        /// </summary>
+        /// <remarks>
+        /// This method is called in a background thread (i.e., you don't need to include your own Task). 
+        /// Remember that UI thread related tasks must be posted to the dispatcher from this method
+        /// </remarks>
         void RunTasks();
 
+        /// <summary>
+        /// Specifies the minimum show time (in milliseconds) for the SplashScreen.
+        /// </summary>
+        /// <remarks>
+        /// For quick background loading jobs, you may get undesirable visual effects from the window opening,
+        /// and immediately switching from Splash to main content. If the background tasks (i.e., RunTasks()) 
+        /// finishes before this time, the background thread will hold until the desired time elapses, before
+        /// returning to let CoreWindow finish opening.
+        /// </remarks>
         int MinimumShowTime { get; }
     }
 }

--- a/FluentAvalonia/Styling/Controls/CoreWindowStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/CoreWindowStyles.axaml
@@ -4,6 +4,13 @@
 		xmlns:ui="using:FluentAvalonia.UI.Controls"
 		xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">
 
+    <Styles.Resources>
+        <x:Double x:Key="SplashScreenImageWidth">128</x:Double>
+        <x:Double x:Key="SplashScreenImageHeight">128</x:Double>
+        <x:Double x:Key="SplashScreenTextSize">32</x:Double>
+        <FontWeight x:Key="SplashScreenTextFontWeight">SemiBold</FontWeight>
+    </Styles.Resources>
+
 	<!-- This template should generally not be modified. Use the customization APIs to
 		 modify the appearance of a CoreWindow instance 
 		 Use ApplicationViewTitleBar.Instance to modify the colors here
@@ -205,4 +212,117 @@
 		<Setter Property="Width" Value="10" />
 	</Style>
 
+
+    <!-- SplashScreen Support -->
+    <Style Selector="Window:splashScreen">
+        <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource ApplicationPageBackgroundThemeBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel>
+                    <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+                    <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+                    <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+                    <VisualLayerManager>
+                        <VisualLayerManager.ChromeOverlayLayer>
+                            <TitleBar />
+                        </VisualLayerManager.ChromeOverlayLayer>
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Content="{TemplateBinding Content}"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </VisualLayerManager>
+                    <ui:CoreSplashScreen Name="SplashHost" />
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    
+    <Style Selector="Window:windows:splashScreen">
+        <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource ApplicationPageBackgroundThemeBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <VisualLayerManager>
+                    <!-- Because we use the System Border, we don't specify anything like that here.-->
+                    <Border Background="{TemplateBinding Background}"
+							Padding="{TemplateBinding Padding}"
+							Name="RootBorder">
+                        <Panel>
+                            <Panel Name="DefaultTitleBar"
+								   Height="32"
+								   VerticalAlignment="Top">
+                                <TextBlock Name="TitleText"
+										   Text="{TemplateBinding Title}"
+										   Margin="12 0 0 0"
+										   FontSize="12"
+										   VerticalAlignment="Center"
+										   HorizontalAlignment="Left" />
+                            </Panel>
+
+                            <ContentPresenter Name="PART_ContentPresenter"
+											  ClipToBounds="False"
+											  Margin="0 0 0 0"
+											  HorizontalAlignment="Stretch"
+											  VerticalAlignment="Stretch"
+											  Content="{TemplateBinding Content}"
+											  ContentTemplate="{TemplateBinding ContentTemplate}" />
+                            
+                            <ui:CoreSplashScreen Name="SplashHost" />
+
+                            <!-- Add the Caption Buttons, these should ALWAYS overlay the window -->
+                            <uip:MinMaxCloseControl HorizontalAlignment="Right"
+													VerticalAlignment="Top"
+													Name="SystemCaptionButtons"/>
+
+                        </Panel>
+                    </Border>
+                </VisualLayerManager>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+
+    
+
+    <Style Selector="Window:splashScreen /template/ ui|CoreSplashScreen">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="Window:splashScreen:splashOpen /template/ ui|CoreSplashScreen">
+        <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+
+    <Style Selector="ui|CoreSplashScreen">
+        <Setter Property="Background" Value="{DynamicResource CoreSplashScreenBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource CoreSplashScreenForeground}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel Name="Root"
+                       Background="{TemplateBinding Background}">
+                    <TextBlock Name="AppNameText"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Center"
+                               FontSize="{DynamicResource SplashScreenTextSize}"
+                               FontWeight="{DynamicResource SplashScreenTextFontWeight}"/>
+                    <Image Name="AppImageHost"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Center"
+                           Width="{DynamicResource SplashScreenImageWidth}"
+                           Height="{DynamicResource SplashScreenImageWidth}" />
+                    <ContentPresenter Name="ContentHost"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch"
+                                      VerticalContentAlignment="Stretch" />
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </Style>    
 </Styles>

--- a/FluentAvalonia/Styling/Controls/CoreWindowStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/CoreWindowStyles.axaml
@@ -272,7 +272,8 @@
 											  HorizontalAlignment="Stretch"
 											  VerticalAlignment="Stretch"
 											  Content="{TemplateBinding Content}"
-											  ContentTemplate="{TemplateBinding ContentTemplate}" />
+											  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              IsVisible="False"/>
                             
                             <ui:CoreSplashScreen Name="SplashHost" />
 

--- a/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
@@ -2014,4 +2014,9 @@
     <StaticResource x:Key="TaskDialogCommandBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
     <StaticResource x:Key="TaskDialogCommandTextForegroundDisabled" ResourceKey="AccentTextFillColorDisabledBrush" />
     <StaticResource x:Key="TaskDialogCommandDescriptionForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+
+
+    <!-- CoreWindow > CoreSplashScreen -->
+    <StaticResource x:Key="CoreSplashScreenBackground" ResourceKey="SystemAccentColor" />
+    <StaticResource x:Key="CoreSplashScreenForeground" ResourceKey="TextOnAccentFillColorPrimary" />
 </ResourceDictionary>

--- a/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
@@ -1952,5 +1952,11 @@
     <StaticResource x:Key="TaskDialogCommandDescriptionForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
     <StaticResource x:Key="TaskDialogCommandBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
     <StaticResource x:Key="TaskDialogCommandTextForegroundDisabled" ResourceKey="AccentTextFillColorDisabledBrush" />
-    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />    
+    <StaticResource x:Key="TaskDialogCommandDescriptionForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+
+
+
+    <!-- CoreWindow > CoreSplashScreen -->
+    <StaticResource x:Key="CoreSplashScreenBackground" ResourceKey="SystemColorWindowColor" />
+    <StaticResource x:Key="CoreSplashScreenForeground" ResourceKey="SystemColorWindowTextColor" />
 </ResourceDictionary>

--- a/FluentAvalonia/Styling/StylesV2/LightResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/LightResources.axaml
@@ -2077,4 +2077,9 @@
     <StaticResource x:Key="TaskDialogCommandBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
     <StaticResource x:Key="TaskDialogCommandTextForegroundDisabled" ResourceKey="AccentTextFillColorDisabledBrush" />
     <StaticResource x:Key="TaskDialogCommandDescriptionForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+
+
+    <!-- CoreWindow > CoreSplashScreen -->
+    <StaticResource x:Key="CoreSplashScreenBackground" ResourceKey="SystemAccentColor" />
+    <StaticResource x:Key="CoreSplashScreenForeground" ResourceKey="TextOnAccentFillColorPrimary" />
 </ResourceDictionary>

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreSplashScreen.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreSplashScreen.cs
@@ -1,0 +1,37 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using FluentAvalonia.Core.ApplicationModel;
+
+namespace FluentAvalonia.UI.Controls
+{
+    public class CoreSplashScreen : TemplatedControl
+    {
+        public IApplicationSplashScreen SplashScreen { get; set; }
+
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+        {
+            base.OnApplyTemplate(e);
+
+            if (SplashScreen != null)
+            {
+                // User set content has priority
+                if (SplashScreen.SplashScreenContent != null)
+                {
+                    var cp = e.NameScope.Find<ContentPresenter>("ContentHost");
+                    cp.Content = SplashScreen.SplashScreenContent;
+                }
+                else if (SplashScreen.AppIcon != null) // Followed by the icon
+                {
+                    var img = e.NameScope.Find<Image>("AppImageHost");
+                    img.Source = SplashScreen.AppIcon;
+                }
+                else if (!string.IsNullOrEmpty(SplashScreen.AppName)) // Followed by just the app name
+                {
+                    var tb = e.NameScope.Find<TextBlock>("AppNameText");
+                    tb.Text = SplashScreen.AppName;
+                }
+            }            
+        }
+    }
+}

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
@@ -192,7 +192,7 @@ namespace FluentAvalonia.UI.Controls
 
         protected override async void OnOpened(EventArgs e)
         {
-            if (_splashContext != null && !Design.IsDesignMode)
+            if (_splashContext != null && !_splashContext.HasShownSplashScreen && !Design.IsDesignMode)
             {
                 PseudoClasses.Set(":splashOpen", true);
                 var time = DateTime.Now;
@@ -269,6 +269,7 @@ namespace FluentAvalonia.UI.Controls
                 aniCP.RunAsync((Animatable)Presenter, null));
 
             PseudoClasses.Set(":splashOpen", false);
+            _splashContext.HasShownSplashScreen = true;
         }
 
         protected override void OnClosed(EventArgs e)
@@ -510,6 +511,8 @@ namespace FluentAvalonia.UI.Controls
             }
 
             public IApplicationSplashScreen SplashScreen => _splashScreen;
+
+            public bool HasShownSplashScreen { get; set; }
 
             public CoreSplashScreen Host
             {

--- a/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
+++ b/FluentAvalonia/UI/Controls/CoreWindow/CoreWindow.cs
@@ -194,7 +194,6 @@ namespace FluentAvalonia.UI.Controls
         {
             if (_splashContext != null && !Design.IsDesignMode)
             {
-                Presenter.IsVisible = false;
                 PseudoClasses.Set(":splashOpen", true);
                 var time = DateTime.Now;
 

--- a/FluentAvaloniaSamples/Pages/FAControlPages/CoreWindowPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/CoreWindowPage.axaml
@@ -75,6 +75,14 @@ By default, CoreWindow does not support Icons. However, with the ability set you
                 </x:String>
             </TextBlock>
         </ctrls:ControlExample>
-        
+
+        <ctrls:ControlExample Header="*Experimental* Adding a Splash Screen"
+                              CSharpSource="avares://FluentAvaloniaSamples/Pages/SampleCode/CoreWindow4.cs.txt">
+            <TextBlock TextWrapping="Wrap">
+                <x:String xml:space="preserve">
+As an experimental feature, adding a UWP like splash screen to do background loading tasks before the main window opens is now possible. 
+                </x:String>
+            </TextBlock>
+        </ctrls:ControlExample>
     </StackPanel>
 </UserControl>

--- a/FluentAvaloniaSamples/Pages/SampleCode/CoreWindow4.cs.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/CoreWindow4.cs.txt
@@ -1,0 +1,58 @@
+﻿// To start, implement IApplicationSplashScreen
+// There you can customize the display.
+// You have three options for how the splash screen displays (prioritized in this order):
+// 1 - User set custom content (SplashScreenContent) - can be anything you want
+// 2 - Application Icon centered image (AppIcon)
+// 3 - Application Name centered text (AppName)
+
+// The SplashScreen is set to only open the first time the window opens, so you you need to 
+// Show/Hide the main window, it won't show each time
+
+// This is the splash screen used by this sample app
+public class SampleAppSplashScreen : IApplicationSplashScreen
+{
+    public SampleAppSplashScreen()
+    {
+        var al = AvaloniaLocator.Current.GetService<IAssetLoader>();
+        using (var s = al.Open(new Uri("avares://FluentAvaloniaSamples/Assets/FAIcon.ico")))
+            AppIcon = new Bitmap(s);
+    }
+
+    string IApplicationSplashScreen.AppName { get; }
+
+    public IImage AppIcon { get; }
+
+    object IApplicationSplashScreen.SplashScreenContent { get; }
+
+    // You can also choose to set a minimum show time to hold the splash screen up if the background tasks
+    // complete too quickly. This might be desired to prevent weird animation related visual artifacts
+    int IApplicationSplashScreen.MinimumShowTime => 2000;
+
+
+    // This is where you run any custom background tasks. This is called on a background thread so you
+    // don't need to do your own Task.Run(); Note that any UI Thread related work must be posted to the
+    // dispatcher from here to prevent errors
+    void IApplicationSplashScreen.RunTasks()
+    {
+        
+    }
+}
+
+public class MainWindow : CoreWindow
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        // Set your splash screen and the rest is taken care of when you open the window
+        SplashScreen = new SampleAppSplashScreen();
+    }
+
+    // NOTE: If you override OnOpened for custom logic, be sure to call base.OnOpened() FIRST
+    // as that allows the SplashScreen to run which will hold the loading of window content
+    // until it finishes (unless you must run something first).
+    protected override void OnOpened()
+    {
+        base.OnOpened();
+    }
+}

--- a/FluentAvaloniaSamples/Views/MainView.axaml.cs
+++ b/FluentAvaloniaSamples/Views/MainView.axaml.cs
@@ -59,9 +59,18 @@ namespace FluentAvaloniaSamples.Views
         {
             base.OnAttachedToVisualTree(e);
 
+            // Changed for SplashScreens:
+            // -- If using a SplashScreen, the window will be available when this is attached
+            //    and we can just call OnParentWindowOpened
+            // -- If not using a SplashScreen (like before), the window won't be initialized
+            //    yet and setting our custom titlebar won't work... so wait for the 
+            //    WindowOpened event first
             if (e.Root is Window b)
             {
-                b.Opened += OnParentWindowOpened;
+                if (!b.IsActive)
+                    b.Opened += OnParentWindowOpened;
+                else
+                    OnParentWindowOpened(b, null);
             }
 
             _windowIconControl = this.FindControl<IControl>("WindowIcon");
@@ -169,7 +178,8 @@ namespace FluentAvaloniaSamples.Views
 
         private void OnParentWindowOpened(object sender, EventArgs e)
         {
-            (sender as Window).Opened -= OnParentWindowOpened;
+            if (e != null)
+                (sender as Window).Opened -= OnParentWindowOpened;
 
             if (sender is CoreWindow cw)
             {

--- a/FluentAvaloniaSamples/Views/MainWindow.axaml.cs
+++ b/FluentAvaloniaSamples/Views/MainWindow.axaml.cs
@@ -5,7 +5,10 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using Avalonia.Media.Immutable;
+using Avalonia.Platform;
+using FluentAvalonia.Core.ApplicationModel;
 using FluentAvalonia.Styling;
 using FluentAvalonia.UI.Controls;
 using FluentAvalonia.UI.Media;
@@ -15,12 +18,35 @@ using System.Runtime.InteropServices;
 
 namespace FluentAvaloniaSamples.Views
 {
-	public class MainWindow : CoreWindow
+    public class SampleAppSplashScreen : IApplicationSplashScreen
+    {
+        public SampleAppSplashScreen()
+        {
+            var al = AvaloniaLocator.Current.GetService<IAssetLoader>();
+            using (var s = al.Open(new Uri("avares://FluentAvaloniaSamples/Assets/FAIcon.ico")))
+                AppIcon = new Bitmap(s);
+        }
+
+        string IApplicationSplashScreen.AppName { get; }
+
+        public IImage AppIcon { get; }
+
+        object IApplicationSplashScreen.SplashScreenContent { get; }
+
+        int IApplicationSplashScreen.MinimumShowTime => 2000;
+
+        void IApplicationSplashScreen.RunTasks()
+        {
+
+        }
+    }
+
+    public class MainWindow : CoreWindow
     {
 		public MainWindow()
         {
 			InitializeComponent();
-
+            SplashScreen = new SampleAppSplashScreen();
 #if DEBUG
 			this.AttachDevTools();
 #endif


### PR DESCRIPTION
Little something I was testing out, but adding a UWP-like splash screen for `CoreWindow` but with a bit more customization. Despite the CoreWindow primarily targeting Windows for it's window style, this feature is available on Mac/Linux too.

There are 3 different built-in display modes:
1) Simple App Name
![image](https://user-images.githubusercontent.com/40413319/171545853-bd5547d0-fc48-4ed6-bcea-13936bacbb2d.png)

2) App Icon/Image
![image](https://user-images.githubusercontent.com/40413319/171545878-53c670fb-a7ad-4935-bb6b-9db9c18d508f.png)

3) Custom content
![image](https://user-images.githubusercontent.com/40413319/171545904-e896a35e-d5a5-4040-a152-b2d06e497c7e.png)


To implement, create a class that implements `IApplicationSplashScreen` (see the commit for the API) and set either `AppName`, `AppIcon`, or `SplashScreenContent`. Only one of these will end up displaying and have a priority in the order of SplashScreenContent -> AppIcon -> AppName. Then set the `SplashScreen` property on your CoreWindow instance.

IApplicationSplashScreen has a `RunTasks()` member that you can run background related tasks while loading here (this is called on a background thread). Just remember doing UI thread related work here does mean you must post it to the dispatcher. There's also a `MinimumShowItem` property to specify a minimum duration the splash screen should show, if desired. 

In order to support this, if you override `OnOpened()` in any CoreWindow instance, be sure to put your logic AFTER `base.OnOpened()` to let the splash screen run first to prevent undesired effects, unless you must run something before.

When the splash screen is done, a simple fade transition is used to bring the main content of the window back into view.

The foreground/background is specified by the following resources and can be overriden to customize the appearance. It defaults to the accent color background & text on accent foreground.
```Xaml
<StaticResource x:Key="CoreSplashScreenBackground" ResourceKey="SystemAccentColor" />
<StaticResource x:Key="CoreSplashScreenForeground" ResourceKey="TextOnAccentFillColorPrimary" />
```

In addition, the following resources are available to customize the appearance of the AppIcon and AppName modes:
```Xaml
<!-- Only affects AppIcon mode -->
<x:Double x:Key="SplashScreenImageWidth">128</x:Double>
<x:Double x:Key="SplashScreenImageHeight">128</x:Double>

<!-- Only affects AppName mode -->
<x:Double x:Key="SplashScreenTextSize">32</x:Double>
<FontWeight x:Key="SplashScreenTextFontWeight">SemiBold</FontWeight>
```