### PR TITLE
FluentAvalonia v1.4

### DIFF
--- a/FASandbox/FASandbox.csproj
+++ b/FASandbox/FASandbox.csproj
@@ -7,10 +7,10 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.14" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.14" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.15" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -41,10 +41,10 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="0.10.14" />
-		<PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.14" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.14" />
+		<PackageReference Include="Avalonia" Version="0.10.15" />
+		<PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.15" />
 		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.4" />
 		<PackageReference Include="MicroCom.Runtime" Version="0.10.4" />
         <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -20,8 +20,8 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>1.3.5</Version>
-        <AssemblyVersion>1.3.5.0</AssemblyVersion>        
+        <Version>1.4.0</Version>
+        <AssemblyVersion>1.4.0.0</AssemblyVersion>        
     </PropertyGroup>
 
 

--- a/FluentAvalonia/Styling/BasicControls/ListBoxStyles.axaml
+++ b/FluentAvalonia/Styling/BasicControls/ListBoxStyles.axaml
@@ -1,7 +1,7 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
         <Border Padding="20">
-            <ListBox>
+            <ListBox SelectedIndex="0">
                 <ListBoxItem>Test</ListBoxItem>
                 <ListBoxItem>Test</ListBoxItem>
                 <ListBoxItem>Test</ListBoxItem>
@@ -82,7 +82,8 @@
                             VerticalAlignment="Center"
                             Width="3"
                             Height="16"
-							Margin="1 0 0 0"
+							Margin="2.5 0 0 0"
+                            UseLayoutRounding="False"
                             CornerRadius="{DynamicResource ControlCornerRadius}"
 							Background="{DynamicResource AccentFillColorDefaultBrush}" />
                 </Panel>

--- a/FluentAvalonia/Styling/Controls/ColorPickerButtonStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/ColorPickerButtonStyles.axaml
@@ -25,31 +25,26 @@
 		<Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Panel>
-                    <ui:Button Name="MainButton"
-                               Padding="0 0 32 0"
-							   CornerRadius="{TemplateBinding CornerRadius}">
+                <ui:Button Name="MainButton"
+                           CornerRadius="{TemplateBinding CornerRadius}"
+                           HorizontalContentAlignment="Stretch"
+                           Padding="0">
+                    <Grid ColumnDefinitions="*,Auto">
                         <Border BorderBrush="{DynamicResource ColorPickerButtonOutline}"
                                 BorderThickness="1"
-                                Margin="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                Margin="8 6 4 6" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 MinWidth="23" MinHeight="23"
                                 Background="{TemplateBinding Color, Converter={StaticResource ColorBrushConv}}"
-								CornerRadius="{TemplateBinding CornerRadius}">
-                            <ui:ColorPicker Name="ColorPicker" IsVisible="False" />
-                        </Border>                        
-                    </ui:Button>
+                                CornerRadius="{TemplateBinding CornerRadius}" />
 
-                    <Viewbox Width="18" Height="18" 
-                             IsHitTestVisible="False"
-                             VerticalAlignment="Center"
-                             HorizontalAlignment="Right"
-                             Margin="0 0 8 0" Name="Chevron">
-                        <ui:SymbolIcon Symbol="ChevronDown" />
-                    </Viewbox>
-                </Panel>
+                        <ui:SymbolIcon Symbol="ChevronDown"
+                                       FontSize="18"
+                                       Margin="4 6 8 6"
+                                       Grid.Column="1"
+                                       HorizontalAlignment="Right"/>
+                    </Grid>
+                </ui:Button>
             </ControlTemplate>
         </Setter>
     </Style>
-
-   
 </Styles>

--- a/FluentAvalonia/Styling/Controls/ColorPickerStyles.axaml
+++ b/FluentAvalonia/Styling/Controls/ColorPickerStyles.axaml
@@ -32,6 +32,13 @@
         <DataTemplate x:Key="ColorSpectrumTabContent">
             <ui:ColorSpectrum />
         </DataTemplate>
