### PR TITLE
More styling fixes

### DIFF
--- a/FluentAvalonia/Styling/ControlThemes/BasicControls/TransitioningContentControlStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/BasicControls/TransitioningContentControlStyles.axaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTheme x:Key="{x:Type TransitioningContentControl}" TargetType="TransitioningContentControl">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <ContentPresenter Name="PART_ContentPresenter"
+                                  Background="{TemplateBinding Background}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  CornerRadius="{TemplateBinding CornerRadius}"
+                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                  Content="{TemplateBinding CurrentContent}"
+                                  Padding="{TemplateBinding Padding}"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+</ResourceDictionary>

--- a/FluentAvalonia/Styling/ControlThemes/Controls.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/Controls.axaml
@@ -51,6 +51,7 @@
                 <ResourceInclude Source="/Styling/ControlThemes/BasicControls/DatePickerStyles.axaml" />
                 <ResourceInclude Source="/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml" />
                 <ResourceInclude Source="/Styling/ControlThemes/BasicControls/TitleBarStyles.axaml" />
+                <ResourceInclude Source="/Styling/ControlThemes/BasicControls/TransitioningContentControlStyles.axaml" />
                 <ResourceInclude Source="/Styling/ControlThemes/BasicControls/ColorPicker/ColorPickerStyles.axaml" />
                 <ResourceInclude Source="/Styling/ControlThemes/BasicControls/DataGrid/DataGridStyles.axaml" />
 

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
@@ -47,6 +47,8 @@
         <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}"/>
         <Setter Property="Width" Value="{DynamicResource TabViewItemAddButtonWidth}"/>
         <Setter Property="Height" Value="{DynamicResource TabViewItemAddButtonHeight}"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <ControlTemplate>
                 <ContentPresenter Name="ContentPresenter"
@@ -107,11 +109,10 @@
                                 Grid.Column="2" Grid.ColumnSpan="2"
                                 VerticalAlignment="Bottom"/>
 
-                        <ContentPresenter
-                                Grid.Column="0"
-                                Name="LeftContentPresenter"
-                                Content="{TemplateBinding TabStripHeader}"
-                                ContentTemplate="{TemplateBinding TabStripHeaderTemplate}"/>
+                        <ContentPresenter Grid.Column="0"
+                                          Name="LeftContentPresenter"
+                                          Content="{TemplateBinding TabStripHeader}"
+                                          ContentTemplate="{TemplateBinding TabStripHeaderTemplate}"/>
 
                         <uip:TabViewListView Grid.Column="1"
                                              Name="TabListView"
@@ -123,16 +124,16 @@
                                              DragDrop.AllowDrop="{TemplateBinding AllowDropTabs}" />
 
                         <Border IsVisible="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}"
-                                 Grid.Column="2"
-                                 Padding="{DynamicResource TabViewItemAddButtonContainerPadding}"
-                                 VerticalAlignment="Bottom">
+                                Grid.Column="2"
+                                Padding="{DynamicResource TabViewItemAddButtonContainerPadding}"
+                                VerticalAlignment="Bottom">
                             <Button Name="AddButton"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       Content="&#xE710;"
-                                       Command="{TemplateBinding AddTabButtonCommand}"
-                                       CommandParameter="{TemplateBinding AddTabButtonCommandParameter}"
-                                       Theme="{StaticResource TabViewButtonStyle}" />
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Content="&#xE710;"
+                                    Command="{TemplateBinding AddTabButtonCommand}"
+                                    CommandParameter="{TemplateBinding AddTabButtonCommandParameter}"
+                                    Theme="{StaticResource TabViewButtonStyle}" />
                         </Border>
 
                         <ContentPresenter Grid.Column="3"


### PR DESCRIPTION
- Adds missing control theme for `TransitioningContentControl`
- Fixes the "add tab button" in the TabView - HCA/VCA needed to be 'Center' to keep the '+' icon centered