### PR TITLE
Improve theme detection on Linux

### DIFF
--- a/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
+++ b/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
@@ -603,10 +603,7 @@ namespace FluentAvalonia.Styling
                 var str = p.StandardOutput.ReadToEnd().Trim();
                 p.WaitForExit();
 
-                if (str.Equals("Dark", StringComparison.OrdinalIgnoreCase))
-                {
-                    theme = DarkModeString;
-                }
+                theme = str.Equals("Dark", StringComparison.OrdinalIgnoreCase) ? DarkModeString : LightModeString;
             }
             catch { }
 

--- a/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
+++ b/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
@@ -651,9 +651,16 @@ namespace FluentAvalonia.Styling
                 var str = p.StandardOutput.ReadToEnd().Trim();
                 p.WaitForExit();
 
-                if (str.IndexOf("-dark", StringComparison.OrdinalIgnoreCase) != -1)
+                if (p.ExitCode == 0)
                 {
-                    theme = DarkModeString;
+                    if (str.IndexOf("-dark", StringComparison.OrdinalIgnoreCase) != -1)
+                    {
+                        theme = DarkModeString;
+                    }
+                    else
+                    {
+                        theme = LightModeString;
+                    }
                 }
             }
             catch { }


### PR DESCRIPTION
If the gsettings process exits with exit code 0 we can assume that theme detection is supported on the system and so if the output result does not include -dark we should set the requested theme to Light mode.

Perhaps the exit code check should be added for OSX too, but as I don't have an OSX environment to test it on to know the exit code behavior when dark mode is not set I left it out, and this shouldn't be an issue anyway because as far as I can tell this method of theme detection works on every version of OSX supported by dotnet.