+
+        <!-- Icons used in TabControl of ColorPicker -->
+        <!-- Icon Credit: materialdesignicons.com, Austin Andrews (palette-advanced) -->
+        <StreamGeometry x:Key="ColorSpectrumGeometry">M22,22H10V20H22V22M2,22V20H9V22H2M18,18V10H22V18H18M18,3H22V9H18V3M2,18V3H16V18H2M9,14.56A3,3 0 0,0 12,11.56C12,9.56 9,6.19 9,6.19C9,6.19 6,9.56 6,11.56A3,3 0 0,0 9,14.56Z</StreamGeometry>
+        <StreamGeometry x:Key="ColorTriangleGeometry">M 512,12 C 379.40721,12 252.20453,64.690004 158.44727,158.44727 64.689998,252.20452 12,379.40721 12,512 12,644.59279 64.689998,771.79548 158.44727,865.55273 252.20453,959.30999 379.40721,1012 512,1012 644.59279,1012 771.79547,959.30999 865.55273,865.55273 959.31,771.79548 1012,644.59279 1012,512 1012,379.40721 959.31,252.20452 865.55273,158.44727 771.79547,64.690004 644.59279,12 512,12 Z M 512,91.755859 C 623.47114,91.755859 730.3362,136.0198 809.1582,214.8418 887.68289,293.36648 931.88037,399.72647 932.21289,510.74219 L 242.02148,190.06445 C 317.39159,126.8518 412.847,91.755859 512,91.755859 Z M 241.20312,190.76953 V 833.02539 L 932.24219,511.95508 C 932.24219,511.9701 932.24414,511.98498 932.24414,512 932.24414,623.47113 887.9802,730.33621 809.1582,809.1582 730.3362,887.9802 623.47114,932.24414 512,932.24414 400.52886,932.24414 293.6638,887.9802 214.8418,809.1582 136.0198,730.33621 91.755859,623.47113 91.755859,512 91.755859,400.52887 136.0198,293.66379 214.8418,214.8418 223.29566,206.38793 232.13301,198.41637 241.20312,190.76953 Z</StreamGeometry>
+        <!-- Icon Credit: materialdesignicons.com, Colton Wiscombe (tune-variant) -->
+        <StreamGeometry x:Key="ColorSliderGeometry">M8 13C6.14 13 4.59 14.28 4.14 16H2V18H4.14C4.59 19.72 6.14 21 8 21S11.41 19.72 11.86 18H22V16H11.86C11.41 14.28 9.86 13 8 13M8 19C6.9 19 6 18.1 6 17C6 15.9 6.9 15 8 15S10 15.9 10 17C10 18.1 9.1 19 8 19M19.86 6C19.41 4.28 17.86 3 16 3S12.59 4.28 12.14 6H2V8H12.14C12.59 9.72 14.14 11 16 11S19.41 9.72 19.86 8H22V6H19.86M16 9C14.9 9 14 8.1 14 7C14 5.9 14.9 5 16 5S18 5.9 18 7C18 8.1 17.1 9 16 9Z</StreamGeometry>
     </Styles.Resources>
     
     <Style Selector="ui|NumberBox.ColorPicker">
@@ -56,9 +63,12 @@
                              TextAlignment="{TemplateBinding TextAlignment}">
                         <TextBox.InnerLeftContent>
                             <Border Background="{DynamicResource ColorPickerComponentLabelBackground}"
+                                    Width="32"
+                                    CornerRadius="{Binding $parent[TextBox].CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
 									Name="Label">
                                 <TextBlock Text="{Binding $parent[ui:NumberBox].Header}"
                                            VerticalAlignment="Center"
+                                           HorizontalAlignment="Center"
                                            FontWeight="SemiBold" Margin="9 4"
                                            Name="Comp1Label"/>
                             </Border>
@@ -202,7 +212,8 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="ItemsPanel">
             <ItemsPanelTemplate>
-                <UniformGrid Rows="1" />
+                <UniformGrid Rows="1"
+                             Background="{DynamicResource ColorPickerTabsBackground}"/>
             </ItemsPanelTemplate>
         </Setter>        
     </Style>
@@ -226,7 +237,7 @@
                                       TextBlock.FontSize="{TemplateBinding FontSize}"
                                       TextBlock.FontWeight="{TemplateBinding FontWeight}"
                                       TextBlock.Foreground="{TemplateBinding Foreground}"
-                                      CornerRadius="{DynamicResource ControlCornerRadius}"/>
+                                      CornerRadius="{TemplateBinding CornerRadius}"/>
                     <Border Name="SelectionIndicator"
                             VerticalAlignment="Bottom"
                             Margin="{DynamicResource ColorPickerTabItemSelectionIndicatorMargin}"
@@ -377,8 +388,12 @@
                                         <TabItem Name="SpectrumTab"
                                                  IsVisible="{TemplateBinding UseSpectrum}">
                                             <TabItem.Header>
-                                                <!-- Icon Credit: materialdesignicons.com, Austin Andrews (palette-advanced) -->
-                                                <ui:PathIcon Data="M22,22H10V20H22V22M2,22V20H9V22H2M18,18V10H22V18H18M18,3H22V9H18V3M2,18V3H16V18H2M9,14.56A3,3 0 0,0 12,11.56C12,9.56 9,6.19 9,6.19C9,6.19 6,9.56 6,11.56A3,3 0 0,0 9,14.56Z" />
+                                                <ui:IconSourceElement Width="18" Height="18">
+                                                    <ui:IconSourceElement.IconSource>
+                                                        <ui:PathIconSource Stretch="Fill" 
+                                                                           Data="{StaticResource ColorSpectrumGeometry}" />
+                                                    </ui:IconSourceElement.IconSource>
+                                                </ui:IconSourceElement>
                                             </TabItem.Header>
                                         </TabItem>
                                         <TabItem Name="WheelTab"
@@ -393,20 +408,12 @@
                                         <TabItem Name="TriangleTab"
                                                  IsVisible="{TemplateBinding UseColorTriangle}">
                                             <TabItem.Header>
