### PR TITLE
Preview3 Updates

### DIFF
--- a/FASandbox/FASandbox.csproj
+++ b/FASandbox/FASandbox.csproj
@@ -7,10 +7,10 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview2" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview2" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview2" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -48,8 +48,8 @@
 		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview2" />
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview2" />
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview2" />
-		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.4" />
-		<PackageReference Include="MicroCom.Runtime" Version="0.10.4" />
+		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.5" />
+		<PackageReference Include="MicroCom.Runtime" Version="0.10.5" />
         <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />
         <PackageReference Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.1'" />

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -43,11 +43,11 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.0-preview2" />
-		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.0-preview2" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview2" />
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview2" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview2" />
+		<PackageReference Include="Avalonia" Version="11.0.0-preview3" />
+		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.0-preview3" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview3" />
 		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.5" />
 		<PackageReference Include="MicroCom.Runtime" Version="0.10.5" />
         <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />

--- a/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
@@ -9,7 +9,6 @@
                     x:CompileBindings="True">
 
   <pc:ContrastBrushConverter x:Key="ContrastBrushConverter" />
-  <pc:ThirdComponentConverter x:Key="ThirdComponentConverter" />
   <converters:ColorToDisplayNameConverter x:Key="ColorToDisplayNameConverter" />
   <converters:ColorToHexConverter x:Key="ColorToHexConverter" />
   <converters:DoNothingForNullConverter x:Key="DoNothingForNullConverter" />
@@ -299,7 +298,7 @@
                                         IsSaturationValueMaxForced="False"
                                         Orientation="Vertical"
                                         ColorModel="Hsva"
-                                        ColorComponent="{Binding Components, ElementName=ColorSpectrum, Converter={StaticResource ThirdComponentConverter}}"
+                                        ColorComponent="{Binding ThirdComponent, ElementName=ColorSpectrum}"
                                         HsvColor="{Binding HsvColor, ElementName=ColorSpectrum}"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Stretch"

--- a/FluentAvalonia/Styling/ControlThemes/BasicControls/DatePickerStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/BasicControls/DatePickerStyles.axaml
@@ -14,14 +14,13 @@
         </Border>
     </Design.PreviewWith>
 
-    <!-- 
+    <!--
     This file contines some resources used by TimePicker 
     
     Did NOT port the MonochromaticOverlayPresenter, b/c not sure how that
     works and how to implement it outside WinUI comp
     -->
 
-    <Thickness x:Key="DatePickerTopHeaderMargin">0,0,0,4</Thickness>
     <x:Double x:Key="DatePickerFlyoutPresenterHighlightHeight">40</x:Double>
     <x:Double x:Key="DatePickerFlyoutPresenterItemHeight">40</x:Double>
     <x:Double x:Key="DatePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
@@ -261,18 +260,8 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <DataValidationErrors>
-                    <Grid Name="LayoutRoot" Margin="{TemplateBinding Padding}" RowDefinitions="Auto,*">
-                        <ContentPresenter Name="HeaderContentPresenter" Grid.Row="0"
-                                          Content="{TemplateBinding Header}"
-                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                          Margin="{DynamicResource DatePickerTopHeaderMargin}"
-                                          MaxWidth="{DynamicResource DatePickerThemeMaxWidth}"
-                                          HorizontalAlignment="Stretch"
-                                          VerticalAlignment="Top"
-                                          IsVisible="{Binding $self.Content, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                          Foreground="{DynamicResource DatePickerHeaderForeground}"/>
-
-                        <Button Name="PART_FlyoutButton" Grid.Row="1"
+                    <Grid Name="LayoutRoot" Margin="{TemplateBinding Padding}">
+                        <Button Name="PART_FlyoutButton"
                                 Theme="{StaticResource DatePickerFlyoutButtonStyle}"
                                 Foreground="{TemplateBinding Foreground}"
                                 Background="{TemplateBinding Background}"
@@ -327,9 +316,6 @@
         </Setter>
 
         <Style Selector="^:disabled">
-            <Style Selector="^ /template/ ContentPresenter#HeaderContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource DatePickerHeaderForegroundDisabled}"/>
-            </Style>
             <Style Selector="^ /template/ Rectangle">
                 <Setter Property="Fill" Value="{DynamicResource DatePickerSpacerFillDisabled}"/>
             </Style>
@@ -477,5 +463,5 @@
             <Setter Property="IsVisible" Value="True" />
         </Style>
     </ControlTheme>
-    
+
 </ResourceDictionary>

--- a/FluentAvalonia/Styling/ControlThemes/BasicControls/SliderStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/BasicControls/SliderStyles.axaml
@@ -43,8 +43,8 @@
                 <ControlTemplate>
                     <!-- Elevation Brush effect really doesn't come through with this... -->
                     <Border Margin="-2"
