### PR TITLE
FluentAvalonia v2-preview4

### DIFF
--- a/FASandbox/FASandbox.csproj
+++ b/FASandbox/FASandbox.csproj
@@ -7,10 +7,10 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia\FluentAvalonia.csproj" />

--- a/FluentAvalonia.UI.Windowing/FluentAvalonia.UI.Windowing.csproj
+++ b/FluentAvalonia.UI.Windowing/FluentAvalonia.UI.Windowing.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.0.0-preview3</Version>
+    <Version>2.0.0-preview4</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/FluentAvalonia.UI.Windowing/FluentAvalonia.UI.Windowing.csproj
+++ b/FluentAvalonia.UI.Windowing/FluentAvalonia.UI.Windowing.csproj
@@ -25,12 +25,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
 
-    <PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.5" />
-    <PackageReference Include="MicroCom.Runtime" Version="0.10.5" />
+    <PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.0" />
+    <PackageReference Include="MicroCom.Runtime" Version="0.11.0" />
     <MicroComIdl Include="$(MSBuildThisFileDirectory)\Win32\Win32Com.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Win32\Win32Com.Generated.cs" />
   </ItemGroup>
 

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -22,7 +22,7 @@
 
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>2.0.0-preview3</Version>
+        <Version>2.0.0-preview4</Version>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>        
     </PropertyGroup>
 

--- a/FluentAvalonia/FluentAvalonia.csproj
+++ b/FluentAvalonia/FluentAvalonia.csproj
@@ -43,13 +43,13 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.0-preview3" />
-		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.0-preview3" />
-		<PackageReference Include="Avalonia.Skia" Version="11.0.0-preview3" />
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview3" />
-		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.10.5" />
-		<PackageReference Include="MicroCom.Runtime" Version="0.10.5" />
+		<PackageReference Include="Avalonia" Version="11.0.0-preview4" />
+		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.0-preview4" />
+		<PackageReference Include="Avalonia.Skia" Version="11.0.0-preview4" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview4" />
+		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.0" />
+		<PackageReference Include="MicroCom.Runtime" Version="0.11.0" />
         <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />
         <PackageReference Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.1'" />

--- a/FluentAvalonia/UI/Controls/CommandBarFlyout/TextCommandBarFlyout.cs
+++ b/FluentAvalonia/UI/Controls/CommandBarFlyout/TextCommandBarFlyout.cs
@@ -307,35 +307,7 @@ public class TextCommandBarFlyout : CommandBarFlyout
 
                 if (args.Handled)
                     break;
-            }
-
-            RawInputModifiers GetRawMods(KeyModifiers km)
-            {
-                RawInputModifiers rm = RawInputModifiers.None;
-
-                if ((km & KeyModifiers.Control) == KeyModifiers.Control)
-                    rm |= RawInputModifiers.Control;
-
-                if ((km & KeyModifiers.Shift) == KeyModifiers.Shift)
-                    rm |= RawInputModifiers.Shift;
-
-                if ((km & KeyModifiers.Meta) == KeyModifiers.Meta)
-                    rm |= RawInputModifiers.Meta;
-
-                if ((km & KeyModifiers.Alt) == KeyModifiers.Alt)
-                    rm |= RawInputModifiers.Alt;
-
-                return rm;
-            }
-
-            //tb.RaiseEvent(new KeyEventArgs
-            //{
-            //    Device = KeyboardDevice.Instance,
-            //    Key = Key.Z,
-            //    KeyModifiers = KeyModifiers.Control,
-            //    RoutedEvent = InputElement.KeyDownEvent,
-            //    Route = Avalonia.Interactivity.RoutingStrategies.Direct,
-            //});
+            }            
         }
 
         if (IsButtonInPrimaryCommands(TextControlButtons.Undo))
@@ -373,42 +345,31 @@ public class TextCommandBarFlyout : CommandBarFlyout
                 if (args.Handled)
                     break;
             }
-
-            RawInputModifiers GetRawMods(KeyModifiers km)
-            {
-                RawInputModifiers rm = RawInputModifiers.None;
-
-                if ((km & KeyModifiers.Control) == KeyModifiers.Control)
-                    rm |= RawInputModifiers.Control;
-
-                if ((km & KeyModifiers.Shift) == KeyModifiers.Shift)
-                    rm |= RawInputModifiers.Shift;
-
-                if ((km & KeyModifiers.Meta) == KeyModifiers.Meta)
-                    rm |= RawInputModifiers.Meta;
-
-                if ((km & KeyModifiers.Alt) == KeyModifiers.Alt)
-                    rm |= RawInputModifiers.Alt;
-
-                return rm;
-            }
-
-            //KeyboardDevice.Instance.ProcessRawEvent(new RawKeyEventArgs())
-
-            //tb.RaiseEvent(new KeyEventArgs
-            //{
-            //    Device = KeyboardDevice.Instance,
-            //    Key = Key.Y,
-            //    KeyModifiers = KeyModifiers.Control,
-            //    RoutedEvent = InputElement.KeyDownEvent,
-            //    Route = Avalonia.Interactivity.RoutingStrategies.Direct,
-            //});
         }
 
         if (IsButtonInPrimaryCommands(TextControlButtons.Redo))
         {
             UpdateButtons();
         }