-                                                <Panel>
-                                                    <!-- TODO: probably could make a better icon for this... -->
-													<Ellipse Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabItem}}, Path=Foreground}"
-															 StrokeThickness="2"
-															 Width="18" Height="18" Margin="-1 0 0 0" />
-                                                    <!--<ui:FontIcon Glyph="&#xF645;"
-                                                                 FontSize="20"
-                                                                 FontFamily="{DynamicResource SymbolThemeFontFamily}"
-                                                     />-->
-                                                    <ui:PathIcon Data="M1,21H23L12,2"
-                                                                 Width="14" Height="12"
-                                                                 Margin="1 0 0 0"
-                                                                 RenderTransform="rotate(90deg)"/>
-                                                </Panel>
+                                                <ui:IconSourceElement Width="18" Height="18">
+                                                    <ui:IconSourceElement.IconSource>
+                                                        <ui:PathIconSource Stretch="Fill" 
+                                                                           Data="{StaticResource ColorTriangleGeometry}" />
+                                                    </ui:IconSourceElement.IconSource>
+                                                </ui:IconSourceElement>
                                             </TabItem.Header>
                                         </TabItem>
                                         <TabItem Name="PaletteTab"
@@ -444,9 +451,12 @@
                                         </TabItem>
                                         <TabItem Name="TextEntryTab">
                                             <TabItem.Header>
-                                                <!-- Icon Credit: materialdesignicons.com, Colton Wiscombe (tune-variant) -->
-                                                <ui:PathIcon
-                                                        Data="M8 13C6.14 13 4.59 14.28 4.14 16H2V18H4.14C4.59 19.72 6.14 21 8 21S11.41 19.72 11.86 18H22V16H11.86C11.41 14.28 9.86 13 8 13M8 19C6.9 19 6 18.1 6 17C6 15.9 6.9 15 8 15S10 15.9 10 17C10 18.1 9.1 19 8 19M19.86 6C19.41 4.28 17.86 3 16 3S12.59 4.28 12.14 6H2V8H12.14C12.59 9.72 14.14 11 16 11S19.41 9.72 19.86 8H22V6H19.86M16 9C14.9 9 14 8.1 14 7C14 5.9 14.9 5 16 5S18 5.9 18 7C18 8.1 17.1 9 16 9Z" />
+                                                <ui:IconSourceElement Width="18" Height="18">
+                                                    <ui:IconSourceElement.IconSource>
+                                                        <ui:PathIconSource Stretch="Fill" 
+                                                                           Data="{StaticResource ColorSliderGeometry}" />
+                                                    </ui:IconSourceElement.IconSource>
+                                                </ui:IconSourceElement>
                                             </TabItem.Header>
                                             <Panel Name="TextEntryTabHost" />
                                         </TabItem>

--- a/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
@@ -1419,6 +1419,10 @@
     <StaticResource x:Key="ColorPickerMoreButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
     <StaticResource x:Key="ColorPickerColorPaletteItemBorderBrushPointerOver" ResourceKey="ControlStrokeColorDefaultBrush" />
 
+    <!-- COLORPICKER BUTTON -->
+    <StaticResource x:Key="ColorPickerButtonOutline" ResourceKey="ControlStrokeColorDefaultBrush" />
+
+
 
     <!-- SPLIT BUTTON -->
     <StaticResource x:Key="SplitButtonBackground" ResourceKey="ControlFillColorDefaultBrush" />

--- a/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/DarkResources.axaml
@@ -1404,13 +1404,14 @@
     <!-- COLOR PICKER -->
     <StaticResource x:Key="ColorPickerBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
     <StaticResource x:Key="ColorRampBorderBrush" ResourceKey="ControlStrokeColorDefaultBrush" />
-    <StaticResource x:Key="ColorPickerComponentLabelBackground" ResourceKey="SolidBackgroundFillColorSecondary" />
-    <StaticResource x:Key="ColorPickerTabItemBackground" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemBackgroundPointerOver" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemBackgroundSelected" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
+    <StaticResource x:Key="ColorPickerComponentLabelBackground" ResourceKey="CardBackgroundFillColorDefaultBrush" />
+    <StaticResource x:Key="ColorPickerTabsBackground" ResourceKey="LayerFillColorDefaultBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackgroundPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackgroundSelected" ResourceKey="SubtleFillColorTransparentBrush" />
     <StaticResource x:Key="ColorPickerTabItemForeground" ResourceKey="TextFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemForegroundSelected" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="ColorPickerTabItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="ColorPickerTabItemForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
     <StaticResource x:Key="ColorPickerTabItemSelectionIndicatorColor" ResourceKey="AccentFillColorSecondaryBrush" />
     <StaticResource x:Key="ColorPickerTabItemSelectionIndicatorPointerOver" ResourceKey="AccentFillColorTertiaryBrush" />
     <StaticResource x:Key="ColorPickerColorTypeButtonBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />

--- a/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/HighContrastResources.axaml
@@ -1393,13 +1393,14 @@
     <!-- COLOR PICKER -->
     <StaticResource x:Key="ColorPickerBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
     <StaticResource x:Key="ColorRampBorderBrush" ResourceKey="ControlStrokeColorDefaultBrush" />
