### PR TITLE
NavigationView indicator animations for OSX

### DIFF
--- a/FluentAvalonia/Core/NavigationViewItemSelectedIndicatorState.cs
+++ b/FluentAvalonia/Core/NavigationViewItemSelectedIndicatorState.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Threading;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+
+namespace FluentAvalonia.Core;
+
+internal class NavigationViewItemSelectedIndicatorState : IDisposable
+{
+	private readonly Easing _bckEasing = new SplineEasing(0.2, 1, 0.1, 0.9);
+	private readonly Easing _fwdEasing = new SplineEasing(0.1, 0.9, 0.2);
+	private readonly TimeSpan _totalDuration = TimeSpan.FromSeconds(0.4);
+
+	private CancellationTokenSource _currentAnimationCts = new();
+	private IControl? _activeIndicator;
+
+	private bool _isDisposed;
+	private bool _previousAnimationOngoing;
+
+	// This will be used in the future for horizontal selection indicators.
+	public Orientation NavItemsOrientation { get; set; } = Orientation.Vertical;
+
+	public void Dispose()
+	{
+		_isDisposed = true;
+		CancelPriorAnimation();
+	}
+
+	private void CancelPriorAnimation()
+	{
+		_currentAnimationCts.Cancel();
+		_currentAnimationCts.Dispose();
+		_currentAnimationCts = new CancellationTokenSource();
+	}
+
+	private static Matrix GetOffsetFrom(IVisual ancestor, IVisual visual)
+	{
+		var identity = Matrix.Identity;
+		while (visual != ancestor)
+		{
+			var bounds = visual.Bounds;
+			var topLeft = bounds.TopLeft;
+
+			if (topLeft != new Point())
+			{
+				identity *= Matrix.CreateTranslation(topLeft);
+			}
+
+			if (visual.VisualParent is null)
+			{
+				return Matrix.Identity;
+			}
+
+			visual = visual.VisualParent;
+		}
+
+		return identity;
+	}
+
+	public async void AnimateIndicatorAsync(IControl next)
+	{
+		if (_isDisposed)
+		{
+			return;
+		}
+
+		var prevIndicator = _activeIndicator;
+		var nextIndicator = next;
+
+		// user clicked twice
+		if (prevIndicator is null || prevIndicator.Equals(next))
+		{
+			return;
+		}
+
+		// Get the common ancestor as a reference point.
+        var commonAncestor = prevIndicator.FindCommonVisualAncestor(nextIndicator);
+
+		// likely being dragged
+		if (commonAncestor is null)
+		{
+			return;
+		}
+
+		_activeIndicator = next;
+
+		if (_previousAnimationOngoing)
+		{
+			CancelPriorAnimation();
+		}
+
+		prevIndicator.Opacity = 1;
+		nextIndicator.Opacity = 0;
+
+		// Ignore the RenderTransforms so we can get the actual positions
+		var prevMatrix = GetOffsetFrom(commonAncestor, prevIndicator);
+		var nextMatrix = GetOffsetFrom(commonAncestor, nextIndicator);
+
+		var prevVector = new Point().Transform(prevMatrix);
+		var nextVector = new Point().Transform(nextMatrix);
+
+		var targetVector = nextVector - prevVector;
+		var fromTopToBottom = targetVector.Y > 0;
+		var curEasing = fromTopToBottom ? _fwdEasing : _bckEasing;
+		var newDim = Math.Abs(NavItemsOrientation == Orientation.Vertical ? targetVector.Y : targetVector.X);
+		var maxScale = newDim / (NavItemsOrientation == Orientation.Vertical
+			? nextIndicator.Bounds.Height
+			: nextIndicator.Bounds.Width) + 1;
+
+		Animation translationAnimation = new()
+		{
+			Easing = curEasing,
+			Duration = _totalDuration,
+			Children =
+				{
+					new KeyFrame
+					{
+						Cue = new Cue(0d),
+						Setters =
+						{
+							new Setter(ScaleTransform.ScaleYProperty, 1d),
+							new Setter(TranslateTransform.XProperty, 0d),
+							new Setter(TranslateTransform.YProperty, 0d)
+						}
+					},
+					new KeyFrame
+					{
+						Cue = new Cue(0.33333d),
+						Setters =
+						{
+							new Setter(ScaleTransform.ScaleYProperty, maxScale * 0.5d)
+						}
+					},
+					new KeyFrame
+					{
+						Cue = new Cue(1d),
+						Setters =
+						{
+							new Setter(ScaleTransform.ScaleYProperty, 1d),
+							new Setter(TranslateTransform.XProperty, targetVector.X),
+							new Setter(TranslateTransform.YProperty, targetVector.Y)
+						}
+					}
+				}
+		};
+
+		_previousAnimationOngoing = true;
+		await translationAnimation.RunAsync(prevIndicator as Control ?? throw new InvalidOperationException(), null, _currentAnimationCts.Token);
+		_previousAnimationOngoing = false;
+
+		prevIndicator.Opacity = 0;
+		nextIndicator.Opacity = Equals(_activeIndicator, nextIndicator) ? 1 : 0;
+	}
+
+	public void SetActive(Control initial)
+	{
+		if (_activeIndicator is not null)
+		{
+			_activeIndicator.Opacity = 0;
+		}
+
+		_activeIndicator = initial;
+		_activeIndicator.Opacity = 1;
+	}
+}