+    }
+
+    private static RawInputModifiers GetRawMods(KeyModifiers km)
+    {
+        RawInputModifiers rm = RawInputModifiers.None;
+
+        if ((km & KeyModifiers.Control) == KeyModifiers.Control)
+            rm |= RawInputModifiers.Control;
+
+        if ((km & KeyModifiers.Shift) == KeyModifiers.Shift)
+            rm |= RawInputModifiers.Shift;
+
+        if ((km & KeyModifiers.Meta) == KeyModifiers.Meta)
+            rm |= RawInputModifiers.Meta;
+
+        if ((km & KeyModifiers.Alt) == KeyModifiers.Alt)
+            rm |= RawInputModifiers.Alt;
+
+        return rm;
     }
 
     private void ExecuteSelectAllCommand()

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
@@ -15,17 +15,23 @@ public class MenuFlyoutItemBase : TemplatedControl
     protected override void OnPointerEntered(PointerEventArgs e)
     {
         base.OnPointerEntered(e);
-        var point = e.GetCurrentPoint(null);
-        RaiseEvent(new PointerEventArgs(MenuItem.PointerEnteredItemEvent, this, e.Pointer, VisualRoot, point.Position,
-            e.Timestamp, point.Properties, e.KeyModifiers));
+
+        // v2 - Avalonia decided PointerEventArgs and like shouldn't be publicly constructable so our way to get around
+        //      this is to just change the event name and source and re-raise it. This isn't ideal
+        e.RoutedEvent = MenuItem.PointerEnteredItemEvent;
+        e.Source = this;
+        RaiseEvent(e);
     }
 
     protected override void OnPointerExited(PointerEventArgs e)
     {
         base.OnPointerExited(e);
-        var point = e.GetCurrentPoint(null);
-        RaiseEvent(new PointerEventArgs(MenuItem.PointerExitedItemEvent, this, e.Pointer, VisualRoot, point.Position,
-            e.Timestamp, point.Properties, e.KeyModifiers));
+
+        // v2 - Avalonia decided PointerEventArgs and like shouldn't be publicly constructable so our way to get around
+        //      this is to just change the event name and source and re-raise it. This isn't ideal
+        e.RoutedEvent = MenuItem.PointerExitedItemEvent;
+        e.Source = this;
+        RaiseEvent(e);
     }
 
     protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
@@ -20,18 +20,22 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     {
         base.OnPointerEntered(e);
 
-        var point = e.GetCurrentPoint(null);
-        RaiseEvent(new PointerEventArgs(MenuItem.PointerEnteredItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
-            e.Timestamp, point.Properties, e.KeyModifiers));
+        // v2 - Avalonia decided PointerEventArgs and like shouldn't be publicly constructable so our way to get around
+        //      this is to just change the event name and source and re-raise it. This isn't ideal
+        e.RoutedEvent = MenuItem.PointerEnteredItemEvent;
+        e.Source = this;
+        RaiseEvent(e);
     }
 
     protected override void OnPointerExited(PointerEventArgs e)
     {
         base.OnPointerExited(e);
 
-        var point = e.GetCurrentPoint(null);
-        RaiseEvent(new PointerEventArgs(MenuItem.PointerExitedItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
-            e.Timestamp, point.Properties, e.KeyModifiers));
+        // v2 - Avalonia decided PointerEventArgs and like shouldn't be publicly constructable so our way to get around
+        //      this is to just change the event name and source and re-raise it. This isn't ideal
+        e.RoutedEvent = MenuItem.PointerExitedItemEvent;
+        e.Source = this;
+        RaiseEvent(e);
     }
 
     /// <summary>

--- a/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -11,10 +11,10 @@
     <AvaloniaResource Include="Pages\SampleCode\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.0-preview1" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FluentAvalonia.UI.Windowing\FluentAvalonia.UI.Windowing.csproj" />


### PR DESCRIPTION
Updates to Avalonia11.0-preview4

Changes that had to be made to support preview4, since it was apparently decided pointer and key eventargs shouldn't be publicly construct-able:
- MenuFlyoutItemBase & MenuFlyoutSubItem now reuse the existing PointerEntered and PointerExited event args and just change the RoutedEvent to the MenuItem.PointerEntered[Exited]ItemEvent. No idea if this has side-effects, but seems to work
- TextCommandBarFlyout Undo/Redo now uses the RawInputEvent (lower-level) to raise the necessary keystrokes for triggering Undo or Redo. I've also updated this to iterate over the key configurations in the PlatformHotKeyConfiguration rather than hard-coding to Ctrl-Z & Ctrl-Y. No other TextCommandBarFlyout behaviors have been changed or implemented to support newer features (will go on the list though)

Please remember that preview versions may have breaking changes between versions causing incompatibility between this library and upstream with version mismatches. Either wait until I update the package here or tread carefully if using a new upstream preview.