-    <StaticResource x:Key="ColorPickerComponentLabelBackground" ResourceKey="SolidBackgroundFillColorSecondary" />
-    <StaticResource x:Key="ColorPickerTabItemBackground" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemBackgroundPointerOver" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemBackgroundSelected" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
+    <StaticResource x:Key="ColorPickerComponentLabelBackground" ResourceKey="CardBackgroundFillColorDefaultBrush" />
+    <StaticResource x:Key="ColorPickerTabsBackground" ResourceKey="LayerFillColorDefaultBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackgroundPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackgroundSelected" ResourceKey="SubtleFillColorTransparentBrush" />
     <StaticResource x:Key="ColorPickerTabItemForeground" ResourceKey="TextFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemForegroundSelected" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="ColorPickerTabItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="ColorPickerTabItemForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
     <StaticResource x:Key="ColorPickerTabItemSelectionIndicatorColor" ResourceKey="AccentFillColorSecondaryBrush" />
     <StaticResource x:Key="ColorPickerTabItemSelectionIndicatorPointerOver" ResourceKey="AccentFillColorTertiaryBrush" />
     <StaticResource x:Key="ColorPickerColorTypeButtonBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />

--- a/FluentAvalonia/Styling/StylesV2/LightResources.axaml
+++ b/FluentAvalonia/Styling/StylesV2/LightResources.axaml
@@ -1465,13 +1465,14 @@
     <!-- COLOR PICKER -->
     <StaticResource x:Key="ColorPickerBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
     <StaticResource x:Key="ColorRampBorderBrush" ResourceKey="ControlStrokeColorDefaultBrush" />
-    <StaticResource x:Key="ColorPickerComponentLabelBackground" ResourceKey="SolidBackgroundFillColorSecondary" />
-    <StaticResource x:Key="ColorPickerTabItemBackground" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemBackgroundPointerOver" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemBackgroundSelected" ResourceKey="SolidBackgroundFillColorSecondaryBrush" />
+    <StaticResource x:Key="ColorPickerComponentLabelBackground" ResourceKey="CardBackgroundFillColorDefaultBrush" />
+    <StaticResource x:Key="ColorPickerTabsBackground" ResourceKey="LayerFillColorDefaultBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackgroundPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+    <StaticResource x:Key="ColorPickerTabItemBackgroundSelected" ResourceKey="SubtleFillColorTransparentBrush" />
     <StaticResource x:Key="ColorPickerTabItemForeground" ResourceKey="TextFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
-    <StaticResource x:Key="ColorPickerTabItemForegroundSelected" ResourceKey="TextFillColorSecondaryBrush" />
+    <StaticResource x:Key="ColorPickerTabItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+    <StaticResource x:Key="ColorPickerTabItemForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
     <StaticResource x:Key="ColorPickerTabItemSelectionIndicatorColor" ResourceKey="AccentFillColorSecondaryBrush" />
     <StaticResource x:Key="ColorPickerTabItemSelectionIndicatorPointerOver" ResourceKey="AccentFillColorTertiaryBrush" />
     <StaticResource x:Key="ColorPickerColorTypeButtonBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />

--- a/FluentAvalonia/UI/Controls/ColorPicker/ColorPicker.cs
+++ b/FluentAvalonia/UI/Controls/ColorPicker/ColorPicker.cs
@@ -1,13 +1,11 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Media;
 using System;
 using FluentAvalonia.UI.Media;
 using FluentAvalonia.Core;
-using System.Collections.Generic;
 using Avalonia.Interactivity;
 
 namespace FluentAvalonia.UI.Controls
@@ -776,6 +774,21 @@ namespace FluentAvalonia.UI.Controls
 			{
 				_textEntryTabHost.Children.Remove(_textEntryArea);
 				_rootGrid.Children.Add(_textEntryArea);
+
+                // If we expand the ColorPicker and we were in the Text entry area while compact
+                // make sure we find another tab to switch to so we don't end up with a blank
+                // space from the text area being moved
+                if (_displayItemTabControl.SelectedIndex == 4)
+                {
+                    for (int i = 3; i >= 0; i--)
+                    {
+                        if (_displayItemTabControl.Items.ElementAt(i) is TabItem ti && ti.IsVisible)
+                        {
+                            _displayItemTabControl.SelectedIndex = i;
+                            break;
+                        }
+                    }
+                }
 			}
 
 			UpdatePickerComponents();

--- a/FluentAvalonia/UI/Controls/ColorPicker/ColorRamp.cs
+++ b/FluentAvalonia/UI/Controls/ColorPicker/ColorRamp.cs
@@ -173,6 +173,17 @@ namespace FluentAvalonia.UI.Controls
 						});
 					}
 				}