--- a/FluentAvalonia/Helpers/PlatformExtension.cs
+++ b/FluentAvalonia/Helpers/PlatformExtension.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Data.Core;
+using Avalonia.Markup.Xaml;
+using Avalonia.Utilities;
+
+namespace FluentAvalonia.Helpers;
+
+public class PlatformExtension : MarkupExtension
+{
+    public PlatformExtension()
+    {
+    }
+
+    public PlatformExtension(object defaultValue)
+    {
+        Default = defaultValue;
+    }
+
+    public object? Default { get; set; }
+
+    public object? Osx { get; set; }
+
+    public object? Linux { get; set; }
+
+    public object? Windows { get; set; }
+
+    public override object? ProvideValue(IServiceProvider serviceProvider)
+    {
+        var result = Default;
+
+        if (Osx is not null && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            result = Osx;
+        }
+        else if (Linux is not null && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            result = Linux;
+        }
+        else if (Windows is not null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            result = Windows;
+        }
+
+        var provideValueTarget = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+
+        if (provideValueTarget is { TargetProperty: IPropertyInfo propertyInfo })
+        {
+            if (TypeUtilities.TryConvert(
+                    propertyInfo.PropertyType,
+                    result,
+                    CultureInfo.InvariantCulture,
+                    out var converted))
+            {
+                return converted;
+            }
+        }
+
+        return AvaloniaProperty.UnsetValue;
+    }
+}

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
@@ -33,12 +33,11 @@
 
                         <Panel HorizontalAlignment="Left"
                                VerticalAlignment="Center">
-
                             <Border Name="SelectionIndicator"
-									Background="{DynamicResource NavigationViewSelectionIndicatorForeground}"
-									Opacity="0"
+                                    Background="{DynamicResource NavigationViewSelectionIndicatorForeground}"
+                                    Opacity="0"
                                     Margin="0.5,0,0,0" 
-                                    ZIndex="1000000"
+                                    ZIndex="100"
                                     Width="{DynamicResource NavigationViewSelectionIndicatorWidth}"
                                     Height="{DynamicResource NavigationViewSelectionIndicatorHeight}"
                                     CornerRadius="{DynamicResource NavigationViewSelectionIndicatorRadius}" />

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
@@ -37,6 +37,8 @@
                             <Border Name="SelectionIndicator"
 									Background="{DynamicResource NavigationViewSelectionIndicatorForeground}"
 									Opacity="0"
+                                    Margin="0.5,0,0,0" 
+                                    ZIndex="1000000"
                                     Width="{DynamicResource NavigationViewSelectionIndicatorWidth}"
                                     Height="{DynamicResource NavigationViewSelectionIndicatorHeight}"
                                     CornerRadius="{DynamicResource NavigationViewSelectionIndicatorRadius}" />

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemStyles.axaml
@@ -20,6 +20,7 @@
         <Setter Property="BorderThickness" Value="{DynamicResource NavigationViewItemBorderThickness}" />
         <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
         <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="ClipToBounds" Value="False"/>
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="Margin" Value="{DynamicResource NavigationViewItemMargin}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -27,7 +28,7 @@
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Once" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid Name="NVIRootGrid" RowDefinitions="*,Auto">
+                <Grid ClipToBounds="False" Name="NVIRootGrid" RowDefinitions="*,Auto">
                     <Grid.Styles>
                         <Style Selector="FlyoutPresenter">
                             <Setter Property="Theme" Value="{StaticResource NavViewFlyoutStyle}" />