-							BorderBrush="{TemplateBinding BorderBrush}"
-							BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Background="{DynamicResource SliderOuterThumbBackground}"
                             CornerRadius="{DynamicResource SliderThumbCornerRadius}"
                             RenderTransform="scaleY(-1)">
@@ -99,7 +99,7 @@
                                               FontWeight="{DynamicResource SliderHeaderThemeFontWeight}" 
                                               Foreground="{DynamicResource SliderHeaderForeground}"
                                               Margin="{DynamicResource SliderTopHeaderMargin}"
-											  />-->
+                                              />-->
 
                                 <Grid x:Name="SliderContainer" Grid.Row="1" ClipToBounds="False">
                                     <Grid.Styles>
@@ -131,9 +131,9 @@
                                                  VerticalAlignment="Top" Margin="0,4,0,0" Grid.Row="2" Grid.ColumnSpan="3" />
 
                                         <!-- 
-									Added a 2px Horizontal margin here otherwise the thumb gets clipped
-									Despite EVERY...SINGLE...ITEM having ClipToBounds=False
-									-->
+                                    Added a 2px Horizontal margin here otherwise the thumb gets clipped
+                                    Despite EVERY...SINGLE...ITEM having ClipToBounds=False
+                                    -->
                                         <Track Name="PART_Track" Grid.Row="1" Margin="2 0"
                                                Grid.ColumnSpan="3" Orientation="Horizontal"
                                                Minimum="{TemplateBinding Minimum}"
@@ -235,9 +235,9 @@
                                                  Margin="4,0,0,0" Grid.Column="2" Grid.RowSpan="3" />
 
                                         <!-- 
-									Added a 2px Vertical margin here otherwise the thumb gets clipped
-									Despite EVERY...SINGLE...ITEM having ClipToBounds=False
-									-->
+                                    Added a 2px Vertical margin here otherwise the thumb gets clipped
+                                    Despite EVERY...SINGLE...ITEM having ClipToBounds=False
+                                    -->
                                         <Track Name="PART_Track" Margin="0 2"
                                                Grid.Column="1" Grid.ColumnSpan="1"
                                                Grid.RowSpan="3" Orientation="Vertical"

--- a/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
@@ -16,7 +16,6 @@
 
     <!-- Some resources are shared with DatePicker and are declared in DatePickerStyles.axaml -->
 
-    <Thickness x:Key="TimePickerTopHeaderMargin">0,0,0,4</Thickness>
     <x:Double x:Key="TimePickerFlyoutPresenterHighlightHeight">40</x:Double>
     <x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
     <x:Double x:Key="TimePickerThemeMinWidth">242</x:Double>
@@ -76,21 +75,9 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <DataValidationErrors>
-                    <Grid Name="LayoutRoot" Margin="{TemplateBinding Padding}" RowDefinitions="Auto,*">
-                        <ContentPresenter Name="HeaderContentPresenter"
-                                          Grid.Row="0"
-                                          Content="{TemplateBinding Header}"
-                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                          Margin="{DynamicResource TimePickerTopHeaderMargin}"
-                                          MaxWidth="{DynamicResource TimePickerThemeMaxWidth}"
-                                          HorizontalAlignment="Stretch"
-                                          VerticalAlignment="Top"
-                                          IsVisible="{Binding $self.Content, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                          Foreground="{DynamicResource TimePickerHeaderForeground}"/>
-
+                    <Grid Name="LayoutRoot" Margin="{TemplateBinding Padding}">
                         <Button Name="PART_FlyoutButton"
                                 Theme="{StaticResource TimePickerFlyoutButtonStyle}"
-                                Grid.Row="1"
                                 Foreground="{TemplateBinding Foreground}"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -161,9 +148,6 @@
         </Setter>
 
         <Style Selector="^:disabled">
-            <Style Selector="^ /template/ ContentPresenter#HeaderContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource TimePickerHeaderForegroundDisabled}"/>
-            </Style>
             <Style Selector="^ /template/ Rectangle">
                 <Setter Property="Fill" Value="{DynamicResource TimePickerSpacerFillDisabled}"/>
             </Style>
@@ -235,7 +219,7 @@
                                 <RepeatButton Name="PART_HourUpButton" VerticalAlignment="Top"
                                               Theme="{StaticResource DateTimePickerFlyoutLoopingNavButton}"
                                               Classes="UpButton"/>
-                                <RepeatButton Name="PART_HourDownButton"                                              
+                                <RepeatButton Name="PART_HourDownButton"
                                               Theme="{StaticResource DateTimePickerFlyoutLoopingNavButton}"
                                               Classes="DownButton"/>
 

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,10 +11,10 @@
     <AvaloniaResource Include="Pages\SampleCode\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview2" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview3" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.0-preview1" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview2" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview2" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />


### PR DESCRIPTION
@amwx This gets FluentAvalonia to build against preview3.

- Updated only the necessary nugets
- Removed header from Date/TimePicker to match upstream (following WPF now where there are no headers)
- Updated ColorPicker removing converter usage