### PR TITLE
[Feat] Enhancements to Frame navigation

### DIFF
--- a/FluentAvalonia/UI/Controls/Frame/Frame.properties.cs
+++ b/FluentAvalonia/UI/Controls/Frame/Frame.properties.cs
@@ -73,6 +73,13 @@ public partial class Frame : ContentControl
             x => x.IsNavigationStackEnabled, (x, v) => x.IsNavigationStackEnabled = v);
 
     /// <summary>
+    /// Defines the <see cref="NavigationPageFactory"/> property
+    /// </summary>
+    public static readonly DirectProperty<Frame, INavigationPageFactory> NavigationPageFactoryProperty =
+        AvaloniaProperty.RegisterDirect<Frame, INavigationPageFactory>(nameof(NavigationPageFactory),
+            x => x.NavigationPageFactory, (x, v) => x.NavigationPageFactory = v);
+
+    /// <summary>
     /// Gets or sets a type reference of the current content, or the content that should be navigated to.
     /// </summary>
     public Type SourcePageType
@@ -166,6 +173,16 @@ public partial class Frame : ContentControl
         }
     }
 
+    /// <summary>
+    /// Gets or sets the user specified factory that should be use for resolving pages
+    /// when types are not controls or from object instances directly
+    /// </summary>
+    public INavigationPageFactory NavigationPageFactory
+    {
+        get => _pageFactory;
+        set => SetAndRaise(NavigationPageFactoryProperty, ref _pageFactory, value);
+    }
+
     internal PageStackEntry CurrentEntry { get; set; }
 
     /// <summary>
@@ -218,4 +235,5 @@ public partial class Frame : ContentControl
     private IList<PageStackEntry> _backStack;
     private IList<PageStackEntry> _forwardStack;
     private bool _isNavigationStackEnabled = true;
+    private INavigationPageFactory _pageFactory;
 }

--- a/FluentAvalonia/UI/Controls/Frame/INavigationPageFactory.cs
+++ b/FluentAvalonia/UI/Controls/Frame/INavigationPageFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Avalonia.Controls;
+
+namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Specifies factory methods a <see cref="Frame"/> can use to resolve pages from
+/// Types that aren't controls or from object/ViewModel instances directly
+/// </summary>
+public interface INavigationPageFactory
+{
+    /// <summary>
+    /// Returns a user specified page based on the given type passed to <see cref="Frame.Navigate"/>
+    /// </summary>
+    /// <param name="srcType">The type of object used for creating the page</param>
+    /// <returns>An IControl for the new page or <c>null</c> to use the default behavior</returns>
+    IControl GetPage(Type srcType);
+
+    /// <summary>
+    /// Returns a user specified page based on an instance of an existing object
+    /// </summary>
+    /// <param name="target">The target object that should be used to create the page</param>
+    /// <returns>An IControl for the new page. Returning null will cancel the navigation operation</returns>
+    IControl GetPageFromObject(object target);
+}


### PR DESCRIPTION
One of the issues with the current `Frame` control, which was adapted from UWP, is it doesn't lend itself well to those who use MVVM, DI/IoC, etc. in their apps as navigation is done by page (view) type and pages are created using `Activator.CreateInstance()` requiring parameterless constructors of the page, and data contexts have to be set in the page directly.

This PR adds `INavigationPageFactory` interface which you can set on the `Frame` control to override the default page creation behavior to gain more control. The existing behavior of `Frame` will continue to work, this is simply adding new behavior. These new methods are also still compatible with the navigation stack and cache. The interface has two methods to implement:

```C# 
IControl GetPage(Type srcType);
```
This method allows you to take a given type (like a view model) and transform it into the page you want it to correspond to. This method will get called before `Activator.CreateInstance()` using the already existing `Navigate` methods on Frame.
<br />
```C# 
IControl GetPageFromObject(object target);
```
This method allows you to pass an existing ViewModel reference from which to create the page. This is useful if you need to create your view models in a certain way (i.e., specifying services in constructors, parent view models, etc.) and creating them from scratch as part of the page/view creating isn't compatible (i.e., you can't just do DataContext = new MyViewModel() in the cs file of the view).
To facilitate this, a new method `NavigateFromObject(object target, FrameNavigationOptions = null)` was added to frame. This method will only work if you specify the `NavigationPageFactory` on the frame. The logic of this method will check the internal page cache first, then ask the factory for a page instance before following the normal navigation sequence. 

Example usage:
```C#
// Implement INavigationPageFactory
public class PageFactory : INavigationPageFactory
{
    public IControl GetPage(Type srcPageType)
    {
        if (srcPageType == typeof(MyViewModel))
            return new TestView1();
        else if (srcPageType == typeof(MyOtherViewModel))
            return new TestView2();

        return null;
    }

    public IControl GetPageFromObject(object target)
    {
        if (target is MyViewModel)
        {
            return new MyView() { DataContext = target };
        }
        else if (target is MyOtherViewModel)
        {
            return new MyView2() { DataContext = target };
        }

        return null;
    }
}

// set the factory to the frame
// This is also a DirectProperty, so if needed, you can bind it in too in Xaml
myFrame.NavigationPageFactory = new PageFactory();

-------------

// Navigate by view model type
f.Navigate(typeof(MyViewModel));

// Navigate by existing view model reference
f.NavigateFromObject(myViewModelRef);
```



