### PR TITLE
Remove border from `TransparentButton` theme

### DIFF
--- a/FluentAvalonia/Styling/ControlThemes/BasicControls/ButtonStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/BasicControls/ButtonStyles.axaml
@@ -99,7 +99,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="Transparent" />
-        <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThemeThickness}" />
+        <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />


### PR DESCRIPTION
Per `AppBarButton` class in version 1.x. Closes #198.