@@ -36,6 +37,7 @@
                     
                     <uip:NavigationViewItemPresenter Name="NVIPresenter"
                                                      Icon="{TemplateBinding Icon}"
+                                                     ClipToBounds="False"
 													 InfoBadge="{TemplateBinding InfoBadge}"
                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
                                                      Padding="{TemplateBinding Padding}"

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
@@ -1,6 +1,8 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+                    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+                    xmlns:helpers="clr-namespace:FluentAvalonia.Helpers"
+                    xmlns:system="clr-namespace:System;assembly=netstandard">
 
     <Design.PreviewWith>
         <Border Padding="40" >
@@ -14,12 +16,15 @@
         </Border>
     </Design.PreviewWith>
 
+    <Thickness  x:Key="WindowsLayout">0</Thickness>
+    <Thickness  x:Key="OSXLayout">0,24,0,0</Thickness>
+
     <ControlTheme x:Key="{x:Type ui:NavigationView}" TargetType="ui:NavigationView">
         <!--<Setter Property="KeyboardNavigation.IsTabStop" Value="False" />-->
         <Setter Property="CompactPaneLength" Value="{DynamicResource NavigationViewCompactPaneLength}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Panel Name="RootGrid">
+                <Panel Name="RootGrid"                           Margin="{helpers:Platform {StaticResource WindowsLayout},  Osx={StaticResource OSXLayout}}">
 
                     <!--Button grid-->
                     <Grid Name="PaneToggleButtonGrid"
@@ -27,7 +32,7 @@
                           VerticalAlignment="Top"
                           ZIndex="100"
                           RowDefinitions="Auto,Auto">
-
+                        
                         <Rectangle Name="TogglePaneTopPadding"
                                    Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.TopPadding}" />
 

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -25,8 +25,11 @@ namespace FluentAvalonia.UI.Controls;
 /// </summary>
 public partial class NavigationView : HeaderedContentControl
 {
+    private readonly NavigationViewItemSelectedIndicatorState _navBarSelectedIndicatorState;
+
     public NavigationView()
     {
+        _navBarSelectedIndicatorState = new NavigationViewItemSelectedIndicatorState();
         //PseudoClasses.Add(":autosuggestcollapsed");
         //PseudoClasses.Add(":headercollapsed");
         //PseudoClasses.Add(":backbuttoncollapsed");
@@ -3249,10 +3252,15 @@ public partial class NavigationView : HeaderedContentControl
         if (prevIndicator == nextIndicator)
             return;
 
-        if (prevIndicator != null)
-            prevIndicator.Opacity = 0;
-        if (nextIndicator != null)
-            nextIndicator.Opacity = 1;
+        //_navBarSelectedIndicatorState.SetActive(nextIndicator as Control);
+        if (prevIndicator == null)
+        {
+            _navBarSelectedIndicatorState.SetActive(nextIndicator as Control);
+        }
+        else
+        {
+            _navBarSelectedIndicatorState.AnimateIndicatorAsync(nextIndicator);
+        }
 
         _activeIndicator = nextIndicator;
     }

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -3259,7 +3259,7 @@ public partial class NavigationView : HeaderedContentControl
         }
         else
         {
-            _navBarSelectedIndicatorState.AnimateIndicatorAsync(nextIndicator);
+            _navBarSelectedIndicatorState.AnimateIndicatorAsync(nextIndicator as Control);
         }
 
         _activeIndicator = nextIndicator;


### PR DESCRIPTION
On MacOS, the NavigationView did not have animations when changing the selected item on the navigation view.

This PR fixes that by implementing a custom behaviour, which animates the SelectedIndicator border (on Left display mode).

Before:

https://user-images.githubusercontent.com/13438702/200153392-b081413a-336e-4ed0-9d6a-da90c89b2cca.mov


After:

https://user-images.githubusercontent.com/13438702/200153394-1a214835-2645-49a3-9ebd-9635198fc94b.mov