+                else
+                {
+                    for (int i = 0, idx=0; i <= 360; i += 60, idx++)
+                    {
+                        _lgb.GradientStops[idx] = new GradientStop
+                        {
+                            Color = Color.WithHue(i).WithAlpha(255),
+                            Offset = i / 360.0
+                        };
+                    }
+                }
 			}
 			else
 			{

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorButtonColorChangedEventArgs.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorButtonColorChangedEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Avalonia.Media;
+
+namespace FluentAvalonia.UI.Controls;
+
+public class ColorButtonColorChangedEventArgs : EventArgs
+{
+    public Color? OldColor { get; }
+
+    public Color? NewColor { get; }
+
+    internal ColorButtonColorChangedEventArgs(Color? oldC, Color? newC)
+    {
+        OldColor = oldC;
+        NewColor = newC;
+    }
+}

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
@@ -2,152 +2,151 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using Avalonia.Styling;
-using FluentAvalonia.Core;
 using FluentAvalonia.UI.Media;
 using System;
 
-namespace FluentAvalonia.UI.Controls
+namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// A button that hides a <see cref="ColorPicker"/> within a <see cref="Flyout"/>
+/// </summary>
+public partial class ColorPickerButton : TemplatedControl, IStyleable
 {
-	/// <summary>
-	/// A button that hides a <see cref="ColorPicker"/> within a <see cref="Flyout"/>
-	/// </summary>
-    public partial class ColorPickerButton : TemplatedControl, IStyleable
-    {
-		static ColorPickerButton()
-		{
-			IsMoreButtonVisibleProperty.OverrideDefaultValue<ColorPickerButton>(true);
-			UseSpectrumProperty.OverrideDefaultValue<ColorPickerButton>(true);
-			UseColorWheelProperty.OverrideDefaultValue<ColorPickerButton>(true);
-			UseColorTriangleProperty.OverrideDefaultValue<ColorPickerButton>(true);
-		}
-		
-		Type IStyleable.StyleKey => typeof(ColorPickerButton);
-				
-		/// <summary>
-		/// Fired when the current <see cref="Color"/> property changes
-		/// </summary>
-		public event TypedEventHandler<ColorPickerButton, ColorChangedEventArgs> ColorChanged;
-
-        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-        {
-            if (_button != null)
-			{
-				_button.Click -= OnButtonClick;
-			}
-
-            base.OnApplyTemplate(e);
-
-			_button = e.NameScope.Find<Button>("MainButton");
-			if (_button != null)
-			{
-				_button.Click += OnButtonClick;
-			}
-        }
-
-		protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
-		{
-			base.OnAttachedToVisualTree(e);
-			if(_flyout == null)
-			{
-				_flyout = new ColorPickerFlyout();
-			}
-			_flyout.Closed += OnFlyoutClosed;
-			_flyout.Confirmed += OnFlyoutConfirmed;
-			_flyout.Dismissed += OnFlyoutDismissed;
-		}
-
-		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-		{
-			base.OnDetachedFromVisualTree(e);
-			_flyout.Closed -= OnFlyoutClosed;
-			_flyout.Confirmed -= OnFlyoutConfirmed;
-			_flyout.Dismissed -= OnFlyoutDismissed;
-		}
-
-		protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
-		{
-			base.OnPropertyChanged(change);
-			if (change.Property == ColorProperty)
-			{
-				ColorChanged?.Invoke(this, new ColorChangedEventArgs(change.OldValue.GetValueOrDefault<Color2>(),
-					change.NewValue.GetValueOrDefault<Color2>()));
-			}
-		}
-
-		private void OnButtonClick(object sender, RoutedEventArgs e)
-		{
-			// ColorPicker is a large control, so the flyout is shared among all the ColorButton instances
-			// So we need to make sure the ColorPicker is properly set for this button
-			_flyout.ColorPicker.PreviousColor = Color;
-						
-			_flyout.ColorPicker.Color = Color;
-
-			_flyout.ShowHideButtons(ShowAcceptDismissButtons);
-			
-			// If not showing the buttons, we'll update the color in real time
-			if (!ShowAcceptDismissButtons)
-			{
-				_flyout.ColorPicker.ColorChanged += OnColorPickerColorChanged;
-			}
-
-			_flyout.ColorPicker.IsMoreButtonVisible = IsMoreButtonVisible;
-			_flyout.ColorPicker.IsCompact = IsCompact;
-			_flyout.ColorPicker.IsAlphaEnabled = IsAlphaEnabled;
-			_flyout.ColorPicker.UseSpectrum = UseSpectrum;
-			_flyout.ColorPicker.UseColorWheel = UseColorWheel;
-			_flyout.ColorPicker.UseColorTriangle = UseColorTriangle;
-			_flyout.ColorPicker.UseColorPalette = UseColorPalette;
-			_flyout.ColorPicker.CustomPaletteColors = CustomPaletteColors;
-			_flyout.ColorPicker.PaletteColumnCount = PaletteColumnCount;
-			_flyout.ShowAt(this);
-
-			// Keep track of which button the flyout is active on
-			_flyoutActive = true;
-
-            FlyoutOpened?.Invoke(this, EventArgs.Empty);
-		}
-
-		private void OnColorPickerColorChanged(ColorPicker sender, ColorChangedEventArgs args)
-		{
-			Color = args.NewColor;
-		}
-
-		private void OnFlyoutDismissed(ColorPickerFlyout sender, object args)
-		{
-			if (_flyoutActive)
-			{
-                FlyoutDismissed?.Invoke(this, EventArgs.Empty);
-            }
-		}
-
-		private void OnFlyoutConfirmed(ColorPickerFlyout sender, object args)
-		{
-			if (_flyoutActive)
-            {
-                var oldColor = Color;
-                Color = _flyout.ColorPicker.Color;
-                FlyoutConfirmed?.Invoke(this, new ColorChangedEventArgs(oldColor, Color));
-            }
-		}
-
-		private void OnFlyoutClosed(object sender, EventArgs e)
-		{
-			if (!ShowAcceptDismissButtons)
-			{
-				_flyout.ColorPicker.ColorChanged -= OnColorPickerColorChanged;
-			}
-
-            if (_flyoutActive)
-            {
-                FlyoutClosed?.Invoke(this, EventArgs.Empty);
-                _flyoutActive = false;
-            }
-        }
-
-		private static ColorPickerFlyout _flyout;
-
-		private bool _flyoutActive;
-		private Button _button;		
+	static ColorPickerButton()
+	{
+		IsMoreButtonVisibleProperty.OverrideDefaultValue<ColorPickerButton>(true);
+		UseSpectrumProperty.OverrideDefaultValue<ColorPickerButton>(true);
+		UseColorWheelProperty.OverrideDefaultValue<ColorPickerButton>(true);
+		UseColorTriangleProperty.OverrideDefaultValue<ColorPickerButton>(true);
 	}
+		
+	Type IStyleable.StyleKey => typeof(ColorPickerButton);
+	
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        if (_button != null)
+		{
+			_button.Click -= OnButtonClick;
+		}
+
+        base.OnApplyTemplate(e);
+
+		_button = e.NameScope.Find<Button>("MainButton");
+		if (_button != null)
+		{
+			_button.Click += OnButtonClick;
+		}
+    }
+
+	protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+	{
+		base.OnAttachedToVisualTree(e);
+		if(_flyout == null)
+		{
+			_flyout = new ColorPickerFlyout();
+		}
+		_flyout.Closed += OnFlyoutClosed;
+		_flyout.Confirmed += OnFlyoutConfirmed;
+		_flyout.Dismissed += OnFlyoutDismissed;
+	}
+
+	protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+	{
+		base.OnDetachedFromVisualTree(e);
+		_flyout.Closed -= OnFlyoutClosed;
+		_flyout.Confirmed -= OnFlyoutConfirmed;
+		_flyout.Dismissed -= OnFlyoutDismissed;
+	}
+
+	protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
+	{
+		base.OnPropertyChanged(change);
+		if (change.Property == ColorProperty)
+		{
+			ColorChanged?.Invoke(this, new ColorButtonColorChangedEventArgs(
+                change.OldValue.GetValueOrDefault<Color?>(),
+				change.NewValue.GetValueOrDefault<Color?>()));
+		}
+	}
+
+	private void OnButtonClick(object sender, RoutedEventArgs e)
+	{
+        // ColorPicker is a large control, so the flyout is shared among all the ColorButton instances
+        // So we need to make sure the ColorPicker is properly set for this button
+        var color = Color;
+		_flyout.ColorPicker.PreviousColor = color ?? Color2.Empty;
+						
+		_flyout.ColorPicker.Color = color ?? Colors.Black;
+
+        _flyout.Placement = FlyoutPlacement;
+
+		_flyout.ShowHideButtons(ShowAcceptDismissButtons);
+			
+		// If not showing the buttons, we'll update the color in real time
+		if (!ShowAcceptDismissButtons)
+		{
+			_flyout.ColorPicker.ColorChanged += OnColorPickerColorChanged;
+		}
+
+		_flyout.ColorPicker.IsMoreButtonVisible = IsMoreButtonVisible;
+		_flyout.ColorPicker.IsCompact = IsCompact;
+		_flyout.ColorPicker.IsAlphaEnabled = IsAlphaEnabled;
+		_flyout.ColorPicker.UseSpectrum = UseSpectrum;
+		_flyout.ColorPicker.UseColorWheel = UseColorWheel;
+		_flyout.ColorPicker.UseColorTriangle = UseColorTriangle;
+		_flyout.ColorPicker.UseColorPalette = UseColorPalette;
+		_flyout.ColorPicker.CustomPaletteColors = CustomPaletteColors;
+		_flyout.ColorPicker.PaletteColumnCount = PaletteColumnCount;
+		_flyout.ShowAt(this);
+
+		// Keep track of which button the flyout is active on
+		_flyoutActive = true;
+
+        FlyoutOpened?.Invoke(this, EventArgs.Empty);
+	}
+
+	private void OnColorPickerColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+	{
+		Color = args.NewColor;
+	}
+
+	private void OnFlyoutDismissed(ColorPickerFlyout sender, object args)
+	{
+		if (_flyoutActive)
+		{
+            FlyoutDismissed?.Invoke(this, EventArgs.Empty);
+        }
+	}
+
+	private void OnFlyoutConfirmed(ColorPickerFlyout sender, object args)
+	{
+		if (_flyoutActive)
+        {
+            var oldColor = Color;
+            Color = _flyout.ColorPicker.Color;
+            FlyoutConfirmed?.Invoke(this, new ColorButtonColorChangedEventArgs(oldColor, Color));
+        }
+	}
+
+	private void OnFlyoutClosed(object sender, EventArgs e)
+	{
+		if (!ShowAcceptDismissButtons)
+		{
+			_flyout.ColorPicker.ColorChanged -= OnColorPickerColorChanged;
+		}
+
+        if (_flyoutActive)
+        {
+            FlyoutClosed?.Invoke(this, EventArgs.Empty);
+            _flyoutActive = false;
+        }
+    }
+
+	private static ColorPickerFlyout _flyout;
+
+	private bool _flyoutActive;
+	private Button _button;		
 }
+

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
@@ -2,11 +2,11 @@
 using Avalonia.Data;
 using Avalonia;
 using Avalonia.Media;
-using FluentAvalonia.UI.Media;
 using System.Collections.Generic;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using FluentAvalonia.Core;
+using Avalonia.Controls.Primitives;
 
 namespace FluentAvalonia.UI.Controls
 {
@@ -15,8 +15,8 @@ namespace FluentAvalonia.UI.Controls
 		/// <summary>
 		/// Defines the <see cref="Color"/> property
 		/// </summary>
-		public static readonly StyledProperty<Color2> ColorProperty =
-			AvaloniaProperty.Register<ColorPickerButton, Color2>(nameof(Color),
+		public static readonly StyledProperty<Color?> ColorProperty =
+			AvaloniaProperty.Register<ColorPickerButton, Color?>(nameof(Color),
 				defaultBindingMode: BindingMode.TwoWay);
 
 		/// <summary>
@@ -82,11 +82,18 @@ namespace FluentAvalonia.UI.Controls
 		public static readonly StyledProperty<bool> ShowAcceptDismissButtonsProperty =
 			AvaloniaProperty.Register<ColorPickerButton, bool>(nameof(ShowAcceptDismissButtons), defaultValue: true);
 
+        /// <summary>
+        /// Defines the <see cref="FlyoutPlacement"/> property
+        /// </summary>
+        public static readonly StyledProperty<FlyoutPlacementMode> FlyoutPlacementProperty =
+            AvaloniaProperty.Register<ColorPickerButton, FlyoutPlacementMode>(nameof(FlyoutPlacement),
+                defaultValue: FlyoutPlacementMode.Bottom);
+
 
 		/// <summary>
 		/// Gets or sets the current <see cref="Avalonia.Media.Color"/> of the ColorPickerButton
 		/// </summary>
-		public Color Color
+		public Color? Color
 		{
 			get => GetValue(ColorProperty);
 			set => SetValue(ColorProperty, value);
@@ -203,9 +210,18 @@ namespace FluentAvalonia.UI.Controls
 		}
 
         /// <summary>
+        /// Gets or sets the placement for the color picker flyout
+        /// </summary>
+        public FlyoutPlacementMode FlyoutPlacement
+        {
+            get => GetValue(FlyoutPlacementProperty);
+            set => SetValue(FlyoutPlacementProperty, value);
+        }
+
+        /// <summary>
         /// Raised when the color change was confirmed and the flyout closes.
         /// </summary>
-        public event TypedEventHandler<ColorPickerButton, ColorChangedEventArgs> FlyoutConfirmed;
+        public event TypedEventHandler<ColorPickerButton, ColorButtonColorChangedEventArgs> FlyoutConfirmed;
 
         /// <summary>
         /// Raised when the color change was dismissed and the flyout closes.
@@ -220,6 +236,11 @@ namespace FluentAvalonia.UI.Controls
         /// Raised when the flyout closes regardless of confirmation or dismissal.
         /// </summary>
         public event TypedEventHandler<ColorPickerButton, EventArgs> FlyoutClosed;
+
+        /// <summary>
+        /// Fired when the current <see cref="Color"/> property changes
+        /// </summary>
+        public event TypedEventHandler<ColorPickerButton, ColorButtonColorChangedEventArgs> ColorChanged;
 
         private bool _isCompact = true;
 		private bool _isAlphaEnabled = true;

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutPresenter.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutPresenter.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
@@ -97,7 +96,16 @@ namespace FluentAvalonia.UI.Controls
 
 					_toggleCount++;                    
                 }
-				else if (e.Containers[i].ContainerControl is MenuFlyoutItem mfi)
+                else if (e.Containers[i].ContainerControl is RadioMenuFlyoutItem rmfi)
+                {
+                    if (rmfi.Icon != null)
+                    {
+                        _iconCount++;
+                    }
+
+                    _toggleCount++;
+                }
+                else if (e.Containers[i].ContainerControl is MenuFlyoutItem mfi)
 				{
 					if (mfi.Icon != null)
 					{
@@ -122,8 +130,17 @@ namespace FluentAvalonia.UI.Controls
 					}
 
 					_toggleCount--;
-				}
-				else if (e.Containers[i].ContainerControl is MenuFlyoutItem mfi)
+                }
+                else if (e.Containers[i].ContainerControl is RadioMenuFlyoutItem rmfi)
+                {
+                    if (rmfi.Icon != null)
+                    {
+                        _iconCount--;
+                    }
+
+                    _toggleCount--;
+                }
+                else if (e.Containers[i].ContainerControl is MenuFlyoutItem mfi)
 				{
 					if (mfi.Icon != null)
 					{

--- a/FluentAvaloniaSamples/Assets/ChangeLog.txt
+++ b/FluentAvaloniaSamples/Assets/ChangeLog.txt
@@ -299,3 +299,32 @@
 -Fixed CoreWindow resizing down when restoring from minimized or maximized
 -Added system context menu support to CoreWindow titlebars
 -Checks ShouldShowConfirmationButtons when opening PickerFlyoutBase
+
+
+
+[1.4.0]
+*TabView
+-Fixed crash with TabViewItem with cultures that don't use '.' as decimal separator (#143)
+
+*FluentAvaloniaTheme
+-Prevent crash when calling InvalidateThemeingFromSystemThemeChange (thanks to GH user PhantomGamers, #150)
+-Add Support for retreiving system theme and accent color on MacOS and Linux (#152)
+
+*Frame
+-Don't remove pages from Cache when they're loaded (thanks to GH user PhantomGamers, #151)
+
+*CoreWindow
+-Added experimental support for UWP-like splashscreen (#154)
+
+*FluentAvalonia.UI.Controls.MenuFlyout
+-Fixed issue where MenuFlyoutItems would be misaligned if used with RadioMenuFlyoutItem
+
+*ColorPickerButton
+-Changed Color property to nullable (BREAKING)
+-Changed ColorChanged and FlyoutConfirmed events args to ColorButtonColorChangedEventArgs (BREAKING)
+-Removed ColorPicker from template (it was unneeded), and simplfied template
+-Add missed resource for swatch outline for dark theme
+
+*General
+-Moved target framework from net5.0 to net6.0
+-Removed Avalonia.Diagnostics from release builds (thanks to GH user PhantomGamers, #153)

--- a/FluentAvaloniaSamples/Assets/ChangeLog.txt
+++ b/FluentAvaloniaSamples/Assets/ChangeLog.txt
@@ -319,11 +319,20 @@
 *FluentAvalonia.UI.Controls.MenuFlyout
 -Fixed issue where MenuFlyoutItems would be misaligned if used with RadioMenuFlyoutItem
 
+*ListBoxItem
+-Temporary fix for #116 to the SelectionIndicator to try to prevent the rendering artifacts by setting the margin to {2.5,0,0,0} and turning off layout rounding
+
 *ColorPickerButton
 -Changed Color property to nullable (BREAKING)
 -Changed ColorChanged and FlyoutConfirmed events args to ColorButtonColorChangedEventArgs (BREAKING)
 -Removed ColorPicker from template (it was unneeded), and simplfied template
 -Add missed resource for swatch outline for dark theme
+-Added FlyoutPlacement property to control placement of flyout
+
+*ColorPicker
+-Fixed issue where Hue ramp slider would sometimes stay all black
+-Fixed issue where switching to expanded mode while still on Text entry tab would remain on that tab even though it was hidden
+-Updates to styles and colors
 
 *General
 -Moved target framework from net5.0 to net6.0

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,10 +11,10 @@
     <AvaloniaResource Include="Pages\SampleCode\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.14" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.12.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.14" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.14" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />


### PR DESCRIPTION
Quite a bit here to add, with some breaking changes...

*ColorPickerButton* (BREAKING CHANGE)
-Changed Color property to nullable
-Changed ColorChanged and FlyoutConfirmed event args to ColorButtonColorChangedEventArgs
-Simplified template and remove the ColorPicker reference in the template (unused and unneeded)
-Add missed resource for swatch outline for dark theme
-Added `FlyoutPlacement` property to control placement of flyout

*ColorPicker*
-Fixed issue where Hue ramp slider would sometimes stay all black
-Fixed issue where switching to expanded mode while still on Text entry tab would remain on that tab even though it was hidden
-Updates to styles and colors

*FluentAvalonia.UI.Controls.MenuFlyout*
-Fixed issue where MenuFlyoutItems would be misaligned if used with RadioMenuFlyoutItem

*ListBoxItem*
-Temporary fix for #116 to the SelectionIndicator to try to prevent the rendering artifacts by setting the margin to {2.5,0,0,0} and turning off layout rounding 

Includes fixes from PRs 143-now. Recap:
*TabView*
-Fixed crash with TabViewItem with cultures that don't use '.' as decimal separator (#143)

*FluentAvaloniaTheme*
-Prevent crash when calling InvalidateThemeingFromSystemThemeChange (thanks to GH user PhantomGamers, #150)
-Add Support for retreiving system theme and accent color on MacOS and Linux (#152)

*Frame*
-Don't remove pages from Cache when they're loaded (thanks to GH user PhantomGamers, #151)

*CoreWindow*
-Added experimental support for UWP-like splashscreen (#154)

*General*
-Moved target framework from net5.0 to net6.0
-Removed Avalonia.Diagnostics from release builds (thanks to GH user PhantomGamers, #153)