### PR TITLE
[WIP] Add `TemplatePartAttribute` and missing `PseudoclassesAttribute`

### DIFF
--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -15,6 +15,7 @@ internal class SharedPseudoclasses
     public const string s_pcFlyout = ":flyout";
     public const string s_pcHotkey = ":hotkey";
     public const string s_pcOverflow = ":overflow";
+    public const string s_pcHidden = ":hidden";
 
     public const string s_cAccent = "accent";
 }

--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -17,8 +17,12 @@ internal class SharedPseudoclasses
     public const string s_pcOverflow = ":overflow";
     public const string s_pcHidden = ":hidden";
     public const string s_pcHeader = ":header";
+    public const string s_pcFooter = ":footer";
     public const string s_pcPressed = ":pressed";
     public const string s_pcChecked = ":checked";
+
+    // SettingsExpander specific
+    public const string s_pcAllowClick = ":allowClick";
 
     public const string s_cAccent = "accent";
 }

--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -28,6 +28,17 @@ internal class SharedPseudoclasses
     public const string s_pcNoBorder = ":noborder";
     public const string s_pcBorderLeft = ":borderLeft";
     public const string s_pcBorderRight = ":borderRight";
-    
+
+    // NavigationViewItem / NavigationViewItemPresenter
+    public const string s_pcIconLeft = ":iconleft";
+    public const string s_pcIconOnly = ":icononly";
+    public const string s_pcContentOnly = ":contentonly";
+    public const string s_pcLeftNav = ":leftnav";
+    public const string s_pcTopNav = ":topnav";
+    public const string s_pcTopOverflow = ":topoverflow";
+    public const string s_pcChevronOpen = ":chevronopen";
+    public const string s_pcChevronClosed = ":chevronclosed";
+    public const string s_pcChevronHidden = ":chevronhidden";
+
     public const string s_cAccent = "accent";
 }

--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -16,6 +16,7 @@ internal class SharedPseudoclasses
     public const string s_pcHotkey = ":hotkey";
     public const string s_pcOverflow = ":overflow";
     public const string s_pcHidden = ":hidden";
+    public const string s_pcHeader = ":header";
 
     public const string s_cAccent = "accent";
 }

--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -17,6 +17,8 @@ internal class SharedPseudoclasses
     public const string s_pcOverflow = ":overflow";
     public const string s_pcHidden = ":hidden";
     public const string s_pcHeader = ":header";
+    public const string s_pcPressed = ":pressed";
+    public const string s_pcChecked = ":checked";
 
     public const string s_cAccent = "accent";
 }

--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -15,4 +15,6 @@ internal class SharedPseudoclasses
     public const string s_pcFlyout = ":flyout";
     public const string s_pcHotkey = ":hotkey";
     public const string s_pcOverflow = ":overflow";
+
+    public const string s_cAccent = "accent";
 }

--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluentAvalonia.Core;
+
+// These are pseudoclass names that are used in multiple controls. Share them so we don't have
+// a bunch of duplicate strings everywhere
+internal class SharedPseudoclasses
+{
+    public const string s_pcOpen = ":open";
+    public const string s_pcCompact = ":compact";
+    public const string s_pcIcon = ":icon";
+    public const string s_pcLabel = ":label";
+    public const string s_pcFlyout = ":flyout";
+    public const string s_pcHotkey = ":hotkey";
+    public const string s_pcOverflow = ":overflow";
+}

--- a/FluentAvalonia/Core/SharedPseudoclasses.cs
+++ b/FluentAvalonia/Core/SharedPseudoclasses.cs
@@ -24,5 +24,10 @@ internal class SharedPseudoclasses
     // SettingsExpander specific
     public const string s_pcAllowClick = ":allowClick";
 
+    // TabViewSpecific
+    public const string s_pcNoBorder = ":noborder";
+    public const string s_pcBorderLeft = ":borderLeft";
+    public const string s_pcBorderRight = ":borderRight";
+    
     public const string s_cAccent = "accent";
 }

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/ColorPickerButtonStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/ColorPickerButtonStyles.axaml
@@ -22,7 +22,7 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Button Name="MainButton"
+                <Button Name="ShowFlyoutButton"
                            CornerRadius="{TemplateBinding CornerRadius}"
                            HorizontalContentAlignment="Stretch"
                            Padding="0">

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.cs
@@ -33,7 +33,7 @@ public partial class ColorPickerButton : TemplatedControl, IStyleable
 
         base.OnApplyTemplate(e);
 
-        _button = e.NameScope.Find<Button>("MainButton");
+        _button = e.NameScope.Find<Button>(s_tpShowFlyoutButton);
         if (_button != null)
         {
             _button.Click += OnButtonClick;

--- a/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/ColorPickerButton/ColorPickerButton.properties.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using FluentAvalonia.Core;
+using Avalonia.Controls.Metadata;
 
 namespace FluentAvalonia.UI.Controls;
 
+[TemplatePart(s_tpShowFlyoutButton, typeof(Button))]
 public partial class ColorPickerButton
 {
     /// <summary>
@@ -244,4 +246,5 @@ public partial class ColorPickerButton
     private bool _isCompact = true;
     private bool _isAlphaEnabled = true;
     private IEnumerable<Color> _customPaletteColors;
+    private const string s_tpShowFlyoutButton = "ShowFlyoutButton";
 }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
@@ -3,6 +3,7 @@ using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using FluentAvalonia.Core;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -25,24 +26,33 @@ public partial class CommandBar : ContentControl
 
         // Don't initialize the actual item lists here, we'll do that as needed
 
-        PseudoClasses.Add(":dynamicoverflow");
-        PseudoClasses.Add(":compact");
-        PseudoClasses.Add(":labelbottom");
+        PseudoClasses.Add(s_pcDynamicOverflow);
+        PseudoClasses.Add(SharedPseudoclasses.s_pcCompact);
+        PseudoClasses.Add(s_pcLabelBottom);
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         _appliedTemplate = false;
 
+        if (_moreButton != null)
+        {
+            _moreButton.Click -= OnMoreButtonClick;
+        }
+
         base.OnApplyTemplate(e);
 
-        _primaryItemsHost = e.NameScope.Find<ItemsControl>("PrimaryItemsControl");
-        _contentHost = e.NameScope.Find<ContentControl>("ContentControl");
+        _primaryItemsHost = e.NameScope.Find<ItemsControl>(s_tpPrimaryItemsControl);
+        _contentHost = e.NameScope.Find<ContentControl>(s_tpContentControl);
 
-        _overflowItemsHost = e.NameScope.Find<CommandBarOverflowPresenter>("SecondaryItemsControl");
+        _overflowItemsHost = e.NameScope.Find<CommandBarOverflowPresenter>(s_tpSecondaryItemsControl);
 
-        _moreButton = e.NameScope.Find<Button>("MoreButton");
-        _moreButton.Click += OnMoreButtonClick;
+        _moreButton = e.NameScope.Find<Button>(s_tpMoreButton);
+        if (_moreButton != null)
+        {
+            _moreButton.Click += OnMoreButtonClick;
+        }
+        
         _appliedTemplate = true;
 
         AttachItems();
@@ -54,16 +64,16 @@ public partial class CommandBar : ContentControl
         if (change.Property == DefaultLabelPositionProperty)
         {
             var newVal = change.GetNewValue<CommandBarDefaultLabelPosition>();
-            PseudoClasses.Set(":labelright", newVal == CommandBarDefaultLabelPosition.Right);
-            PseudoClasses.Set(":labelbottom", newVal == CommandBarDefaultLabelPosition.Bottom);
-            PseudoClasses.Set(":labelcollapsed", newVal == CommandBarDefaultLabelPosition.Collapsed);
+            PseudoClasses.Set(s_pcLabelRight, newVal == CommandBarDefaultLabelPosition.Right);
+            PseudoClasses.Set(s_pcLabelBottom, newVal == CommandBarDefaultLabelPosition.Bottom);
+            PseudoClasses.Set(s_pcLabelCollapsed, newVal == CommandBarDefaultLabelPosition.Collapsed);
         }
         else if (change.Property == ClosedDisplayModeProperty)
         {
             var newVal = change.GetNewValue<CommandBarClosedDisplayMode>();
-            PseudoClasses.Set(":compact", newVal == CommandBarClosedDisplayMode.Compact);
-            PseudoClasses.Set(":minimal", newVal == CommandBarClosedDisplayMode.Minimal);
-            PseudoClasses.Set(":hidden", newVal == CommandBarClosedDisplayMode.Hidden);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcCompact, newVal == CommandBarClosedDisplayMode.Compact);
+            PseudoClasses.Set(s_pcMinimal, newVal == CommandBarClosedDisplayMode.Minimal);
+            PseudoClasses.Set(s_pcHidden, newVal == CommandBarClosedDisplayMode.Hidden);
         }
     }
 
@@ -272,8 +282,8 @@ public partial class CommandBar : ContentControl
                 break;
         }
 
-        PseudoClasses.Set(":primaryonly", _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
-        PseudoClasses.Set(":secondaryonly", _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
+        PseudoClasses.Set(s_pcPrimaryOnly, _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
+        PseudoClasses.Set(s_pcSecondaryOnly, _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
         InvalidateMeasure();
     }
 
@@ -317,8 +327,8 @@ public partial class CommandBar : ContentControl
                 break;
         }
 
-        PseudoClasses.Set(":primaryonly", _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
-        PseudoClasses.Set(":secondaryonly", _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
+        PseudoClasses.Set(s_pcPrimaryOnly, _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
+        PseudoClasses.Set(s_pcSecondaryOnly, _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
     }
 
     private void AttachItems()
@@ -355,8 +365,8 @@ public partial class CommandBar : ContentControl
             _overflowItemsHost.Items = _overflowItems;
         }
 
-        PseudoClasses.Set(":primaryonly", _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
-        PseudoClasses.Set(":secondaryonly", _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
+        PseudoClasses.Set(s_pcPrimaryOnly, _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
+        PseudoClasses.Set(s_pcSecondaryOnly, _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
     }
 
     private void PrimaryItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -373,9 +383,9 @@ public partial class CommandBar : ContentControl
                     {
                         if (items[i] is Control c && c.Classes is IPseudoClasses pc)
                         {
-                            pc.Set(s_collapsedClass, pos == CommandBarDefaultLabelPosition.Collapsed);
-                            pc.Set(s_labelRightClass, pos == CommandBarDefaultLabelPosition.Right);
-                            pc.Set(s_labelBottomClass, pos == CommandBarDefaultLabelPosition.Bottom);
+                            pc.Set(s_pcLabelCollapsed, pos == CommandBarDefaultLabelPosition.Collapsed);
+                            pc.Set(s_pcLabelRight, pos == CommandBarDefaultLabelPosition.Right);
+                            pc.Set(s_pcLabelBottom, pos == CommandBarDefaultLabelPosition.Bottom);
                         }
                     }
                 }
@@ -391,9 +401,9 @@ public partial class CommandBar : ContentControl
                         {
                             if (items[i] is Control c && c.Classes is IPseudoClasses pc)
                             {
-                                pc.Set(s_collapsedClass, false);
-                                pc.Set(s_labelRightClass, false);
-                                pc.Set(s_labelBottomClass, false);
+                                pc.Set(s_pcLabelCollapsed, false);
+                                pc.Set(s_pcLabelRight, false);
+                                pc.Set(s_pcLabelBottom, false);
                             }
                         }
                     }
@@ -505,7 +515,7 @@ public partial class CommandBar : ContentControl
         {
             if (_primaryItems[i] is Control c && c.Classes is IPseudoClasses pc)
             {
-                pc.Set(":open", open);
+                pc.Set(SharedPseudoclasses.s_pcOpen, open);
             }
         }
     }
@@ -529,8 +539,4 @@ public partial class CommandBar : ContentControl
     private Dictionary<ICommandBarElement, double> _widthCache;
     private int _numInOverflow = 0;
     private double _minRecoverWidth;
-
-    private readonly string s_collapsedClass = ":labelCollapsed";
-    private readonly string s_labelBottomClass = ":labelBottom";
-    private readonly string s_labelRightClass = ":labelRight";
 }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBar.properties.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBar.properties.cs
@@ -4,9 +4,19 @@ using Avalonia.Layout;
 using Avalonia;
 using FluentAvalonia.Core;
 using System;
+using Avalonia.Controls.Metadata;
 
 namespace FluentAvalonia.UI.Controls;
 
+[TemplatePart(s_tpPrimaryItemsControl, typeof(ItemsControl))]
+[TemplatePart(s_tpContentControl, typeof(ContentControl))]
+[TemplatePart(s_tpSecondaryItemsControl, typeof(CommandBarOverflowPresenter))]
+[TemplatePart(s_tpMoreButton, typeof(Button))]
+[PseudoClasses(s_pcDynamicOverflow)]
+[PseudoClasses(SharedPseudoclasses.s_pcCompact, s_pcMinimal, s_pcHidden)]
+[PseudoClasses(s_pcLabelBottom, s_pcLabelRight, s_pcLabelCollapsed)]
+[PseudoClasses(s_pcPrimaryOnly, s_pcSecondaryOnly)]
+[PseudoClasses(SharedPseudoclasses.s_pcOpen)]
 public partial class CommandBar
 {
     /// <summary>
@@ -209,4 +219,18 @@ public partial class CommandBar
     private IAvaloniaList<ICommandBarElement> _primaryCommands;
     private IAvaloniaList<ICommandBarElement> _secondaryCommands;
     private bool _isDynamicOverflowEnabled = true;
+
+    private const string s_tpPrimaryItemsControl = "PrimaryItemsControl";
+    private const string s_tpContentControl = "ContentControl";
+    private const string s_tpSecondaryItemsControl = "SecondaryItemsControl";
+    private const string s_tpMoreButton = "MoreButton";
+
+    private const string s_pcDynamicOverflow = ":dynamicoverflow";
+    private const string s_pcLabelBottom = ":labelbottom";
+    private const string s_pcLabelRight = ":labelright";
+    private const string s_pcLabelCollapsed = ":labelcollapsed";
+    private const string s_pcMinimal = ":minimal";
+    private const string s_pcHidden = ":hidden";
+    private const string s_pcPrimaryOnly = ":primaryOnly";
+    private const string s_pcSecondaryOnly = ":secondaryOnly";
 }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.LogicalTree;
 using Avalonia.Styling;
+using FluentAvalonia.Core;
 using FluentAvalonia.UI.Input;
 using System;
 
@@ -17,11 +18,11 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
         base.OnPropertyChanged(change);
         if (change.Property == IconProperty)
         {
-            PseudoClasses.Set(":icon", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, change.NewValue != null);
         }
         else if (change.Property == LabelProperty)
         {
-            PseudoClasses.Set(":label", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcLabel, change.NewValue != null);
         }
         else if (change.Property == FlyoutProperty)
         {
@@ -36,22 +37,22 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
                 newFB.Closed += OnFlyoutClosed;
                 newFB.Opened += OnFlyoutOpened;
 
-                PseudoClasses.Set(":flyout", true);
-                PseudoClasses.Set(":submenuopen", newFB.IsOpen);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcFlyout, true);
+                PseudoClasses.Set(s_pcSubmenuOpen, newFB.IsOpen);
             }
             else
             {
-                PseudoClasses.Set(":flyout", false);
-                PseudoClasses.Set(":submenuopen", false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcFlyout, false);
+                PseudoClasses.Set(s_pcSubmenuOpen, false);
             }
         }
         else if (change.Property == HotKeyProperty)
         {
-            PseudoClasses.Set(":hotkey", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcHotkey, change.NewValue != null);
         }
         else if (change.Property == IsCompactProperty)
         {
-            PseudoClasses.Set(":compact", change.GetNewValue<bool>());
+            PseudoClasses.Set(SharedPseudoclasses.s_pcCompact, change.GetNewValue<bool>());
         }
         else if (change.Property == CommandProperty)
         {
@@ -117,11 +118,11 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
 
     private void OnFlyoutOpened(object sender, EventArgs e)
     {
-        PseudoClasses.Set(":submenuopen", true);
+        PseudoClasses.Set(s_pcSubmenuOpen, true);
     }
 
     private void OnFlyoutClosed(object sender, EventArgs e)
     {
-        PseudoClasses.Set(":submenuopen", false);
+        PseudoClasses.Set(s_pcSubmenuOpen, false);
     }
 }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.properties.cs
@@ -1,9 +1,14 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Styling;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(SharedPseudoclasses.s_pcIcon, SharedPseudoclasses.s_pcLabel, SharedPseudoclasses.s_pcCompact)]
+[PseudoClasses(SharedPseudoclasses.s_pcFlyout, s_pcSubmenuOpen, SharedPseudoclasses.s_pcOverflow)]
+[PseudoClasses(SharedPseudoclasses.s_pcHotkey)]
 public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
 {
     /// <summary>
@@ -51,7 +56,7 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
         {
             if (SetAndRaise(IsInOverflowProperty, ref _isInOverflow, value))
             {
-                PseudoClasses.Set(":overflow", value);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcOverflow, value);
             }
         }
     }
@@ -82,4 +87,6 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
 
     private bool _isInOverflow;
     private int _dynamicOverflowOrder;
+
+    private const string s_pcSubmenuOpen = ":submenuopen";
 }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarElementContainer.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarElementContainer.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Styling;
+using FluentAvalonia.Core;
 using System;
 
 namespace FluentAvalonia.UI.Controls;
@@ -9,6 +11,7 @@ namespace FluentAvalonia.UI.Controls;
 /// Represents a container that allows an element that doesn't implement ICommandBarElement 
 /// to be displayed in a command bar.
 /// </summary>
+[PseudoClasses(SharedPseudoclasses.s_pcOverflow)]
 public class CommandBarElementContainer : ContentControl, ICommandBarElement, IStyleable
 {
     Type IStyleable.StyleKey => typeof(CommandBarElementContainer);
@@ -46,7 +49,7 @@ public class CommandBarElementContainer : ContentControl, ICommandBarElement, IS
         {
             if (SetAndRaise(IsInOverflowProperty, ref _isInOverflow, value))
             {
-                PseudoClasses.Set(":overflow", value);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcOverflow, value);
             }
         }
     }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Styling;
 using System;
 using System.Collections;
@@ -14,6 +15,7 @@ namespace FluentAvalonia.UI.Controls;
 /// This class generally should not be used on your own and is meant for
 /// the template of a <see cref="CommandBar"/>
 /// </remarks>
+[PseudoClasses(s_pcIcons, s_pcToggle)]
 public class CommandBarOverflowPresenter : ItemsControl, IStyleable
 {
     Type IStyleable.StyleKey => typeof(CommandBarOverflowPresenter);
@@ -110,8 +112,8 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
                     _hasIcons--;
 
                 cbb.IsInOverflow = false;
-                ((IPseudoClasses)cbb.Classes).Set(s_iconClass, false);
-                ((IPseudoClasses)cbb.Classes).Set(s_toggleClass, false);
+                ((IPseudoClasses)cbb.Classes).Set(s_pcIcons, false);
+                ((IPseudoClasses)cbb.Classes).Set(s_pcToggle, false);
             }
             else if (l[i] is CommandBarToggleButton cbtb)
             {
@@ -121,14 +123,14 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
                     _hasIcons--;
 
                 cbtb.IsInOverflow = false;
-                ((IPseudoClasses)cbtb.Classes).Set(s_iconClass, false);
-                ((IPseudoClasses)cbtb.Classes).Set(s_toggleClass, false);
+                ((IPseudoClasses)cbtb.Classes).Set(s_pcIcons, false);
+                ((IPseudoClasses)cbtb.Classes).Set(s_pcToggle, false);
             }
             else if (l[i] is CommandBarElementContainer cont)
             {
                 cont.IsInOverflow = false;
-                ((IPseudoClasses)cont.Classes).Set(s_iconClass, false);
-                ((IPseudoClasses)cont.Classes).Set(s_toggleClass, false);
+                ((IPseudoClasses)cont.Classes).Set(s_pcIcons, false);
+                ((IPseudoClasses)cont.Classes).Set(s_pcToggle, false);
             }
             else if (l[i] is CommandBarSeparator sep)
             {
@@ -147,14 +149,14 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
         {
             if (items[i] is Control c && c.Classes is IPseudoClasses pc)
             {
-                pc.Set(s_iconClass, icon);
-                pc.Set(s_toggleClass, toggle);
+                pc.Set(s_pcIcons, icon);
+                pc.Set(s_pcToggle, toggle);
             }
         }
     }
 
     private int _hasIcons;
     private int _hasToggle;
-    private readonly string s_iconClass = ":icons";
-    private readonly string s_toggleClass = ":toggle";
+    private const string s_pcIcons = ":icons";
+    private const string s_pcToggle = ":toggle";
 }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarSeparator.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarSeparator.cs
@@ -1,9 +1,15 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
+/// <summary>
+/// Represents a separator in between items in a <see cref="CommandBar"/>
+/// </summary>
+[PseudoClasses(SharedPseudoclasses.s_pcOverflow)]
 public class CommandBarSeparator : TemplatedControl, ICommandBarElement
 {
     /// <summary>
@@ -39,7 +45,7 @@ public class CommandBarSeparator : TemplatedControl, ICommandBarElement
         {
             if (SetAndRaise(IsInOverflowProperty, ref _isInOverflow, value))
             {
-                PseudoClasses.Set(":overflow", value);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcOverflow, value);
             }
         }
     }

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.cs
@@ -5,6 +5,7 @@ using System;
 using Avalonia.Styling;
 using Avalonia.LogicalTree;
 using FluentAvalonia.UI.Input;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -20,19 +21,19 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
         base.OnPropertyChanged(change);
         if (change.Property == IconProperty)
         {
-            PseudoClasses.Set(":icon", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, change.NewValue != null);
         }
         else if (change.Property == LabelProperty)
         {
-            PseudoClasses.Set(":label", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcLabel, change.NewValue != null);
         }
         else if (change.Property == HotKeyProperty)
         {
-            PseudoClasses.Set(":hotkey", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcHotkey, change.NewValue != null);
         }
         else if (change.Property == IsCompactProperty)
         {
-            PseudoClasses.Set(":compact", change.GetNewValue<bool>());
+            PseudoClasses.Set(SharedPseudoclasses.s_pcCompact, change.GetNewValue<bool>());
         }
         else if (change.Property == CommandProperty)
         {

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.properties.cs
@@ -2,6 +2,7 @@
 using Avalonia;
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -52,7 +53,7 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
         {
             if (SetAndRaise(IsInOverflowProperty, ref _isInOverflow, value))
             {
-                PseudoClasses.Set(":overflow", value);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcOverflow, value);
             }
         }
     }

--- a/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyoutCommandBar.cs
+++ b/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyoutCommandBar.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Styling;
@@ -15,6 +16,7 @@ namespace FluentAvalonia.UI.Controls;
 /// This class should be treated as internal to FluentAvalonia and not used outside of 
 /// the CommandBarFlyout implementations.
 /// </remarks>
+[TemplatePart(s_tpMoreButton, typeof(Button))]
 public class CommandBarFlyoutCommandBar : CommandBar, IStyleable
 {
     Type IStyleable.StyleKey => typeof(CommandBarFlyoutCommandBar);
@@ -110,7 +112,7 @@ public class CommandBarFlyoutCommandBar : CommandBar, IStyleable
     {
         base.OnApplyTemplate(e);
 
-        _moreButton = e.NameScope.Find<Button>("MoreButton");
+        _moreButton = e.NameScope.Find<Button>(s_tpMoreButton);
 
         PopulateAccessibleControls();
     }
@@ -340,4 +342,6 @@ public class CommandBarFlyoutCommandBar : CommandBar, IStyleable
 
     private Button _moreButton;
     private CommandBarFlyout _owningFlyout;
+
+    private const string s_tpMoreButton = "MoreButton";
 }

--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -417,7 +417,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         // adorner to hide, then continue forward.
         Focus();
 
-        PseudoClasses.Set(s_pcHidden, true);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcHidden, true);
         PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, false);
         
         // Let the close animation finish (now 0.167s in new WinUI update...)

--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace FluentAvalonia.UI.Controls;
 
-[PseudoClasses(s_pcHidden, s_pcOpen)]
+[PseudoClasses(s_pcHidden, SharedPseudoclasses.s_pcOpen)]
 [PseudoClasses(s_pcPrimary, s_pcSecondary, s_pcClose)]
 [PseudoClasses(s_pcFullSize)]
 [TemplatePart(s_tpPrimaryButton, typeof(Button))]
@@ -271,7 +271,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     {
         IsVisible = true;
         PseudoClasses.Set(s_pcHidden, false);
-        PseudoClasses.Set(s_pcOpen, true);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, true);
 
         OnOpened();
     }
@@ -332,9 +332,9 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 if (!_primaryButton.IsVisible)
                     break;
 
-                _primaryButton.Classes.Add(s_cAccent);
-                _secondaryButton.Classes.Remove(s_cAccent);
-                _closeButton.Classes.Remove(s_cAccent);
+                _primaryButton.Classes.Add(SharedPseudoclasses.s_cAccent);
+                _secondaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
+                _closeButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
                 
                 if (setFocus)
                 {
@@ -350,9 +350,9 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 if (!_secondaryButton.IsVisible)
                     break;
 
-                _secondaryButton.Classes.Add(s_cAccent);
-                _primaryButton.Classes.Remove(s_cAccent);
-                _closeButton.Classes.Remove(s_cAccent);
+                _secondaryButton.Classes.Add(SharedPseudoclasses.s_cAccent);
+                _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
+                _closeButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
 
                 if (setFocus)
                 {
@@ -368,9 +368,9 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 if (!_closeButton.IsVisible)
                     break;
 
-                _closeButton.Classes.Add(s_cAccent);
-                _primaryButton.Classes.Remove(s_cAccent);
-                _secondaryButton.Classes.Remove(s_cAccent);
+                _closeButton.Classes.Add(SharedPseudoclasses.s_cAccent);
+                _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
+                _secondaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
 
                 if (setFocus)
                 {
@@ -383,9 +383,9 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 break;
 
             default:
-                _closeButton.Classes.Remove(s_cAccent);
-                _primaryButton.Classes.Remove(s_cAccent);
-                _secondaryButton.Classes.Remove(s_cAccent);
+                _closeButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
+                _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
+                _secondaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
 
                 if (setFocus)
                 {
@@ -425,7 +425,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         Focus();
 
         PseudoClasses.Set(s_pcHidden, true);
-        PseudoClasses.Set(s_pcOpen, false);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, false);
         
         // Let the close animation finish (now 0.167s in new WinUI update...)
         // We'll wait just a touch longer to be sure
@@ -611,10 +611,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     private const string s_tpSecondaryButton = "SecondaryButton";
     private const string s_tpCloseButton = "CloseButton";
 
-    internal const string s_cAccent = "accent"; // Internal for TaskDialog
-    private const string s_pcOpen = ":open";
     private const string s_pcHidden = ":hidden";
-
     private const string s_pcPrimary = ":primary";
     private const string s_pcSecondary = ":secondary";
     private const string s_pcClose = ":close";

--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -1,7 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -18,12 +17,6 @@ using System.Threading.Tasks;
 
 namespace FluentAvalonia.UI.Controls;
 
-[PseudoClasses(s_pcHidden, SharedPseudoclasses.s_pcOpen)]
-[PseudoClasses(s_pcPrimary, s_pcSecondary, s_pcClose)]
-[PseudoClasses(s_pcFullSize)]
-[TemplatePart(s_tpPrimaryButton, typeof(Button))]
-[TemplatePart(s_tpSecondaryButton, typeof(Button))]
-[TemplatePart(s_tpCloseButton, typeof(Button))]
 /// <summary>
 /// Presents a asyncronous dialog to the user.
 /// </summary>
@@ -31,7 +24,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
 {
     public ContentDialog()
     {
-        PseudoClasses.Add(s_pcHidden);
+        PseudoClasses.Add(SharedPseudoclasses.s_pcHidden);
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -270,7 +263,7 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     private void ShowCore()
     {
         IsVisible = true;
-        PseudoClasses.Set(s_pcHidden, false);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcHidden, false);
         PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, true);
 
         OnOpened();
@@ -606,14 +599,4 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     private Button _secondaryButton;
     private Button _closeButton;
     private bool _hasDeferralActive;
-
-    private const string s_tpPrimaryButton = "PrimaryButton";
-    private const string s_tpSecondaryButton = "SecondaryButton";
-    private const string s_tpCloseButton = "CloseButton";
-
-    private const string s_pcHidden = ":hidden";
-    private const string s_pcPrimary = ":primary";
-    private const string s_pcSecondary = ":secondary";
-    private const string s_pcClose = ":close";
-    private const string s_pcFullSize = ":fullsize";
 }

--- a/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.properties.cs
+++ b/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.properties.cs
@@ -3,9 +3,17 @@ using Avalonia;
 using FluentAvalonia.Core;
 using System;
 using System.Windows.Input;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(SharedPseudoclasses.s_pcHidden, SharedPseudoclasses.s_pcOpen)]
+[PseudoClasses(s_pcPrimary, s_pcSecondary, s_pcClose)]
+[PseudoClasses(s_pcFullSize)]
+[TemplatePart(s_tpPrimaryButton, typeof(Button))]
+[TemplatePart(s_tpSecondaryButton, typeof(Button))]
+[TemplatePart(s_tpCloseButton, typeof(Button))]
 public partial class ContentDialog
 {
     /// <summary>
@@ -353,4 +361,14 @@ public partial class ContentDialog
     /// Occurs after the close button has been tapped.
     /// </summary>
     public event TypedEventHandler<ContentDialog, ContentDialogButtonClickEventArgs> CloseButtonClick;
+
+
+    private const string s_tpPrimaryButton = "PrimaryButton";
+    private const string s_tpSecondaryButton = "SecondaryButton";
+    private const string s_tpCloseButton = "CloseButton";
+
+    private const string s_pcPrimary = ":primary";
+    private const string s_pcSecondary = ":secondary";
+    private const string s_pcClose = ":close";
+    private const string s_pcFullSize = ":fullsize";
 }

--- a/FluentAvalonia/UI/Controls/Flyouts/PickerFlyoutPresenter.cs
+++ b/FluentAvalonia/UI/Controls/Flyouts/PickerFlyoutPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using FluentAvalonia.Core;
@@ -10,11 +11,14 @@ namespace FluentAvalonia.UI.Controls;
 /// <summary>
 /// The FlyoutPresenter that is used within a <see cref="PickerFlyoutBase"/>
 /// </summary>
+[PseudoClasses(s_pcAcceptDismiss)]
+[TemplatePart(s_tpAcceptButton, typeof(Button))]
+[TemplatePart(s_tpDismissButton, typeof(Button))]
 public class PickerFlyoutPresenter : ContentControl
 {
     public PickerFlyoutPresenter()
     {
-        PseudoClasses.Add(":acceptdismiss");
+        PseudoClasses.Add(s_pcAcceptDismiss);
     }
 
     /// <summary>
@@ -40,12 +44,12 @@ public class PickerFlyoutPresenter : ContentControl
 
         base.OnApplyTemplate(e);
 
-        _acceptButton = e.NameScope.Find<Button>("AcceptButton");
+        _acceptButton = e.NameScope.Find<Button>(s_tpAcceptButton);
         if (_acceptButton != null)
         {
             _acceptButton.Click += OnAcceptClick;
         }
-        _dismissButton = e.NameScope.Find<Button>("DismissButton");
+        _dismissButton = e.NameScope.Find<Button>(s_tpDismissButton);
         if (_dismissButton != null)
         {
             _dismissButton.Click += OnDismissClick;
@@ -64,9 +68,13 @@ public class PickerFlyoutPresenter : ContentControl
 
     internal void ShowHideButtons(bool show)
     {
-        PseudoClasses.Set(":acceptdismiss", show);
+        PseudoClasses.Set(s_pcAcceptDismiss, show);
     }
 
     private Button _acceptButton;
     private Button _dismissButton;
+
+    private const string s_pcAcceptDismiss = ":acceptdismiss";
+    private const string s_tpAcceptButton = "AcceptButton";
+    private const string s_tpDismissButton = "DismissButton";
 }

--- a/FluentAvalonia/UI/Controls/Frame/Frame.cs
+++ b/FluentAvalonia/UI/Controls/Frame/Frame.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Logging;
@@ -19,6 +20,7 @@ namespace FluentAvalonia.UI.Controls;
 /// Displays <see cref="UserControl"/> instances (Pages in WinUI), supports navigation to new pages, 
 /// and maintains a navigation history to support forward and backward navigation.
 /// </summary>
+[TemplatePart(s_tpContentPresenter, typeof(ContentPresenter))]
 public partial class Frame : ContentControl
 {
     public Frame()
@@ -58,7 +60,7 @@ public partial class Frame : ContentControl
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
-        _presenter = e.NameScope.Find<ContentPresenter>("ContentPresenter");
+        _presenter = e.NameScope.Find<ContentPresenter>(s_tpContentPresenter);
     }
 
     /// <summary>
@@ -618,5 +620,7 @@ public partial class Frame : ContentControl
 
     private ContentPresenter _presenter;
     private readonly List<(Type pageSrcType, IControl page)> _cache = new List<(Type, IControl)>(10);
-    bool _isNavigating = false;
+    private bool _isNavigating = false;
+
+    private const string s_tpContentPresenter = "ContentPresenter";
 }

--- a/FluentAvalonia/UI/Controls/InfoBadge/InfoBadge.cs
+++ b/FluentAvalonia/UI/Controls/InfoBadge/InfoBadge.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using FluentAvalonia.Core;
 using System;
 
 namespace FluentAvalonia.UI.Controls;
@@ -59,29 +60,29 @@ public partial class InfoBadge : TemplatedControl
         var icoSource = IconSource;
         if (Value >= 0)
         {
-            PseudoClasses.Set(":value", true);
+            PseudoClasses.Set(s_pcValue, true);
 
-            PseudoClasses.Set(":fonticon", false);
-            PseudoClasses.Set(":icon", false);
-            PseudoClasses.Set(":dot", false);
+            PseudoClasses.Set(s_pcFontIcon, false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, false);
+            PseudoClasses.Set(s_pcDot, false);
         }
         else if (icoSource != null)
         {
             TemplateSettings.IconElement = IconHelpers.CreateFromUnknown(icoSource);
 
-            PseudoClasses.Set(":fonticon", icoSource is FontIconSource);
-            PseudoClasses.Set(":icon", icoSource is not FontIconSource);
+            PseudoClasses.Set(s_pcFontIcon, icoSource is FontIconSource);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, icoSource is not FontIconSource);
 
-            PseudoClasses.Set(":value", false);
-            PseudoClasses.Set(":dot", false);
+            PseudoClasses.Set(s_pcValue, false);
+            PseudoClasses.Set(s_pcDot, false);
         }
         else
         {
-            PseudoClasses.Set(":dot", true);
+            PseudoClasses.Set(s_pcDot, true);
 
-            PseudoClasses.Set(":value", false);
-            PseudoClasses.Set(":fonticon", false);
-            PseudoClasses.Set(":icon", false);
+            PseudoClasses.Set(s_pcValue, false);
+            PseudoClasses.Set(s_pcFontIcon, false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, false);
         }
     }
 

--- a/FluentAvalonia/UI/Controls/InfoBadge/InfoBadge.properties.cs
+++ b/FluentAvalonia/UI/Controls/InfoBadge/InfoBadge.properties.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -7,6 +9,7 @@ namespace FluentAvalonia.UI.Controls;
 /// Represents a control for indicating notifications, alerts, new content, 
 /// or to attract focus to an area within an app.
 /// </summary>
+[PseudoClasses(s_pcValue, s_pcFontIcon, SharedPseudoclasses.s_pcIcon, s_pcDot)]
 public partial class InfoBadge : TemplatedControl
 {
     /// <summary>
@@ -54,4 +57,8 @@ public partial class InfoBadge : TemplatedControl
         get => GetValue(TemplateSettingsProperty);
         internal set => SetValue(TemplateSettingsProperty, value);
     }
+
+    private const string s_pcValue = ":value";
+    private const string s_pcFontIcon = ":fonticon";
+    private const string s_pcDot = ":dot";
 }

--- a/FluentAvalonia/UI/Controls/InfoBar/InfoBar.cs
+++ b/FluentAvalonia/UI/Controls/InfoBar/InfoBar.cs
@@ -3,14 +3,13 @@ using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using FluentAvalonia.Core;
 using System;
 
 namespace FluentAvalonia.UI.Controls;
 
 public partial class InfoBar : ContentControl
-{
-    private const string SR_InfoBarCloseButtonTooltip = "InfoBarCloseButtonTooltip";
-
+{    
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         _appliedTemplate = false;
@@ -21,7 +20,7 @@ public partial class InfoBar : ContentControl
 
         base.OnApplyTemplate(e);
 
-        _closeButton = e.NameScope.Find<Button>("CloseButton");
+        _closeButton = e.NameScope.Find<Button>(s_tpCloseButton);
         if (_closeButton != null)
         {
             _closeButton.Click += OnCloseButtonClick;
@@ -124,12 +123,12 @@ public partial class InfoBar : ContentControl
                 if (IsOpen)
                 {
                     _isVisible = true;
-                    PseudoClasses.Set(":hidden", false);
+                    PseudoClasses.Set(SharedPseudoclasses.s_pcHidden, false);
                 }
                 else
                 {
                     _isVisible = false;
-                    PseudoClasses.Set(":hidden", true);
+                    PseudoClasses.Set(SharedPseudoclasses.s_pcHidden, true);
                 }
             }
         }
@@ -143,31 +142,31 @@ public partial class InfoBar : ContentControl
         switch (Severity)
         {
             case InfoBarSeverity.Success:
-                PseudoClasses.Set(":success", true);
-                PseudoClasses.Set(":warning", false);
-                PseudoClasses.Set(":error", false);
-                PseudoClasses.Set(":informational", false);
+                PseudoClasses.Set(s_pcSuccess, true);
+                PseudoClasses.Set(s_pcWarning, false);
+                PseudoClasses.Set(s_pcError, false);
+                PseudoClasses.Set(s_pcInformational, false);
                 break;
 
             case InfoBarSeverity.Warning:
-                PseudoClasses.Set(":success", false);
-                PseudoClasses.Set(":warning", true);
-                PseudoClasses.Set(":error", false);
-                PseudoClasses.Set(":informational", false);
+                PseudoClasses.Set(s_pcSuccess, false);
+                PseudoClasses.Set(s_pcWarning, true);
+                PseudoClasses.Set(s_pcError, false);
+                PseudoClasses.Set(s_pcInformational, false);
                 break;
 
             case InfoBarSeverity.Error:
-                PseudoClasses.Set(":success", false);
-                PseudoClasses.Set(":warning", false);
-                PseudoClasses.Set(":error", true);
-                PseudoClasses.Set(":informational", false);
+                PseudoClasses.Set(s_pcSuccess, false);
+                PseudoClasses.Set(s_pcWarning, false);
+                PseudoClasses.Set(s_pcError, true);
+                PseudoClasses.Set(s_pcInformational, false);
                 break;
 
             default: // default to informational
-                PseudoClasses.Set(":success", false);
-                PseudoClasses.Set(":warning", false);
-                PseudoClasses.Set(":error", false);
-                PseudoClasses.Set(":informational", true);
+                PseudoClasses.Set(s_pcSuccess, false);
+                PseudoClasses.Set(s_pcWarning, false);
+                PseudoClasses.Set(s_pcError, false);
+                PseudoClasses.Set(s_pcInformational, true);
                 break;
         }
     }
@@ -182,25 +181,25 @@ public partial class InfoBar : ContentControl
     {
         if (!IsIconVisible)
         {
-            PseudoClasses.Set(":icon", false);
-            PseudoClasses.Set(":standardIcon", false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, false);
+            PseudoClasses.Set(s_pcStandardIcon, false);
         }
         else
         {
             bool hasUserIcon = IconSource != null;
-            PseudoClasses.Set(":icon", hasUserIcon);
-            PseudoClasses.Set(":standardIcon", !hasUserIcon);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, hasUserIcon);
+            PseudoClasses.Set(s_pcStandardIcon, !hasUserIcon);
         }
     }
 
     private void UpdateCloseButton()
     {
-        PseudoClasses.Set(":closehidden", !IsClosable);
+        PseudoClasses.Set(s_pcCloseHidden, !IsClosable);
     }
 
     private void UpdateForeground()
     {
-        PseudoClasses.Set(":foregroundset", this.GetValue(TextElement.ForegroundProperty) != AvaloniaProperty.UnsetValue);
+        PseudoClasses.Set(s_pcForegroundSet, this.GetValue(TextElement.ForegroundProperty) != AvaloniaProperty.UnsetValue);
     }
 
     private Button _closeButton;

--- a/FluentAvalonia/UI/Controls/InfoBar/InfoBar.properties.cs
+++ b/FluentAvalonia/UI/Controls/InfoBar/InfoBar.properties.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using FluentAvalonia.Core;
 using System.Windows.Input;
 
@@ -11,6 +12,11 @@ namespace FluentAvalonia.UI.Controls;
 /// or float on top of it. It supports rich content (including titles, messages, icons, and buttons) 
 /// and can be configured to be user-dismissable or persistent.
 /// </summary>
+[PseudoClasses(SharedPseudoclasses.s_pcHidden, s_pcCloseHidden)]
+[PseudoClasses(s_pcSuccess, s_pcWarning, s_pcError, s_pcInformational)]
+[PseudoClasses(SharedPseudoclasses.s_pcIcon, s_pcStandardIcon)]
+[PseudoClasses(s_pcForegroundSet)]
+[TemplatePart(s_tpCloseButton, typeof(Button))]
 public partial class InfoBar : ContentControl
 {
     /// <summary>
@@ -182,4 +188,16 @@ public partial class InfoBar : ContentControl
 
 
     private bool _isOpen;
+
+    private const string SR_InfoBarCloseButtonTooltip = "InfoBarCloseButtonTooltip";
+
+    private const string s_tpCloseButton = "CloseButton";
+
+    private const string s_pcSuccess = ":success";
+    private const string s_pcWarning = ":warning";
+    private const string s_pcError = ":error";
+    private const string s_pcInformational = ":informational";
+    private const string s_pcStandardIcon = ":standardIcon";
+    private const string s_pcCloseHidden = ":closehidden";
+    private const string s_pcForegroundSet = ":foregroundset";
 }

--- a/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Controls.Generators;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -13,6 +14,7 @@ namespace FluentAvalonia.UI.Controls;
 /// <summary>
 /// Displays the content of a <see cref="FAMenuFlyout"/> control.
 /// </summary>
+[PseudoClasses(s_pcIcons, s_pcToggle)]
 public class FAMenuFlyoutPresenter : MenuBase, IStyleable
 {
     public FAMenuFlyoutPresenter()
@@ -24,7 +26,7 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
     public FAMenuFlyoutPresenter(IMenuInteractionHandler handler)
         : base(handler) { }
 
-    Type IStyleable.StyleKey => typeof(Avalonia.Controls.MenuFlyoutPresenter);
+    Type IStyleable.StyleKey => typeof(MenuFlyoutPresenter);
 
     /// <summary>
     /// Closes the MenuFlyout.
@@ -194,17 +196,18 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
         // v2 Change: ControlThemes means we can't use styling on the MFP to apply the 
         // Icon/Toggle adjustments and we have to put them directly on the items
 
-        const string iconClass = ":icons";
-        const string toggleClass = ":toggle";
         bool icon = _iconCount > 0;
         bool toggle = _toggleCount > 0;
         foreach (var item in ItemContainerGenerator.Containers)
         {
-            ((IPseudoClasses)item.ContainerControl.Classes).Set(iconClass, icon);
-            ((IPseudoClasses)item.ContainerControl.Classes).Set(toggleClass, toggle);
+            ((IPseudoClasses)item.ContainerControl.Classes).Set(s_pcIcons, icon);
+            ((IPseudoClasses)item.ContainerControl.Classes).Set(s_pcToggle, toggle);
         }
     }
 
     private int _iconCount = 0;
     private int _toggleCount = 0;
+
+    private const string s_pcIcons = ":icons";
+    private const string s_pcToggle = ":toggle";
 }

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -1,8 +1,10 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using FluentAvalonia.Core;
 using FluentAvalonia.UI.Input;
 using System;
 using System.Windows.Input;
@@ -116,7 +118,7 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
         }
         else if (change.Property == InputGestureProperty)
         {
-            PseudoClasses.Set(":hotkey", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcHotkey, change.NewValue != null);
         }
         else if (change.Property == HotKeyProperty)
         {
@@ -130,7 +132,7 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
         base.OnPointerPressed(e);
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            PseudoClasses.Set(":pressed", true);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, true);
         }
     }
 
@@ -139,7 +141,7 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
         base.OnPointerReleased(e);
         if (e.InitialPressMouseButton == MouseButton.Left)
         {
-            PseudoClasses.Set(":pressed", false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
         }
     }
 

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
@@ -6,9 +6,13 @@ using Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Windows.Input;
+using Avalonia.Controls.Metadata;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(SharedPseudoclasses.s_pcHotkey)]
+[PseudoClasses(SharedPseudoclasses.s_pcPressed)]
 public partial class MenuFlyoutItem
 {
     /// <summary>

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
@@ -93,12 +93,12 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
 
     private void OnPopupOpen(object sender, EventArgs e)
     {
-        PseudoClasses.Set(":submenuopen", true);
+        PseudoClasses.Set(s_pcSubmenuOpen, true);
     }
 
     private void OnPopupClose(object sender, EventArgs e)
     {
-        PseudoClasses.Set(":submenuopen", false);
+        PseudoClasses.Set(s_pcSubmenuOpen, false);
     }
 
     bool IMenuElement.MoveSelection(NavigationDirection direction, bool wrap) => false;

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Templates;
 using Avalonia.Metadata;
 using System.Collections;
@@ -8,6 +9,7 @@ using System.Linq;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(s_pcSubmenuOpen)]
 public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
 {
     /// <summary>
@@ -120,4 +122,6 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     bool IMenuItem.StaysOpenOnClick { get => false; set { } }
 
     private IEnumerable _items;
+
+    private const string s_pcSubmenuOpen = ":submenuopen";
 }

--- a/FluentAvalonia/UI/Controls/MenuFlyout/RadioMenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/RadioMenuFlyoutItem.cs
@@ -4,12 +4,15 @@ using Avalonia;
 using System;
 using System.Collections.Generic;
 using Avalonia.Data;
+using Avalonia.Controls.Metadata;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
 /// <summary>
 /// Represents a menu item that is mutually exclusive with other radio menu items in its group.
 /// </summary>
+[PseudoClasses(SharedPseudoclasses.s_pcChecked)]
 public class RadioMenuFlyoutItem : MenuFlyoutItem, IStyleable
 {
     static RadioMenuFlyoutItem()
@@ -64,7 +67,7 @@ public class RadioMenuFlyoutItem : MenuFlyoutItem, IStyleable
         if (change.Property == IsCheckedProperty)
         {
             var newValue = change.GetNewValue<bool>();
-            PseudoClasses.Set(":checked", newValue);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcChecked, newValue);
 
             if (_isSafeUncheck) // Unchecked via another item in the group
                 return;

--- a/FluentAvalonia/UI/Controls/MenuFlyout/ToggleMenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/ToggleMenuFlyoutItem.cs
@@ -3,6 +3,8 @@ using Avalonia.Data;
 using Avalonia.Styling;
 using Avalonia;
 using System;
+using Avalonia.Controls.Metadata;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -10,6 +12,7 @@ namespace FluentAvalonia.UI.Controls;
 /// Represents an item in a <see cref="FAMenuFlyout"/> that a user can change 
 /// between two states, checked or unchecked.
 /// </summary>
+[PseudoClasses(SharedPseudoclasses.s_pcChecked)]
 public class ToggleMenuFlyoutItem : MenuFlyoutItem, IStyleable
 {
     /// <summary>
@@ -35,7 +38,7 @@ public class ToggleMenuFlyoutItem : MenuFlyoutItem, IStyleable
         base.OnPropertyChanged(change);
         if (change.Property == IsCheckedProperty)
         {
-            PseudoClasses.Set(":checked", change.GetNewValue<bool>());
+            PseudoClasses.Set(SharedPseudoclasses.s_pcChecked, change.GetNewValue<bool>());
         }
     }
 

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.cs
@@ -1,12 +1,12 @@
 ﻿using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
-using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls.Primitives;
 using System;
 using System.Collections.Specialized;
@@ -18,7 +18,6 @@ namespace FluentAvalonia.UI.Controls;
 /// <summary>
 /// Represents the container for an item in a NavigationView control.
 /// </summary>
-[PseudoClasses(":leftnav", ":topnav", ":topoverflow")]
 public partial class NavigationViewItem : NavigationViewItemBase
 {
     public NavigationViewItem()
@@ -64,10 +63,10 @@ public partial class NavigationViewItem : NavigationViewItemBase
         UnhookEventsAndClearFields();
 
         base.OnApplyTemplate(e);
-        var x = this.Content;
-        _presenter = e.NameScope.Find<NavigationViewItemPresenter>("NVIPresenter");
 
-        _rootGrid = e.NameScope.Find<Grid>("NVIRootGrid");
+        _presenter = e.NameScope.Find<NavigationViewItemPresenter>(s_tpNVIPresenter);
+
+        _rootGrid = e.NameScope.Find<Grid>(s_tpNVIRootGrid);
         if (_rootGrid != null)
         {
             var flyout = FlyoutBase.GetAttachedFlyout(_rootGrid);
@@ -105,7 +104,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
         //var navView = GetNavigationView;
         if (navView != null)
         {
-            _repeater = e.NameScope.Find<ItemsRepeater>("NVIMenuItemsHost");
+            _repeater = e.NameScope.Find<ItemsRepeater>(s_tpNVIMenuItemsHost);
             if (_repeater != null)
             {
                 (_repeater.Layout as StackLayout).DisableVirtualization = true;
@@ -119,7 +118,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
             UpdateRepeaterItemsSource();
         }
 
-        _flyoutContentGrid = e.NameScope.Find<Panel>("FlyoutContentGrid");
+        _flyoutContentGrid = e.NameScope.Find<Panel>(s_tpFlyoutContentGrid);
 
         _appliedTemplate = true;
 
@@ -309,9 +308,9 @@ public partial class NavigationViewItem : NavigationViewItemBase
         if (_presenter != null)
         {
             //Possible states :iconleft, :icononly, :contentonly
-            ((IPseudoClasses)_presenter.Classes).Set(":iconleft", showIcon && showContent);
-            ((IPseudoClasses)_presenter.Classes).Set(":icononly", showIcon && !showContent);
-            ((IPseudoClasses)_presenter.Classes).Set(":contentonly", !showIcon);
+            ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcIconLeft, showIcon && showContent);
+            ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcIconOnly, showIcon && !showContent);
+            ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcContentOnly, !showIcon);
         }
     }
 
@@ -323,43 +322,43 @@ public partial class NavigationViewItem : NavigationViewItemBase
         {
             case NavigationViewRepeaterPosition.LeftNav:
             case NavigationViewRepeaterPosition.LeftFooter:
-                PseudoClasses.Set(":leftnav", true);
-                PseudoClasses.Set(":topnav", false);
-                PseudoClasses.Set(":topoverflow", false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcLeftNav, true);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcTopNav, false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcTopOverflow, false);
 
                 if (_presenter != null)
                 {
-                    ((IPseudoClasses)_presenter.Classes).Set(":leftnav", true);
-                    ((IPseudoClasses)_presenter.Classes).Set(":topnav", false);
-                    ((IPseudoClasses)_presenter.Classes).Set(":topoverflow", false);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcLeftNav, true);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcTopNav, false);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcTopOverflow, false);
                 }
 
                 break;
 
             case NavigationViewRepeaterPosition.TopPrimary:
             case NavigationViewRepeaterPosition.TopFooter:
-                PseudoClasses.Set(":leftnav", false);
-                PseudoClasses.Set(":topnav", true);
-                PseudoClasses.Set(":topoverflow", false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcLeftNav, false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcTopNav, true);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcTopOverflow, false);
 
                 if (_presenter != null)
                 {
-                    ((IPseudoClasses)_presenter.Classes).Set(":leftnav", false);
-                    ((IPseudoClasses)_presenter.Classes).Set(":topnav", true);
-                    ((IPseudoClasses)_presenter.Classes).Set(":topoverflow", false);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcLeftNav, false);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcTopNav, true);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcTopOverflow, false);
                 }
                 break;
 
             case NavigationViewRepeaterPosition.TopOverflow:
-                PseudoClasses.Set(":leftnav", false);
-                PseudoClasses.Set(":topnav", false);
-                PseudoClasses.Set(":topoverflow", true);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcLeftNav, false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcTopNav, false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcTopOverflow, true);
 
                 if (_presenter != null)
                 {
-                    ((IPseudoClasses)_presenter.Classes).Set(":leftnav", false);
-                    ((IPseudoClasses)_presenter.Classes).Set(":topnav", false);
-                    ((IPseudoClasses)_presenter.Classes).Set(":topoverflow", true);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcLeftNav, false);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcTopNav, false);
+                    ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcTopOverflow, true);
                 }
                 break;
         }
@@ -379,7 +378,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
 
         if (_presenter != null)
         {
-            ((IPseudoClasses)_presenter.Classes).Set(":selected", IsSelected);
+            ((IPseudoClasses)_presenter.Classes).Set(s_pcSelected, IsSelected);
         }
 
         UpdateVisualStateForNavigationViewPositionChange();
@@ -393,7 +392,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
             {
                 //This is supposed to be for backwards compatibility with RS4-, but
                 //is apparently still used in the NVIPresenterWhenOnLeftPane style
-                ((IPseudoClasses)_presenter.Classes).Set(":iconcollapsed", !showIcon);
+                ((IPseudoClasses)_presenter.Classes).Set(s_pcIconCollapsed, !showIcon);
                 //Only using IconCollapsed, IconVisible is default
             }
         }
@@ -401,7 +400,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
         {
             if (_presenter != null)
             {
-                ((IPseudoClasses)_presenter.Classes).Set(":iconcollapsed", false);
+                ((IPseudoClasses)_presenter.Classes).Set(s_pcIconCollapsed, false);
             }
         }
 
@@ -429,9 +428,9 @@ public partial class NavigationViewItem : NavigationViewItemBase
 
             if (_presenter != null)
             {
-                ((IPseudoClasses)_presenter.Classes).Set(":chevronopen", show && expand);
-                ((IPseudoClasses)_presenter.Classes).Set(":chevronclosed", show & !expand);
-                ((IPseudoClasses)_presenter.Classes).Set(":chevronhidden", !show);
+                ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcChevronOpen, show && expand);
+                ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcChevronClosed, show & !expand);
+                ((IPseudoClasses)_presenter.Classes).Set(SharedPseudoclasses.s_pcChevronHidden, !show);
             }
         }
     }
@@ -565,7 +564,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
     private void UpdateVisualStateForInfoBadge()
     {
         if (_presenter != null)
-            ((IPseudoClasses)_presenter.Classes).Set(":infobadge", InfoBadge != null);
+            ((IPseudoClasses)_presenter.Classes).Set(s_pcInfoBadge, InfoBadge != null);
     }
 
     public override string ToString()

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.properties.cs
@@ -3,9 +3,20 @@ using Avalonia;
 using FluentAvalonia.UI.Controls.Primitives;
 using System.Collections;
 using FluentAvalonia.Core;
+using Avalonia.Controls.Metadata;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(SharedPseudoclasses.s_pcLeftNav, SharedPseudoclasses.s_pcTopNav, SharedPseudoclasses.s_pcTopOverflow)]
+[PseudoClasses(SharedPseudoclasses.s_pcIconLeft, SharedPseudoclasses.s_pcIconOnly, SharedPseudoclasses.s_pcContentOnly)]
+[PseudoClasses(s_pcSelected)]
+[PseudoClasses(s_pcIconCollapsed)]
+[PseudoClasses(SharedPseudoclasses.s_pcChevronClosed, SharedPseudoclasses.s_pcChevronOpen, SharedPseudoclasses.s_pcChevronHidden)]
+[PseudoClasses(s_pcInfoBadge)]
+[TemplatePart(s_tpFlyoutContentGrid, typeof(Panel))]
+[TemplatePart(s_tpNVIPresenter, typeof(NavigationViewItemPresenter))]
+[TemplatePart(s_tpNVIRootGrid, typeof(Grid))]
+[TemplatePart(s_tpNVIMenuItemsHost, typeof(ItemsRepeater))]
 public partial class NavigationViewItem
 {
     /// <summary>
@@ -181,4 +192,13 @@ public partial class NavigationViewItem
     private bool _isExpanded;
     private IEnumerable _menuItems;
     private bool _selectsOnInvoked = true;
+
+    private const string s_tpNVIPresenter = "NVIPresenter";
+    private const string s_tpNVIRootGrid = "NVIRootGrid";
+    private const string s_tpNVIMenuItemsHost = "NVIMenuItemsHost";
+    private const string s_tpFlyoutContentGrid = "FlyoutContentGrid";
+        
+    private const string s_pcSelected = ":selected";
+    private const string s_pcIconCollapsed = ":iconcollapsed";
+    private const string s_pcInfoBadge = ":infobadge";
 }

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemHeader.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemHeader.cs
@@ -10,7 +10,9 @@ namespace FluentAvalonia.UI.Controls;
 /// <summary>
 /// Represents a header for a group of menu items in a NavigationMenu.
 /// </summary>
-[PseudoClasses(":headertextcollapsed", ":headertextvisible")]
+[PseudoClasses(s_pcHeaderTextCollapsed, s_pcHeaderTextVisible)]
+[PseudoClasses(s_pcTopMode)]
+[TemplatePart(s_tpRootGrid, typeof(Grid))]
 public class NavigationViewItemHeader : NavigationViewItemBase
 {
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -29,7 +31,7 @@ public class NavigationViewItemHeader : NavigationViewItemBase
             UpdateIsClosedCompact();
         }
 
-        _rootGrid = e.NameScope.Find<Grid>("RootGrid");
+        _rootGrid = e.NameScope.Find<Grid>(s_tpRootGrid);
 
         UpdateVisualState();
         UpdateItemIndentation();
@@ -65,13 +67,13 @@ public class NavigationViewItemHeader : NavigationViewItemBase
     {
         //states :headertextcollapsed, :headertextvisible
         bool collapsed = _isClosedCompact && IsTopLevelItem;
-        PseudoClasses.Set(":headertextcollapsed", collapsed);
-        PseudoClasses.Set(":headertextvisible", !collapsed);
+        PseudoClasses.Set(s_pcHeaderTextCollapsed, collapsed);
+        PseudoClasses.Set(s_pcHeaderTextVisible, !collapsed);
 
         var navView = GetNavigationView;
         if (navView != null)
         {
-            PseudoClasses.Set(":topmode", navView.PaneDisplayMode == NavigationViewPaneDisplayMode.Top);
+            PseudoClasses.Set(s_pcTopMode, navView.PaneDisplayMode == NavigationViewPaneDisplayMode.Top);
         }
     }
 
@@ -88,4 +90,10 @@ public class NavigationViewItemHeader : NavigationViewItemBase
     private IDisposable _splitViewRevokers;
     private Grid _rootGrid;
     private bool _isClosedCompact;
+
+    private const string s_tpRootGrid = "RootGrid";
+
+    private const string s_pcTopMode = ":topmode";
+    private const string s_pcHeaderTextVisible = ":headertextvisible";
+    private const string s_pcHeaderTextCollapsed = ":headertextcollapsed";
 }

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.cs
@@ -1,20 +1,16 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls.Primitives;
 
 /// <summary>
 /// Represents the visual elements of a NavigationViewItem.
 /// </summary>
-[PseudoClasses(":expanded")]
-[PseudoClasses(":closedcompacttop", ":notclosedcompacttop")]
-[PseudoClasses(":leftnav", ":topnav", ":topoverflow")]
-[PseudoClasses(":chevronopen", ":chevronclosed", ":chevronhidden")]
-[PseudoClasses(":iconleft", ":icononly", ":contentonly")]
+
 public partial class NavigationViewItemPresenter : ContentControl
 {
     public NavigationViewItemPresenter()
@@ -26,17 +22,17 @@ public partial class NavigationViewItemPresenter : ContentControl
     {
         base.OnApplyTemplate(e);
 
-        _selectionIndicator = e.NameScope.Find<Border>("SelectionIndicator");
+        _selectionIndicator = e.NameScope.Find<Border>(s_tpSelectionIndicator);
 
         //This doesn't exist in the TopPane template, so use Find and allow it to be null
-        _contentGrid = e.NameScope.Find<Panel>("PresenterContentRootGrid");
+        _contentGrid = e.NameScope.Find<Panel>(s_tpPresenterContentRootGrid);
 
-        _infoBadgePresenter = e.NameScope.Find<ContentPresenter>("InfoBadgePresenter");
+        _infoBadgePresenter = e.NameScope.Find<ContentPresenter>(s_tpInfoBadgePresenter);
 
         var nvi = GetNVI;
         if (nvi != null)
         {
-            _expandCollapseChevron = e.NameScope.Find<Panel>("ExpandCollapseChevron");
+            _expandCollapseChevron = e.NameScope.Find<Panel>(s_tpExpandCollapseChevron);
 
             if (_expandCollapseChevron != null)
             {
@@ -63,7 +59,7 @@ public partial class NavigationViewItemPresenter : ContentControl
         base.OnPointerPressed(e);
         if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
-            PseudoClasses.Set(":pressed", true);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, true);
         }
     }
 
@@ -73,19 +69,19 @@ public partial class NavigationViewItemPresenter : ContentControl
         if (e.GetCurrentPoint(this).Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased
             && e.InitialPressMouseButton == MouseButton.Left)
         {
-            PseudoClasses.Set(":pressed", false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
         }
     }
 
     protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
     {
         base.OnPointerCaptureLost(e);
-        PseudoClasses.Set(":pressed", false);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
     }
 
     internal void RotateExpandCollapseChevron(bool isExpanded)
     {
-        PseudoClasses.Set(":expanded", isExpanded);
+        PseudoClasses.Set(s_pcExpanded, isExpanded);
     }
 
     internal void UpdateContentLeftIndentation(double leftIndent)
@@ -124,8 +120,8 @@ public partial class NavigationViewItemPresenter : ContentControl
 
         //states :closedcompacttop, :notclosedcompacttop
 
-        PseudoClasses.Set(":closedcompacttop", isClosedCompact && topLevel);
-        PseudoClasses.Set(":notclosedcompacttop", !isClosedCompact && topLevel);
+        PseudoClasses.Set(s_pcClosedCompactTop, isClosedCompact && topLevel);
+        PseudoClasses.Set(s_pcNotClosedCompactTop, !isClosedCompact && topLevel);
     }
 
     private Panel _contentGrid;

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.properties.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.properties.cs
@@ -1,9 +1,17 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.VisualTree;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls.Primitives;
 
+[PseudoClasses(s_pcExpanded)]
+[PseudoClasses(s_pcClosedCompactTop, s_pcNotClosedCompactTop)]
+[PseudoClasses(SharedPseudoclasses.s_pcLeftNav, SharedPseudoclasses.s_pcTopNav, SharedPseudoclasses.s_pcTopOverflow)]
+[PseudoClasses(SharedPseudoclasses.s_pcChevronOpen, SharedPseudoclasses.s_pcChevronClosed, SharedPseudoclasses.s_pcChevronHidden)]
+[PseudoClasses(SharedPseudoclasses.s_pcIconLeft, SharedPseudoclasses.s_pcIconOnly, SharedPseudoclasses.s_pcContentOnly)]
+[PseudoClasses(SharedPseudoclasses.s_pcPressed)]
 public partial class NavigationViewItemPresenter
 {
     /// <summary>
@@ -60,4 +68,13 @@ public partial class NavigationViewItemPresenter
     }
 
     internal IControl SelectionIndicator => _selectionIndicator;
+
+    private const string s_tpSelectionIndicator = "SelectionIndicator";
+    private const string s_tpPresenterContentRootGrid = "PresenterContentRootGrid";
+    private const string s_tpInfoBadgePresenter = "InfoBadgePresenter";
+    private const string s_tpExpandCollapseChevron = "ExpandCollapseChevron";
+
+    private const string s_pcClosedCompactTop = ":closedcompacttop";
+    private const string s_pcNotClosedCompactTop = ":notclosedcompacttop";
+    private const string s_pcExpanded = ":expanded";
 }

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemSeparator.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemSeparator.cs
@@ -10,7 +10,8 @@ namespace FluentAvalonia.UI.Controls;
 /// <summary>
 /// Represents a line that separates menu items in a NavigationView.
 /// </summary>
-[PseudoClasses(":horizontal", ":horizontalcompact", ":vertical")]
+[PseudoClasses(s_pcHorizontal, s_pcHorizontalCompact, s_pcVertical)]
+[TemplatePart(s_tpRootGrid, typeof(Panel))]
 public class NavigationViewItemSeparator : NavigationViewItemBase
 {
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -21,7 +22,7 @@ public class NavigationViewItemSeparator : NavigationViewItemBase
 
         base.OnApplyTemplate(e);
 
-        _rootGrid = e.NameScope.Find<Panel>("RootGrid");
+        _rootGrid = e.NameScope.Find<Panel>(s_tpRootGrid);
 
         var splitView = GetSplitView;
         if (splitView != null)
@@ -61,9 +62,9 @@ public class NavigationViewItemSeparator : NavigationViewItemBase
         //States: :horizontalcompact, :horizontal, :vertical
         bool isTop = Position == NavigationViewRepeaterPosition.TopFooter || Position == NavigationViewRepeaterPosition.TopPrimary;
 
-        PseudoClasses.Set(":horizontal", !isTop && !_isClosedCompact);
-        PseudoClasses.Set(":horizontalcompact", !isTop && _isClosedCompact);
-        PseudoClasses.Set(":vertical", isTop);
+        PseudoClasses.Set(s_pcHorizontal, !isTop && !_isClosedCompact);
+        PseudoClasses.Set(s_pcHorizontalCompact, !isTop && _isClosedCompact);
+        PseudoClasses.Set(s_pcVertical, isTop);
     }
 
     private void UpdateItemIndentation()
@@ -93,4 +94,10 @@ public class NavigationViewItemSeparator : NavigationViewItemBase
     private bool _appliedTemplate;
     private bool _isClosedCompact;
     private Panel _rootGrid;
+
+    private const string s_tpRootGrid = "RootGrid";
+
+    private const string s_pcHorizontal = ":horizontal";
+    private const string s_pcHorizontalCompact = ":horizontalcompact";
+    private const string s_pcVertical = ":vertical";
 }

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -75,7 +75,7 @@ public partial class NavigationView : HeaderedContentControl
 
             base.OnApplyTemplate(e);
 
-            _paneToggleButton = e.NameScope.Get<Button>("TogglePaneButton");
+            _paneToggleButton = e.NameScope.Get<Button>(s_tpTogglePaneButton);
             if (_paneToggleButton != null)
             {
                 _paneToggleButton.Click += OnPaneToggleButtonClick;
@@ -85,15 +85,15 @@ public partial class NavigationView : HeaderedContentControl
                 //KeyboardAccelerator Win+Back
             }
 
-            _leftNavPaneHeaderContentBorder = e.NameScope.Get<ContentControl>("PaneHeaderContentBorder");
-            _leftNavPaneCustomContentBorder = e.NameScope.Get<ContentControl>("PaneCustomContentBorder");
-            _leftNavFooterContentBorder = e.NameScope.Get<ContentControl>("FooterContentBorder");
-            _paneHeaderOnTopPane = e.NameScope.Get<ContentControl>("PaneHeaderOnTopPane");
-            _paneTitleOnTopPane = e.NameScope.Get<ContentControl>("PaneTitleOnTopPane");
-            _paneCustomContentOnTopPane = e.NameScope.Get<ContentControl>("PaneCustomContentOnTopPane");
-            _paneFooterOnTopPane = e.NameScope.Get<ContentControl>("PaneFooterOnTopPane");
+            _leftNavPaneHeaderContentBorder = e.NameScope.Get<ContentControl>(s_tpPaneHeaderContentBorder);
+            _leftNavPaneCustomContentBorder = e.NameScope.Get<ContentControl>(s_tpPaneCustomContentBorder);
+            _leftNavFooterContentBorder = e.NameScope.Get<ContentControl>(s_tpFooterContentBorder);
+            _paneHeaderOnTopPane = e.NameScope.Get<ContentControl>(s_tpPaneHeaderOnTopPane);
+            _paneTitleOnTopPane = e.NameScope.Get<ContentControl>(s_tpPaneTitleOnTopPane);
+            _paneCustomContentOnTopPane = e.NameScope.Get<ContentControl>(s_tpPaneCustomContentOnTopPane);
+            _paneFooterOnTopPane = e.NameScope.Get<ContentControl>(s_tpPaneFooterOnTopPane);
 
-            _splitView = e.NameScope.Get<SplitView>("RootSplitView");
+            _splitView = e.NameScope.Get<SplitView>(s_tpRootSplitView);
             if (_splitView != null)
             {
                 _splitViewRevokers = new CompositeDisposable(
@@ -108,10 +108,10 @@ public partial class NavigationView : HeaderedContentControl
                 UpdateIsClosedCompact();
             }
 
-            _topNavGrid = e.NameScope.Get<Grid>("TopNavGrid");
+            _topNavGrid = e.NameScope.Get<Grid>(s_tpTopNavGrid);
 
             // (WinUI) Change code to NOT do this if we're in top nav mode, to prevent it from being realized:
-            _leftNavRepeater = e.NameScope.Get<ItemsRepeater>("MenuItemsHost");
+            _leftNavRepeater = e.NameScope.Get<ItemsRepeater>(s_tpMenuItemsHost);
             if (_leftNavRepeater != null)
             {
                 // Disabling virtualization for now because of https://github.com/microsoft/microsoft-ui-xaml/issues/2095
@@ -127,7 +127,7 @@ public partial class NavigationView : HeaderedContentControl
             }
 
             // (WinUI) Change code to NOT do this if we're in left nav mode, to prevent it from being realized:
-            _topNavRepeater = e.NameScope.Get<ItemsRepeater>("TopNavMenuItemsHost");
+            _topNavRepeater = e.NameScope.Get<ItemsRepeater>(s_tpTopNavMenuItemsHost);
             if (_topNavRepeater != null)
             {
                 // Disabling virtualization for now because of https://github.com/microsoft/microsoft-ui-xaml/issues/2095
@@ -143,7 +143,7 @@ public partial class NavigationView : HeaderedContentControl
             }
 
             //TODO: This may not be found b/c its in the button flyout
-            _topNavRepeaterOverflowView = e.NameScope.Get<ItemsRepeater>("TopNavMenuItemsOverflowHost");
+            _topNavRepeaterOverflowView = e.NameScope.Get<ItemsRepeater>(s_tpTopNavMenuItemsOverflowHost);
             if (_topNavRepeaterOverflowView != null)
             {
                 // Disabling virtualization for now because of https://github.com/microsoft/microsoft-ui-xaml/issues/2095
@@ -155,7 +155,7 @@ public partial class NavigationView : HeaderedContentControl
                 _topNavRepeater.ItemTemplate = _itemsFactory;
             }
 
-            _topNavOverflowButton = e.NameScope.Get<Button>("TopNavOverflowButton");
+            _topNavOverflowButton = e.NameScope.Get<Button>(s_tpTopNavOverflowButton);
             if (_topNavOverflowButton != null)
             {
                 // Newest style doesn't have content, only an icon, so we'll skip setting that here like WinUI
@@ -174,7 +174,7 @@ public partial class NavigationView : HeaderedContentControl
             }
 
             // Change code to NOT do this if we're in top nav mode, to prevent it from being realized:
-            _leftNavFooterMenuRepeater = e.NameScope.Get<ItemsRepeater>("FooterMenuItemsHost");
+            _leftNavFooterMenuRepeater = e.NameScope.Get<ItemsRepeater>(s_tpFooterMenuItemsHost);
             if (_leftNavFooterMenuRepeater != null)
             {
                 // Disabling virtualization for now because of https://github.com/microsoft/microsoft-ui-xaml/issues/2095
@@ -190,7 +190,7 @@ public partial class NavigationView : HeaderedContentControl
             }
 
             // Change code to NOT do this if we're in left nav mode, to prevent it from being realized:
-            _topNavFooterMenuRepeater = e.NameScope.Get<ItemsRepeater>("TopFooterMenuItemsHost");
+            _topNavFooterMenuRepeater = e.NameScope.Get<ItemsRepeater>(s_tpTopFooterMenuItemsHost);
             if (_topNavFooterMenuRepeater != null)
             {
                 // Disabling virtualization for now because of https://github.com/microsoft/microsoft-ui-xaml/issues/2095
@@ -205,15 +205,15 @@ public partial class NavigationView : HeaderedContentControl
                 _topNavFooterMenuRepeater.ItemTemplate = _itemsFactory;
             }
 
-            _topNavContentOverlayAreaGrid = e.NameScope.Get<Border>("TopNavContentOverlayAreaGrid");
-            _leftNavAutoSuggestBoxPresenter = e.NameScope.Get<ContentControl>("PaneAutoSuggestBoxPresenter");
-            _topNavAutoSuggestBoxPresenter = e.NameScope.Get<ContentControl>("TopPaneAutoSuggestBoxPresenter");
+            _topNavContentOverlayAreaGrid = e.NameScope.Get<Border>(s_tpTopNavContentOverlayAreaGrid);
+            _leftNavAutoSuggestBoxPresenter = e.NameScope.Get<ContentControl>(s_tpPaneAutoSuggestBoxPresenter);
+            _topNavAutoSuggestBoxPresenter = e.NameScope.Get<ContentControl>(s_tpTopPaneAutoSuggestBoxPresenter);
 
-            _paneContentGrid = e.NameScope.Get<Grid>("PaneContentGrid");
+            _paneContentGrid = e.NameScope.Get<Grid>(s_tpPaneContentGrid);
 
-            _contentLeftPadding = e.NameScope.Get<Rectangle>("ContentLeftPadding");
+            _contentLeftPadding = e.NameScope.Get<Rectangle>(s_tpContentLeftPadding);
 
-            var placeholderGrid = e.NameScope.Get<Grid>("PlaceholderGrid");
+            var placeholderGrid = e.NameScope.Get<Grid>(s_tpPlaceholderGrid);
             if (placeholderGrid != null)
             {
                 _paneHeaderCloseButtonColumn = placeholderGrid.ColumnDefinitions[0];
@@ -221,16 +221,16 @@ public partial class NavigationView : HeaderedContentControl
                 _paneHeaderContentBorderRow = placeholderGrid.RowDefinitions[0];
             }
 
-            _paneTitleFrameworkElement = e.NameScope.Get<IControl>("PaneTitleTextBlock");
-            _paneTitlePresenter = e.NameScope.Get<ContentControl>("PaneTitlePresenter");
+            _paneTitleFrameworkElement = e.NameScope.Get<IControl>(s_tpPaneTitleTextBlock);
+            _paneTitlePresenter = e.NameScope.Get<ContentControl>(s_tpPaneTitlePresenter);
 
-            _paneTitleHolderFrameworkElement = e.NameScope.Get<Control>("PaneTitleHolder");
+            _paneTitleHolderFrameworkElement = e.NameScope.Get<Control>(s_tpPaneTitleHolder);
             if (_paneTitleHolderFrameworkElement != null)
             {
                 _paneTitleHolderRevoker = _paneTitleHolderFrameworkElement.GetObservable(BoundsProperty).Subscribe(OnPaneTitleHolderSizeChanged);
             }
 
-            _paneSearchButton = e.NameScope.Get<Button>("PaneAutoSuggestButton");
+            _paneSearchButton = e.NameScope.Get<Button>(s_tpPaneAutoSuggestButton);
             if (_paneSearchButton != null)
             {
                 _paneSearchButton.Click += OnPaneSearchButtonClick;
@@ -240,7 +240,7 @@ public partial class NavigationView : HeaderedContentControl
                 ToolTip.SetTip(_paneSearchButton, searchButtonName);
             }
 
-            _backButton = e.NameScope.Get<Button>("NavigationViewBackButton");
+            _backButton = e.NameScope.Get<Button>(s_tpNavigationViewBackButton);
             if (_backButton != null)
             {
                 _backButton.Click += OnBackButtonClicked;
@@ -252,7 +252,7 @@ public partial class NavigationView : HeaderedContentControl
 
             //titlebar
 
-            _closeButton = e.NameScope.Get<Button>("NavigationViewCloseButton");
+            _closeButton = e.NameScope.Get<Button>(s_tpNavigationViewCloseButton);
             if (_closeButton != null)
             {
                 _closeButton.Click += OnPaneToggleButtonClick;
@@ -265,10 +265,10 @@ public partial class NavigationView : HeaderedContentControl
                 _itemsContainerRow = _paneContentGrid.RowDefinitions[_paneContentGrid.RowDefinitions.Count - 1];
             }
 
-            _menuItemsScrollViewer = e.NameScope.Get<ScrollViewer>("MenuItemsScrollViewer");
-            _footerItemsScrollViewer = e.NameScope.Get<ScrollViewer>("FooterItemsScrollViewer");
+            _menuItemsScrollViewer = e.NameScope.Get<ScrollViewer>(s_tpMenuItemsScrollViewer);
+            _footerItemsScrollViewer = e.NameScope.Get<ScrollViewer>(s_tpFooterItemsScrollViewer);
 
-            _itemsContainer = e.NameScope.Find<IControl>("ItemsContainerGrid");
+            _itemsContainer = e.NameScope.Find<IControl>(s_tpItemsContainerGrid);
             if (_itemsContainerRow != null)
             {
                 _itemsContainerSizeRevoker = _itemsContainer.GetObservable(BoundsProperty).Subscribe(OnItemsContainerSizeChanged);

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -2344,41 +2344,41 @@ public partial class NavigationView : HeaderedContentControl
 
                             if ((_footerMenuItems != null && _footerMenuItems.Count() == 0) && !IsSettingsVisible)
                             {
-                                PseudoClasses.Set(":separator", false);
+                                PseudoClasses.Set(s_pcSeparator, false);
                                 return totalHeight;
                             }
                             else if (_menuItems != null && _menuItems.Count() == 0)
                             {
                                 _footerItemsScrollViewer.MaxHeight = totalHeight;
-                                PseudoClasses.Set(":separator", false);
+                                PseudoClasses.Set(s_pcSeparator, false);
                                 return 0d;
                             }
                             else if (totalHeight >= menuItemsDesiredHeight + footerGroupActualHeight)
                             {
                                 // We have enough space for two so let everyone get as much as they need
                                 _footerItemsScrollViewer.MaxHeight = footerActualHeight;
-                                PseudoClasses.Set(":separator", false);
+                                PseudoClasses.Set(s_pcSeparator, false);
                                 return totalHeight - footerGroupActualHeight;
                             }
                             else if (menuItemsDesiredHeight < totalHeightHalf)
                             {
                                 // Footer items exceed over the half, so let's limit them.
                                 _footerItemsScrollViewer.MaxHeight = (totalHeight - menuItemsActualHeight);
-                                PseudoClasses.Set(":separator", true);
+                                PseudoClasses.Set(s_pcSeparator, true);
                                 return menuItemsActualHeight;
                             }
                             else if (footerGroupActualHeight <= totalHeightHalf)
                             {
                                 // Menu items exceed over the half, so let's limit them.
                                 _footerItemsScrollViewer.MaxHeight = footerActualHeight;
-                                PseudoClasses.Set(":separator", true);
+                                PseudoClasses.Set(s_pcSeparator, true);
                                 return totalHeight - footerGroupActualHeight;
                             }
                             else
                             {
                                 // Both are more than half the height, so split evenly.
                                 _footerItemsScrollViewer.MaxHeight = (totalHeightHalf);
-                                PseudoClasses.Set(":separator", true);
+                                PseudoClasses.Set(s_pcSeparator, true);
                                 return totalHeightHalf;
                             }
                         }
@@ -2824,13 +2824,13 @@ public partial class NavigationView : HeaderedContentControl
                 if (_splitView.DisplayMode == SplitViewDisplayMode.CompactInline ||
                     _splitView.DisplayMode == SplitViewDisplayMode.CompactOverlay)
                 {
-                    PseudoClasses.Set(":listsizecompact", true);
+                    PseudoClasses.Set(s_pcListSizeCompact, true);
                     //PseudoClasses.Set(":listsizefull", false);
                     UpdatePaneToggleSize();
                 }
                 else
                 {
-                    PseudoClasses.Set(":listsizecompact", false);
+                    PseudoClasses.Set(s_pcListSizeCompact, false);
                     //PseudoClasses.Set(":listsizefull", true);
                 }
             }
@@ -2846,7 +2846,7 @@ public partial class NavigationView : HeaderedContentControl
     {
         if (_leftNavRepeater != null)
         {
-            PseudoClasses.Set(":listsizecompact", false);
+            PseudoClasses.Set(s_pcListSizeCompact, false);
             //PseudoClasses.Set(":listsizefull", true);
         }
 
@@ -3030,7 +3030,7 @@ public partial class NavigationView : HeaderedContentControl
             }
         }
 
-        PseudoClasses.Set(":backbuttoncollapsed", !showBack);
+        PseudoClasses.Set(s_pcBackButtonCollapsed, !showBack);
         UpdateTitleBarPadding();
     }
 
@@ -3113,38 +3113,38 @@ public partial class NavigationView : HeaderedContentControl
         switch (vsdm)
         {
             case NavigationViewVisualStateDisplayMode.MinimalWithBackButton:
-                PseudoClasses.Set(":minimalwithback", true);
-                PseudoClasses.Set(":minimal", false);
-                PseudoClasses.Set(":topnavminimal", false);
-                PseudoClasses.Set(":compact", false);
-                PseudoClasses.Set(":expanded", false);
+                PseudoClasses.Set(s_pcMinimalWithBack, true);
+                PseudoClasses.Set(s_pcMinimal, false);
+                PseudoClasses.Set(s_pcTopNavMinimal, false);
+                PseudoClasses.Set(s_pcCompact, false);
+                PseudoClasses.Set(s_pcExpanded, false);
                 svdm = SplitViewDisplayMode.Overlay;
                 break;
 
             case NavigationViewVisualStateDisplayMode.Minimal:
-                PseudoClasses.Set(":minimalwithback", false);
-                PseudoClasses.Set(":minimal", true);
-                PseudoClasses.Set(":topnavminimal", false);
-                PseudoClasses.Set(":compact", false);
-                PseudoClasses.Set(":expanded", false);
+                PseudoClasses.Set(s_pcMinimalWithBack, false);
+                PseudoClasses.Set(s_pcMinimal, true);
+                PseudoClasses.Set(s_pcTopNavMinimal, false);
+                PseudoClasses.Set(s_pcCompact, false);
+                PseudoClasses.Set(s_pcExpanded, false);
                 svdm = SplitViewDisplayMode.Overlay;
                 break;
 
             case NavigationViewVisualStateDisplayMode.Compact:
-                PseudoClasses.Set(":minimalwithback", false);
-                PseudoClasses.Set(":minimal", false);
-                PseudoClasses.Set(":topnavminimal", false);
-                PseudoClasses.Set(":compact", true);
-                PseudoClasses.Set(":expanded", false);
+                PseudoClasses.Set(s_pcMinimalWithBack, false);
+                PseudoClasses.Set(s_pcMinimal, false);
+                PseudoClasses.Set(s_pcTopNavMinimal, false);
+                PseudoClasses.Set(s_pcCompact, true);
+                PseudoClasses.Set(s_pcExpanded, false);
                 svdm = SplitViewDisplayMode.CompactOverlay;
                 break;
 
             case NavigationViewVisualStateDisplayMode.Expanded:
-                PseudoClasses.Set(":minimalwithback", false);
-                PseudoClasses.Set(":minimal", false);
-                PseudoClasses.Set(":topnavminimal", false);
-                PseudoClasses.Set(":compact", false);
-                PseudoClasses.Set(":expanded", true);
+                PseudoClasses.Set(s_pcMinimalWithBack, false);
+                PseudoClasses.Set(s_pcMinimal, false);
+                PseudoClasses.Set(s_pcTopNavMinimal, false);
+                PseudoClasses.Set(s_pcCompact, false);
+                PseudoClasses.Set(s_pcExpanded, true);
                 svdm = SplitViewDisplayMode.CompactInline;
                 break;
         }
@@ -3157,11 +3157,11 @@ public partial class NavigationView : HeaderedContentControl
 
         if (IsTopNavigationView)
         {
-            PseudoClasses.Set(":minimalwithback", false);
-            PseudoClasses.Set(":minimal", false);
-            PseudoClasses.Set(":topnavminimal", true);
-            PseudoClasses.Set(":compact", false);
-            PseudoClasses.Set(":expanded", false);
+            PseudoClasses.Set(s_pcMinimalWithBack, false);
+            PseudoClasses.Set(s_pcMinimal, false);
+            PseudoClasses.Set(s_pcTopNavMinimal, true);
+            PseudoClasses.Set(s_pcCompact, false);
+            PseudoClasses.Set(s_pcExpanded, false);
         }
 
         // Updating the splitview 'DisplayMode' property in some diplaymodes causes children to be added to the popup root.
@@ -3182,8 +3182,8 @@ public partial class NavigationView : HeaderedContentControl
         if (!_appliedTemplate)
             return;
 
-        PseudoClasses.Set(":autosuggestcollapsed", AutoCompleteBox == null);
-        PseudoClasses.Set(":settingscollapsed", IsSettingsVisible);
+        PseudoClasses.Set(s_pcAutoSuggestCollapsed, AutoCompleteBox == null);
+        PseudoClasses.Set(s_pcSettingsCollapsed, IsSettingsVisible);
 
         if (IsTopNavigationView)
         {
@@ -3192,7 +3192,7 @@ public partial class NavigationView : HeaderedContentControl
         else
         {
             //UpdateLeftNavigationOnlyVisualState(); [Zero point in having a dedicated method for this]
-            PseudoClasses.Set(":panetogglecollapsed", !IsPaneToggleButtonVisible || _isLeftPaneTitleEmpty);
+            PseudoClasses.Set(s_pcPaneToggleCollapsed, !IsPaneToggleButtonVisible || _isLeftPaneTitleEmpty);
         }
     }
 
@@ -3210,12 +3210,12 @@ public partial class NavigationView : HeaderedContentControl
             if (IsPaneOpen && (_splitView.DisplayMode == SplitViewDisplayMode.CompactOverlay ||
                 _splitView.DisplayMode == SplitViewDisplayMode.Overlay))
             {
-                PseudoClasses.Set(":panenotoverlaying", false);
+                PseudoClasses.Set(s_pcPaneNotOverlaying, false);
             }
             else
             {
                 //PaneNotOverlaying VisualState
-                PseudoClasses.Set(":panenotoverlaying", true);
+                PseudoClasses.Set(s_pcPaneNotOverlaying, true);
             }
         }
     }
@@ -3354,13 +3354,13 @@ public partial class NavigationView : HeaderedContentControl
         _isClosedCompact = !_splitView.IsPaneOpen && (svdm == SplitViewDisplayMode.CompactInline ||
             svdm == SplitViewDisplayMode.CompactOverlay);
 
-        PseudoClasses.Set(":closedcompact", _isClosedCompact);
+        PseudoClasses.Set(s_pcClosedCompact, _isClosedCompact);
         //PseudoClasses.Set(":notclosedcompact", !_isClosedCompact); (default)
 
 
         //_initialListSizeStateSet = true;
 
-        PseudoClasses.Set(":listsizecompact", _isClosedCompact);
+        PseudoClasses.Set(s_pcListSizeCompact, _isClosedCompact);
         //PseudoClasses.Set(":listsizefull", !_isClosedCompact); (default)
 
 
@@ -3576,14 +3576,14 @@ public partial class NavigationView : HeaderedContentControl
                 TemplateSettings.TopPaneVisibility = false;
             }
 
-            PseudoClasses.Set(":panecollapsed", false);
+            PseudoClasses.Set(s_pcPaneCollapsed, false);
         }
         else
         {
             TemplateSettings.LeftPaneVisibility = false;
             TemplateSettings.TopPaneVisibility = false;
 
-            PseudoClasses.Set(":panecollapsed", true);
+            PseudoClasses.Set(s_pcPaneCollapsed, true);
         }
     }
 
@@ -3646,7 +3646,7 @@ public partial class NavigationView : HeaderedContentControl
         // If theme resource is RS5 or later, we will not show header if header is null.
         showHeader = Header != null && showHeader;
 
-        PseudoClasses.Set(":headercollapsed", !showHeader);
+        PseudoClasses.Set(s_pcHeaderCollapsed, !showHeader);
     }
 
     private void UpdatePaneTitleMargins() { } //SKIP RS4-

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
@@ -67,10 +67,10 @@ public partial class NavigationView : HeaderedContentControl
     private bool IsTopPrimaryListVisible => _topNavRepeater != null && TemplateSettings.TopPaneVisibility;
 
     private double GetPaneToggleButtonWidth() =>
-        this.TryFindResource("PaneToggleButtonWidth", out object value) ? (double)value : 40;
+        this.TryFindResource(s_resPaneToggleButtonWidth, out object value) ? (double)value : 40;
 
     private double GetPaneToggleButtonHeight() =>
-        this.TryFindResource("PaneToggleButtonHeight", out object value) ? (double)value : 40;
+        this.TryFindResource(s_resPaneToggleButtonHeight, out object value) ? (double)value : 40;
 
     internal bool IsOverlay => _splitView != null && _splitView.DisplayMode == SplitViewDisplayMode.Overlay;
 

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.properties.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.properties.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using FluentAvalonia.Core;
 using System;
@@ -10,6 +12,42 @@ using System.Reactive.Disposables;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(s_pcSeparator)]
+[PseudoClasses(s_pcListSizeCompact, s_pcClosedCompact)]
+[PseudoClasses(s_pcBackButtonCollapsed, s_pcPaneCollapsed, s_pcHeaderCollapsed)]
+[PseudoClasses(s_pcMinimalWithBack, s_pcMinimal, s_pcTopNavMinimal, s_pcCompact, s_pcExpanded)]
+[PseudoClasses(s_pcAutoSuggestCollapsed, s_pcSettingsCollapsed, s_pcPaneToggleCollapsed, s_pcPaneNotOverlaying)]
+[TemplatePart(s_tpTogglePaneButton, typeof(Button))]
+[TemplatePart(s_tpPaneHeaderContentBorder, typeof(ContentControl))]
+[TemplatePart(s_tpPaneCustomContentBorder, typeof(ContentControl))]
+[TemplatePart(s_tpFooterContentBorder, typeof(ContentControl))]
+[TemplatePart(s_tpPaneHeaderOnTopPane, typeof(ContentControl))]
+[TemplatePart(s_tpPaneTitleOnTopPane, typeof(ContentControl))]
+[TemplatePart(s_tpPaneCustomContentOnTopPane, typeof(ContentControl))]
+[TemplatePart(s_tpPaneFooterOnTopPane, typeof(ContentControl))]
+[TemplatePart(s_tpRootSplitView, typeof(SplitView))]
+[TemplatePart(s_tpTopNavGrid, typeof(Grid))]
+[TemplatePart(s_tpMenuItemsHost, typeof(ItemsRepeater))]
+[TemplatePart(s_tpTopNavMenuItemsHost, typeof(ItemsRepeater))]
+[TemplatePart(s_tpTopNavMenuItemsOverflowHost, typeof(ItemsRepeater))]
+[TemplatePart(s_tpTopNavOverflowButton, typeof(Button))]
+[TemplatePart(s_tpFooterMenuItemsHost, typeof(ItemsRepeater))]
+[TemplatePart(s_tpTopFooterMenuItemsHost, typeof(ItemsRepeater))]
+[TemplatePart(s_tpTopNavContentOverlayAreaGrid, typeof(Border))]
+[TemplatePart(s_tpPaneAutoSuggestBoxPresenter, typeof(ContentControl))]
+[TemplatePart(s_tpTopPaneAutoSuggestBoxPresenter, typeof(ContentControl))]
+[TemplatePart(s_tpPaneContentGrid, typeof(Grid))]
+[TemplatePart(s_tpContentLeftPadding, typeof(Rectangle))]
+[TemplatePart(s_tpPlaceholderGrid, typeof(Grid))]
+[TemplatePart(s_tpPaneTitleTextBlock, typeof(Control))]
+[TemplatePart(s_tpPaneTitlePresenter, typeof(ContentControl))]
+[TemplatePart(s_tpPaneTitleHolder, typeof(Control))]
+[TemplatePart(s_tpPaneAutoSuggestButton, typeof(Button))]
+[TemplatePart(s_tpNavigationViewBackButton, typeof(Button))]
+[TemplatePart(s_tpNavigationViewCloseButton, typeof(Button))]
+[TemplatePart(s_tpMenuItemsScrollViewer, typeof(ScrollViewer))]
+[TemplatePart(s_tpFooterItemsScrollViewer, typeof(ScrollViewer))]
+[TemplatePart(s_tpItemsContainerGrid, typeof(Control))]
 public partial class NavigationView : HeaderedContentControl
 {
     /// <summary>
@@ -594,4 +632,55 @@ public partial class NavigationView : HeaderedContentControl
     private IEnumerable _footerMenuItems;
     private NavigationViewDisplayMode _displayMode = NavigationViewDisplayMode.Minimal;
     private NavigationViewItem _settingsItem;
+
+    private const string s_tpTogglePaneButton = "TogglePaneButton";
+    private const string s_tpPaneHeaderContentBorder = "PaneHeaderContentBorder";
+    private const string s_tpPaneCustomContentBorder = "PaneCustomContentBorder";
+    private const string s_tpFooterContentBorder = "FooterContentBorder";
+    private const string s_tpPaneHeaderOnTopPane = "PaneHeaderOnTopPane";
+    private const string s_tpPaneTitleOnTopPane = "PaneTitleOnTopPane";
+    private const string s_tpPaneCustomContentOnTopPane = "PaneCustomContentOnTopPane";
+    private const string s_tpPaneFooterOnTopPane = "PaneFooterOnTopPane";
+    private const string s_tpRootSplitView = "RootSplitView";
+    private const string s_tpTopNavGrid = "TopNavGrid";
+    private const string s_tpMenuItemsHost = "MenuItemsHost";
+    private const string s_tpTopNavMenuItemsHost = "TopNavMenuItemsHost";
+    private const string s_tpTopNavMenuItemsOverflowHost = "TopNavMenuItemsOverflowHost";
+    private const string s_tpTopNavOverflowButton = "TopNavOverflowButton";
+    private const string s_tpFooterMenuItemsHost = "FooterMenuItemsHost";
+    private const string s_tpTopFooterMenuItemsHost = "TopFooterMenuItemsHost";
+    private const string s_tpTopNavContentOverlayAreaGrid = "TopNavContentOverlayAreaGrid";
+    private const string s_tpPaneAutoSuggestBoxPresenter = "PaneAutoSuggestBoxPresenter";
+    private const string s_tpTopPaneAutoSuggestBoxPresenter = "TopPaneAutoSuggestBoxPresenter";
+    private const string s_tpPaneContentGrid = "PaneContentGrid";
+    private const string s_tpContentLeftPadding = "ContentLeftPadding";
+    private const string s_tpPlaceholderGrid = "PlaceholderGrid";
+    private const string s_tpPaneTitleTextBlock = "PaneTitleTextBlock";
+    private const string s_tpPaneTitlePresenter = "PaneTitlePresenter";
+    private const string s_tpPaneTitleHolder = "PaneTitleHolder";
+    private const string s_tpPaneAutoSuggestButton = "PaneAutoSuggestButton";
+    private const string s_tpNavigationViewBackButton = "NavigationViewBackButton";
+    private const string s_tpNavigationViewCloseButton = "NavigationViewCloseButton";
+    private const string s_tpMenuItemsScrollViewer = "MenuItemsScrollViewer";
+    private const string s_tpFooterItemsScrollViewer = "FooterItemsScrollViewer";
+    private const string s_tpItemsContainerGrid = "ItemsContainerGrid";
+
+    private const string s_pcSeparator = ":separator";
+    private const string s_pcListSizeCompact = ":listsizecompact";
+    private const string s_pcBackButtonCollapsed = ":backbuttoncollapsed";
+    private const string s_pcMinimalWithBack = ":minimalwithback";
+    private const string s_pcMinimal = ":minimal";
+    private const string s_pcTopNavMinimal = ":topnavminimal";
+    private const string s_pcCompact = ":compact";
+    private const string s_pcExpanded = ":expanded";
+    private const string s_pcAutoSuggestCollapsed = ":autosuggestcollapsed";
+    private const string s_pcSettingsCollapsed = ":settingscollapsed";
+    private const string s_pcPaneToggleCollapsed = ":panetogglecollapsed";
+    private const string s_pcPaneNotOverlaying = ":panenotoverlaying";
+    private const string s_pcClosedCompact = ":closedcompact";
+    private const string s_pcPaneCollapsed = ":panecollapsed";
+    private const string s_pcHeaderCollapsed = ":headercollapsed";
+
+    private const string s_resPaneToggleButtonWidth = "PaneToggleButtonWidth";
+    private const string s_resPaneToggleButtonHeight = "PaneToggleButtonHeight";
 }

--- a/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
+++ b/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using FluentAvalonia.Core;
 using System;
 using System.Globalization;
 
@@ -23,8 +24,8 @@ public partial class NumberBox : TemplatedControl
     {
         base.OnApplyTemplate(e);
 
-        _spinDown = e.NameScope.Find<RepeatButton>("DownSpinButton");
-        _popupDownButton = e.NameScope.Find<RepeatButton>("PopupDownSpinButton");
+        _spinDown = e.NameScope.Find<RepeatButton>(s_tpDownSpinButton);
+        _popupDownButton = e.NameScope.Find<RepeatButton>(s_tpPopupDownSpinButton);
         if (_spinDown != null)
         {
             _spinDown.Click += OnSpinDownClick;
@@ -34,8 +35,8 @@ public partial class NumberBox : TemplatedControl
             _popupDownButton.Click += OnSpinDownClick;
         }
 
-        _spinUp = e.NameScope.Find<RepeatButton>("UpSpinButton");
-        _popupUpButton = e.NameScope.Find<RepeatButton>("PopupUpSpinButton");
+        _spinUp = e.NameScope.Find<RepeatButton>(s_tpUpSpinButton);
+        _popupUpButton = e.NameScope.Find<RepeatButton>(s_tpPopupUpSpinButton);
         if (_spinUp != null)
         {
             _spinUp.Click += OnSpinUpClick;
@@ -45,7 +46,7 @@ public partial class NumberBox : TemplatedControl
             _popupUpButton.Click += OnSpinUpClick;
         }
 
-        _textBox = e.NameScope.Find<TextBox>("InputBox");
+        _textBox = e.NameScope.Find<TextBox>(s_tpInputBox);
         if (_textBox != null)
         {
             _textBox.AddHandler(KeyDownEvent, OnNumberBoxKeyDown, RoutingStrategies.Tunnel);
@@ -53,7 +54,7 @@ public partial class NumberBox : TemplatedControl
             _textBox.KeyUp += OnNumberBoxKeyUp;
         }
 
-        _popup = e.NameScope.Find<Popup>("UpDownPopup");
+        _popup = e.NameScope.Find<Popup>(s_tpUpDownPopup);
         if (_popup != null)
         {
             _popup.OverlayInputPassThroughElement = this;
@@ -388,38 +389,38 @@ public partial class NumberBox : TemplatedControl
 
         if (sbm == NumberBoxSpinButtonPlacementMode.Inline)
         {
-            PseudoClasses.Set(":spinvisible", true);
-            PseudoClasses.Set(":spinpopup", false);
-            PseudoClasses.Set(":spincollapsed", false);
+            PseudoClasses.Set(s_pcSpinVisible, true);
+            PseudoClasses.Set(s_pcSpinPopup, false);
+            PseudoClasses.Set(s_pcSpinCollapsed, false);
 
             if (_textBox != null)
             {
-                ((IPseudoClasses)_textBox.Classes).Set(":spinvisible", true);
-                ((IPseudoClasses)_textBox.Classes).Set(":spinpopup", false);
+                ((IPseudoClasses)_textBox.Classes).Set(s_pcSpinVisible, true);
+                ((IPseudoClasses)_textBox.Classes).Set(s_pcSpinPopup, false);
             }
         }
         else if (sbm == NumberBoxSpinButtonPlacementMode.Compact)
         {
-            PseudoClasses.Set(":spinvisible", false);
-            PseudoClasses.Set(":spinpopup", true);
-            PseudoClasses.Set(":spincollapsed", false);
+            PseudoClasses.Set(s_pcSpinVisible, false);
+            PseudoClasses.Set(s_pcSpinPopup, true);
+            PseudoClasses.Set(s_pcSpinCollapsed, false);
 
             if (_textBox != null)
             {
-                ((IPseudoClasses)_textBox.Classes).Set(":spinvisible", false);
-                ((IPseudoClasses)_textBox.Classes).Set(":spinpopup", true);
+                ((IPseudoClasses)_textBox.Classes).Set(s_pcSpinVisible, false);
+                ((IPseudoClasses)_textBox.Classes).Set(s_pcSpinPopup, true);
             }
         }
         else
         {
-            PseudoClasses.Set(":spinvisible", false);
-            PseudoClasses.Set(":spinpopup", false);
-            PseudoClasses.Set(":spincollapsed", true);
+            PseudoClasses.Set(s_pcSpinVisible, false);
+            PseudoClasses.Set(s_pcSpinPopup, false);
+            PseudoClasses.Set(s_pcSpinCollapsed, true);
 
             if (_textBox != null)
             {
-                ((IPseudoClasses)_textBox.Classes).Set(":spinvisible", false);
-                ((IPseudoClasses)_textBox.Classes).Set(":spinpopup", false);
+                ((IPseudoClasses)_textBox.Classes).Set(s_pcSpinVisible, false);
+                ((IPseudoClasses)_textBox.Classes).Set(s_pcSpinPopup, false);
             }
         }
     }
@@ -447,8 +448,8 @@ public partial class NumberBox : TemplatedControl
             }
         }
 
-        PseudoClasses.Set(":updisabled", !isUpEnabled);
-        PseudoClasses.Set(":downdisabled", !isDownEnabled);
+        PseudoClasses.Set(s_pcUpDisabled, !isUpEnabled);
+        PseudoClasses.Set(s_pcDownDisabled, !isDownEnabled);
     }
 
     private void UpdateHeaderPresenterState()
@@ -476,7 +477,7 @@ public partial class NumberBox : TemplatedControl
         }
 
         //Changed to Pseudoclass rather than keeping a ref to the ContentPresenter
-        PseudoClasses.Set(":header", showHeader);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcHeader, showHeader);
     }
 
     private void MoveCaretToTextEnd()

--- a/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
+++ b/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
@@ -7,9 +7,19 @@ using Avalonia;
 using FluentAvalonia.Core.Attributes;
 using FluentAvalonia.Core;
 using System;
+using Avalonia.Controls.Metadata;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(s_pcSpinVisible, s_pcSpinPopup, s_pcSpinCollapsed)]
+[PseudoClasses(s_pcUpDisabled, s_pcDownDisabled)]
+[PseudoClasses(SharedPseudoclasses.s_pcHeader)]
+[TemplatePart(s_tpDownSpinButton, typeof(RepeatButton))]
+[TemplatePart(s_tpPopupDownSpinButton, typeof(RepeatButton))]
+[TemplatePart(s_tpUpSpinButton, typeof(RepeatButton))]
+[TemplatePart(s_tpPopupUpSpinButton, typeof(RepeatButton))]
+[TemplatePart(s_tpInputBox, typeof(TextBox))]
+[TemplatePart(s_tpUpDownPopup, typeof(Popup))]
 public partial class NumberBox
 {
     /// <summary>
@@ -403,4 +413,17 @@ public partial class NumberBox
     private NumberBoxValidationMode _validationMode;
     private double _value = double.NaN;
     private string _simpleFormat;
+
+    private const string s_tpDownSpinButton = "DownSpinButton";
+    private const string s_tpPopupDownSpinButton = "PopupDownSpinButton";
+    private const string s_tpUpSpinButton = "UpSpinButton";
+    private const string s_tpPopupUpSpinButton = "PopupUpSpinButton";
+    private const string s_tpInputBox = "InputBox";
+    private const string s_tpUpDownPopup = "UpDownPopup";
+
+    private const string s_pcSpinVisible = ":spinvisible";
+    private const string s_pcSpinPopup = ":spinpopup";
+    private const string s_pcSpinCollapsed = ":spincollapsed";
+    private const string s_pcUpDisabled = ":updisabled";
+    private const string s_pcDownDisabled = ":downdisabled";
 }

--- a/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.cs
+++ b/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.cs
@@ -11,6 +11,7 @@ using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -24,7 +25,7 @@ public partial class SettingsExpander : HeaderedItemsControl, ICommandSource
     {
         base.OnApplyTemplate(e);
 
-        _expander = e.NameScope.Get<Expander>("Expander");
+        _expander = e.NameScope.Get<Expander>(s_tpExpander);
         // The Expander's template hasn't been loaded yet, so defer until later when it has
         // so we can load the ToggleButton within the template
         _expander.Loaded += ExpanderLoaded;
@@ -45,12 +46,12 @@ public partial class SettingsExpander : HeaderedItemsControl, ICommandSource
             if (_expanderToggleButton != null)
             {
                 // Disable pointerover/pressed styles if we aren't clickable (empty or !IsClickEnabled)
-                ((IPseudoClasses)_expanderToggleButton.Classes).Set(":allowClick", newVal || ItemCount > 0);
+                ((IPseudoClasses)_expanderToggleButton.Classes).Set(SharedPseudoclasses.s_pcAllowClick, newVal || ItemCount > 0);
 
                 // When IsClickEnabled == true, we don't allow items but we may want to show an ActionIcon
                 // ControlThemes don't let is drill into sub-templates so we have to do this manually here
                 // Set a style on the ToggleButton to indicate we want to hide the expand/collapse chevron
-                ((IPseudoClasses)_expanderToggleButton.Classes).Set(":empty", newVal);
+                ((IPseudoClasses)_expanderToggleButton.Classes).Set(s_pcEmpty, newVal);
             }                
         }
         else if (change.Property == IsExpandedProperty)
@@ -136,12 +137,12 @@ public partial class SettingsExpander : HeaderedItemsControl, ICommandSource
         bool allowClick = IsClickEnabled;
 
         // Disable pointerover/pressed styles if we aren't clickable (empty or !IsClickEnabled)
-        ((IPseudoClasses)_expanderToggleButton.Classes).Set(":allowClick", IsClickEnabled || ItemCount > 0);
+        ((IPseudoClasses)_expanderToggleButton.Classes).Set(SharedPseudoclasses.s_pcAllowClick, IsClickEnabled || ItemCount > 0);
 
         // When IsClickEnabled == true, we don't allow items but we may want to show an ActionIcon
         // ControlThemes don't let is drill into sub-templates so we have to do this manually here
         // Set a style on the ToggleButton to indicate we want to hide the expand/collapse chevron
-        ((IPseudoClasses)_expanderToggleButton.Classes).Set(":empty", IsClickEnabled || ItemCount == 0);
+        ((IPseudoClasses)_expanderToggleButton.Classes).Set(s_pcEmpty, IsClickEnabled || ItemCount == 0);
     }
 
     private void ExpanderToggleButtonClick(object sender, RoutedEventArgs e)

--- a/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.properties.cs
+++ b/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.properties.cs
@@ -2,11 +2,15 @@
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Templates;
 using Avalonia.Interactivity;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(SharedPseudoclasses.s_pcAllowClick, s_pcEmpty)]
+[TemplatePart(s_tpExpander, typeof(Expander))]
 public partial class SettingsExpander
 {
     /// <summary>
@@ -184,4 +188,8 @@ public partial class SettingsExpander
 
     private ICommand _command;
     private bool _isExpanded;
+
+    private const string s_tpExpander = "Expander";
+
+    private const string s_pcEmpty = ":empty";
 }

--- a/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.cs
+++ b/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.cs
@@ -9,6 +9,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -33,13 +34,13 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
                 if (availableSize.Width > _adaptiveWidthTrigger)
                 {
                     _isFooterAtBottom = false;
-                    PseudoClasses.Set(":footerBottom", false);
+                    PseudoClasses.Set(s_pcFooterBottom, false);
                 }
             }
             else if (availableSize.Width < _adaptiveWidthTrigger)
             {
                 _isFooterAtBottom = true;
-                PseudoClasses.Set(":footerBottom", true);
+                PseudoClasses.Set(s_pcFooterBottom, true);
             }
         }
 
@@ -50,14 +51,14 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
     {
         base.OnApplyTemplate(e);
 
-        _adaptiveWidthDisposable = this.GetResourceObservable("SettingsExpanderItemAdaptiveWidthTrigger")
+        _adaptiveWidthDisposable = this.GetResourceObservable(s_resAdaptiveWidthTrigger)
             .Subscribe(OnAdaptiveWidthValueChanged);
 
         // We only want to allow interaction on the SettingsExpanderItem IF we're a child item,
         // because we use this in the header of the expander for the SettingsExpander where the
         // ToggleButton does the heavy lifting for us
         _allowInteraction = IsClickEnabled && this.FindAncestorOfType<ToggleButton>() == null;
-        PseudoClasses.Set(":allowClick", _allowInteraction);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcAllowClick, _allowInteraction);
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -164,12 +165,12 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
             if (new Rect(Bounds.Size).Contains(pt.Position))
             {
                 _isPressed = true;
-                PseudoClasses.Set(":pressed", true);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, true);
             }
             else
             {
                 _isPressed = false;
-                PseudoClasses.Set(":pressed", false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
             }
         }
     }
@@ -180,7 +181,7 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
         if (_isPressed && _allowInteraction)
         {
             _isPressed = false;
-            PseudoClasses.Set(":pressed", false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
 
             if (!e.Handled)
             {
@@ -195,7 +196,7 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
     {
         base.OnPointerCaptureLost(e);
         _isPressed = false;
-        PseudoClasses.Set(":pressed", false);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
     }
 
     /// <summary>
@@ -216,7 +217,7 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
     private void OnIconSourceChanged(AvaloniaPropertyChangedEventArgs args)
     {
         var newIcon = args.GetNewValue<IconSource>();
-        PseudoClasses.Set(":icon", newIcon != null);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, newIcon != null);
 
         TemplateSettings.Icon = IconHelpers.CreateFromUnknown(newIcon);
     }
@@ -227,7 +228,7 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
         {
             // Only set the icon if IsClickEnabled
             var newIcon = args.GetNewValue<IconSource>();
-            PseudoClasses.Set(":actionIcon", newIcon != null);
+            PseudoClasses.Set(s_pcActionIcon, newIcon != null);
 
             TemplateSettings.ActionIcon = IconHelpers.CreateFromUnknown(newIcon);
         }
@@ -237,36 +238,36 @@ public partial class SettingsExpanderItem : ContentControl, ICommandSource
     {
         bool enabled = args.GetNewValue<bool>();
         _allowInteraction = enabled && this.FindAncestorOfType<ToggleButton>() == null;
-        PseudoClasses.Set(":allowClick", _allowInteraction);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcAllowClick, _allowInteraction);
 
         var actionIcon = ActionIconSource;
         if (!enabled && actionIcon != null)
         {
             // If not enabled, clear the ActionIcon in template settings
             TemplateSettings.ActionIcon = null;
-            PseudoClasses.Set(":actionIcon", false);
+            PseudoClasses.Set(s_pcActionIcon, false);
         }
         else if (actionIcon != null)
         {
             TemplateSettings.ActionIcon = IconHelpers.CreateFromUnknown(actionIcon);
-            PseudoClasses.Set(":actionIcon", true);
+            PseudoClasses.Set(s_pcActionIcon, true);
         }
     }
 
     private void OnFooterChanged(AvaloniaPropertyChangedEventArgs args)
     {
         _hasFooter = args.NewValue != null;
-        PseudoClasses.Set(":footer", _hasFooter);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcFooter, _hasFooter);
     }
 
     private void OnContentChanged(AvaloniaPropertyChangedEventArgs args)
     {
-        PseudoClasses.Set(":content", args.NewValue != null);
+        PseudoClasses.Set(s_pcContent, args.NewValue != null);
     }
 
     private void OnDescriptionChanged(AvaloniaPropertyChangedEventArgs args)
     {
-        PseudoClasses.Set(":description", args.NewValue != null);
+        PseudoClasses.Set(s_pcDescription, args.NewValue != null);
     }
 
     private void CanExecuteChanged(object sender, EventArgs e)

--- a/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.properties.cs
@@ -4,9 +4,15 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Interactivity;
 using System;
+using Avalonia.Controls.Metadata;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(s_pcFooterBottom, SharedPseudoclasses.s_pcFooter, s_pcContent, s_pcDescription)]
+[PseudoClasses(SharedPseudoclasses.s_pcAllowClick)]
+[PseudoClasses(SharedPseudoclasses.s_pcPressed)]
+[PseudoClasses(SharedPseudoclasses.s_pcIcon, s_pcActionIcon)]
 public partial class SettingsExpanderItem : ContentControl
 {
     /// <summary>
@@ -171,4 +177,11 @@ public partial class SettingsExpanderItem : ContentControl
     }
 
     private ICommand _command;
+
+    private const string s_pcDescription = ":description";
+    private const string s_pcContent = ":content";
+    private const string s_pcActionIcon = ":actionIcon";
+    private const string s_pcFooterBottom = ":footerBottom";
+
+    private const string s_resAdaptiveWidthTrigger = "SettingsExpanderItemAdaptiveWidthTrigger";
 }

--- a/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -278,9 +278,9 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
 
             if (ContainerFromIndex(i) is TabViewItem tvi)
             {
-                ((IPseudoClasses)tvi.Classes).Set(s_pcNoBorder, state == 0);
-                ((IPseudoClasses)tvi.Classes).Set(s_pcBorderLeft, state == 1);
-                ((IPseudoClasses)tvi.Classes).Set(s_pcBorderRight, state == 2);
+                ((IPseudoClasses)tvi.Classes).Set(SharedPseudoclasses.s_pcNoBorder, state == 0);
+                ((IPseudoClasses)tvi.Classes).Set(SharedPseudoclasses.s_pcBorderLeft, state == 1);
+                ((IPseudoClasses)tvi.Classes).Set(SharedPseudoclasses.s_pcBorderRight, state == 2);
             }
         }
     }
@@ -295,13 +295,13 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
         // Update border lines in the inner TabViewListView
         if (_listView != null)
         {
-            (_listView.Classes as IPseudoClasses).Set(s_pcNoBorder, _isDragging);
+            (_listView.Classes as IPseudoClasses).Set(SharedPseudoclasses.s_pcNoBorder, _isDragging);
         }
 
         // Update border lines in the ScrollViewer
         if (_scrollViewer != null)
         {
-            (_scrollViewer.Classes as IPseudoClasses).Set(s_pcNoBorder, _isDragging);
+            (_scrollViewer.Classes as IPseudoClasses).Set(SharedPseudoclasses.s_pcNoBorder, _isDragging);
         }
     }
 

--- a/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -20,6 +20,9 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace FluentAvalonia.UI.Controls;
 
+/// <summary>
+/// A control used to display a set of tabs and their respective content
+/// </summary>
 public partial class TabView : TemplatedControl, IContentPresenterHost
 {
     public TabView()
@@ -63,10 +66,10 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
 
         base.OnApplyTemplate(e);
 
-        _tabContentPresenter = e.NameScope.Find<ContentPresenter>("TabContentPresenter");
-        _rightContentPresenter = e.NameScope.Find<ContentPresenter>("RightContentPresenter");
+        _tabContentPresenter = e.NameScope.Find<ContentPresenter>(s_tpTabContentPresenter);
+        _rightContentPresenter = e.NameScope.Find<ContentPresenter>(s_tpRightContentPresenter);
 
-        _tabContainerGrid = e.NameScope.Find<Grid>("TabContainerGrid");
+        _tabContainerGrid = e.NameScope.Find<Grid>(s_tpTabContainerGrid);
         if (_tabContainerGrid != null)
         {
             _leftContentColumn = _tabContainerGrid.ColumnDefinitions[0];
@@ -81,7 +84,7 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
             _tabContainerGrid.KeyDown += OnTabContainerGridKeyDown;
         }
 
-        _listView = e.NameScope.Find<TabViewListView>("TabListView");
+        _listView = e.NameScope.Find<TabViewListView>(s_tpTabListView);
 
         if (_listView != null)
         {
@@ -115,7 +118,7 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
             _listView.Loaded += OnListViewLoaded;
         }
 
-        _addButton = e.NameScope.Find<Button>("AddButton");
+        _addButton = e.NameScope.Find<Button>(s_tpAddButton);
         if (_addButton != null)
         {
             // TODO: Automation
@@ -275,9 +278,9 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
 
             if (ContainerFromIndex(i) is TabViewItem tvi)
             {
-                ((IPseudoClasses)tvi.Classes).Set(":noborder", state == 0);
-                ((IPseudoClasses)tvi.Classes).Set(":borderleft", state == 1);
-                ((IPseudoClasses)tvi.Classes).Set(":borderright", state == 2);
+                ((IPseudoClasses)tvi.Classes).Set(s_pcNoBorder, state == 0);
+                ((IPseudoClasses)tvi.Classes).Set(s_pcBorderLeft, state == 1);
+                ((IPseudoClasses)tvi.Classes).Set(s_pcBorderRight, state == 2);
             }
         }
     }
@@ -287,18 +290,18 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
         // Update border line on all tabs
         UpdateTabBottomBorderLineVisualStates();
 
-        PseudoClasses.Set(":singleborder", _isDragging);
+        PseudoClasses.Set(s_pcSingleBorder, _isDragging);
 
         // Update border lines in the inner TabViewListView
         if (_listView != null)
         {
-            (_listView.Classes as IPseudoClasses).Set(":noborder", _isDragging);
+            (_listView.Classes as IPseudoClasses).Set(s_pcNoBorder, _isDragging);
         }
 
         // Update border lines in the ScrollViewer
         if (_scrollViewer != null)
         {
-            (_scrollViewer.Classes as IPseudoClasses).Set(":noborder", _isDragging);
+            (_scrollViewer.Classes as IPseudoClasses).Set(s_pcNoBorder, _isDragging);
         }
     }
 
@@ -421,14 +424,14 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
 
         foreach (RepeatButton button in buttons)
         {
-            if (button.Name == "ScrollDecreaseButton")
+            if (button.Name == s_tpScrollDecreaseButton)
             {
                 _scrollDecreaseButton = button;
                 ToolTip.SetTip(_scrollDecreaseButton, 
                     FALocalizationHelper.Instance.GetLocalizedStringResource(SR_TabViewScrollDecreaseButtonTooltip));
                 _scrollDecreaseButton.Click += OnScrollDecreaseClick;
             }
-            else if (button.Name == "ScrollIncreaseButton")
+            else if (button.Name == s_tpScrollIncreaseButton)
             {
                 _scrollIncreaseButton = button;
                 ToolTip.SetTip(_scrollIncreaseButton, 
@@ -1121,7 +1124,7 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
 
     bool IContentPresenterHost.RegisterContentPresenter(IContentPresenter presenter)
     {
-        if (presenter.Name == "TabContentPresenter")
+        if (presenter.Name == s_tpTabContentPresenter)
             return true;
 
         return false;
@@ -1164,20 +1167,12 @@ public partial class TabView : TemplatedControl, IContentPresenterHost
 
     private Size _lastItemsPresenterSize;
 
-
     private static double c_tabMinimumWidth = 48d;
     private static double c_tabMaximumWidth = 200d;
-
-    private static string c_tabViewItemMinWidthName = "TabViewItemMinWidth";
-    private static string c_tabViewItemMaxWidthName = "TabViewItemMaxWidth";
 
     // (WinUI) TODO: what is the right number and should this be customizable?
     private static double c_scrollAmount = 50d;
 
-    private static readonly string SR_TabViewCloseButtonTooltipWithKA = "TabViewCloseButtonTooltipWithKA";
-    private static readonly string SR_TabViewAddButtonTooltip = "TabViewAddButtonTooltip";
-    private static readonly string SR_TabViewScrollDecreaseButtonTooltip = "TabViewScrollDecreaseButtonTooltip";
-    private static readonly string SR_TabViewScrollIncreaseButtonTooltip = "TabViewScrollIncreaseButtonTooltip";
 
     class TabViewCommand : ICommand
     {

--- a/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
@@ -8,9 +8,19 @@ using FluentAvalonia.Core;
 using System.Collections.Specialized;
 using Avalonia.Input;
 using Avalonia.Metadata;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls;
+using FluentAvalonia.UI.Controls.Primitives;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(SharedPseudoclasses.s_pcNoBorder, SharedPseudoclasses.s_pcBorderLeft, SharedPseudoclasses.s_pcBorderRight, s_pcSingleBorder)]
+[TemplatePart(s_tpTabContentPresenter, typeof(ContentPresenter))]
+[TemplatePart(s_tpRightContentPresenter, typeof(ContentPresenter))]
+[TemplatePart(s_tpTabContainerGrid, typeof(Grid))]
+[TemplatePart(s_tpTabListView, typeof(TabViewListView))]
+[TemplatePart(s_tpAddButton, typeof(Button))]
 public partial class TabView
 {
     /// <summary>
@@ -313,4 +323,25 @@ public partial class TabView
     private IEnumerable _tabItems;
     private int _selectedIndex = 0;
     private object _selectedItem;
+
+    private const string s_tpTabContentPresenter = "TabContentPresenter";
+    private const string s_tpRightContentPresenter = "RightContentPresenter";
+    private const string s_tpTabContainerGrid = "TabContainerGrid";
+    private const string s_tpTabListView = "TabListView";
+    private const string s_tpAddButton = "AddButton";
+
+    // Technically these are template parts on the ScrollViewer, but we ref them here
+    private const string s_tpScrollDecreaseButton = "ScrollDecreaseButton";
+    private const string s_tpScrollIncreaseButton = "ScrollIncreaseButton";
+    
+    // These two come from the WinUI port, so they don't follow the normal naming convention for parity upstream
+    private static string c_tabViewItemMinWidthName = "TabViewItemMinWidth";
+    private static string c_tabViewItemMaxWidthName = "TabViewItemMaxWidth";
+
+    private const string s_pcSingleBorder = ":singleBorder";
+
+    private static readonly string SR_TabViewCloseButtonTooltipWithKA = "TabViewCloseButtonTooltipWithKA";
+    private static readonly string SR_TabViewAddButtonTooltip = "TabViewAddButtonTooltip";
+    private static readonly string SR_TabViewScrollDecreaseButtonTooltip = "TabViewScrollDecreaseButtonTooltip";
+    private static readonly string SR_TabViewScrollIncreaseButtonTooltip = "TabViewScrollIncreaseButtonTooltip";
 }

--- a/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -6,7 +6,6 @@ using System.Text;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
-using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Diagnostics;
@@ -15,10 +14,10 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
-[PseudoClasses(":icon", ":compact", ":closecollapsed", ":borderleft", ":borderright", ":noborder", ":foreground")]
 public partial class TabViewItem : ListBoxItem
 {
     public TabViewItem()
@@ -41,7 +40,7 @@ public partial class TabViewItem : ListBoxItem
 
             if (hasButton)
             {
-                PseudoClasses.Set(":pressed", false);
+                PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
             }
         }, RoutingStrategies.Tunnel);
     }
@@ -104,13 +103,13 @@ public partial class TabViewItem : ListBoxItem
     {
         base.OnApplyTemplate(e);
 
-        TabSeparator = e.NameScope.Find<IVisual>("TabSeparator");
+        TabSeparator = e.NameScope.Find<IVisual>(s_tpTabSeparator);
 
-        _headerContentPresenter = e.NameScope.Find<ContentPresenter>("ContentPresenter");
+        _headerContentPresenter = e.NameScope.Find<ContentPresenter>(s_tpContentPresenter);
 
         var tabView = this.FindAncestorOfType<TabView>();
 
-        _closeButton = e.NameScope.Find<Button>("CloseButton");
+        _closeButton = e.NameScope.Find<Button>(s_tpCloseButton);
         if (_closeButton != null)
         {
             // Skip Automation
@@ -308,7 +307,7 @@ public partial class TabViewItem : ListBoxItem
         bool isForegroundSet = this.GetDiagnostic(ForegroundProperty).Priority != Avalonia.Data.BindingPriority.Unset;
         bool set = isForegroundSet && !IsSelected && !_isPointerOver;
 
-        PseudoClasses.Set(":foreground", set);
+        PseudoClasses.Set(s_pcForeground, set);
 
         // We only need to set the foreground state when the TabViewItem is in rest state and not selected.
         // if (!IsSelected && !_isPointerOver)
@@ -383,7 +382,7 @@ public partial class TabViewItem : ListBoxItem
             }
         }
 
-        PseudoClasses.Set(":closecollapsed", isCollapsed);
+        PseudoClasses.Set(s_pcCloseCollapsed, isCollapsed);
     }
 
     private void UpdateWidthModeVisualState()
@@ -394,7 +393,7 @@ public partial class TabViewItem : ListBoxItem
         // => :compact
 
         // Handling compact/non compact width mode
-        PseudoClasses.Set(":compact", !IsSelected && _tabViewWidthMode == TabViewWidthMode.Compact);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcCompact, !IsSelected && _tabViewWidthMode == TabViewWidthMode.Compact);
     }
 
     private void RequestClose()
@@ -489,12 +488,12 @@ public partial class TabViewItem : ListBoxItem
         if (IconSource != null)
         {
             TabViewTemplateSettings.IconElement = IconHelpers.CreateFromUnknown(IconSource);
-            PseudoClasses.Set(":icon", true);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, true);
         }
         else
         {
             TabViewTemplateSettings.IconElement = null;
-            PseudoClasses.Set(":icon", false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, false);
         }
     }
 
@@ -530,6 +529,6 @@ public partial class TabViewItem : ListBoxItem
 
     private WeakReference<TabView> _parentTabView;
 
-    const string c_overlayCornerRadiusKey = "OverlayCornerRadius";
-    const int c_targetRectWidthIncrement = 2;
+    private const string c_overlayCornerRadiusKey = "OverlayCornerRadius";
+    private const int c_targetRectWidthIncrement = 2;
 }

--- a/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
@@ -2,9 +2,17 @@
 using Avalonia.Controls.Templates;
 using Avalonia;
 using FluentAvalonia.Core;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(SharedPseudoclasses.s_pcIcon, SharedPseudoclasses.s_pcCompact, s_pcCloseCollapsed, s_pcForeground)]
+[PseudoClasses(SharedPseudoclasses.s_pcBorderRight, SharedPseudoclasses.s_pcBorderLeft, SharedPseudoclasses.s_pcNoBorder)]
+[TemplatePart(s_tpTabSeparator, typeof(Visual))]
+[TemplatePart(s_tpContentPresenter, typeof(ContentPresenter))]
+[TemplatePart(s_tpCloseButton, typeof(Button))]
 public partial class TabViewItem
 {
     /// <summary>
@@ -88,4 +96,11 @@ public partial class TabViewItem
     /// button
     /// </summary>
     public event TypedEventHandler<TabViewItem, TabViewTabCloseRequestedEventArgs> CloseRequested;
+
+    private const string s_pcForeground = ":foreground";
+    private const string s_pcCloseCollapsed = ":closecollapsed";
+
+    private const string s_tpTabSeparator = "TabSeparator";
+    private const string s_tpContentPresenter = "ContentPresenter";
+    private const string s_tpCloseButton = "CloseButton";
 }

--- a/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -2,10 +2,10 @@
 using System.Collections;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Generators;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
@@ -14,10 +14,17 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
-using FluentAvalonia.Interop;
 
 namespace FluentAvalonia.UI.Controls.Primitives;
 
+/// <summary>
+/// Represents the ListView used in the TabStrip of a <see cref="TabView"/>
+/// </summary>
+/// <remarks>
+/// This control should not be used outside of a TabView
+/// </remarks>
+[PseudoClasses(s_pcReorder)]
+[TemplatePart(s_tpScrollViewer, typeof(ScrollViewer))]
 public class TabViewListView : ListBox
 {
     public TabViewListView()
@@ -90,7 +97,7 @@ public class TabViewListView : ListBox
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
-        Scroller = e.NameScope.Find<ScrollViewer>("ScrollViewer");
+        Scroller = e.NameScope.Find<ScrollViewer>(s_tpScrollViewer);
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -341,7 +348,7 @@ public class TabViewListView : ListBox
             return;
         }
 
-        PseudoClasses.Set(":reorder", true);
+        PseudoClasses.Set(s_pcReorder, true);
         // This triggers the ItemsPanel to enter reorder state which will insert a blank space
         // where the current item in measured
         ItemsPanelRoot.EnterReorder(_dragIndex);
@@ -424,7 +431,7 @@ public class TabViewListView : ListBox
 
     private void EndReorder()
     {
-        PseudoClasses.Set(":reorder", false);
+        PseudoClasses.Set(s_pcReorder, false);
         if (_dragReorderPopup != null && _dragReorderPopup.IsOpen)
         {
             _dragReorderPopup.IsOpen = false;
@@ -725,6 +732,10 @@ public class TabViewListView : ListBox
     private DispatcherTimer _scrollTimer;
     private int _scrollDirection;
     private Rect _noAutoScrollRect;
+
+    private const string s_tpScrollViewer = "ScrollViewer";
+
+    private const string s_pcReorder = ":reorder";
 
     private enum AutoScrollAction
     {

--- a/FluentAvalonia/UI/Controls/TabView/TabViewStackPanel.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabViewStackPanel.cs
@@ -4,6 +4,12 @@ using Avalonia.Controls;
 
 namespace FluentAvalonia.UI.Controls;
 
+/// <summary>
+/// Special panel for a <see cref="TabViewListView"/> that supports reorder/drag visual feedback
+/// </summary>
+/// <remarks>
+/// This panel should not be used outside of the TabViewListView
+/// </remarks>
 public class TabViewStackPanel : Panel
 {
     protected override Size MeasureOverride(Size availableSize)

--- a/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls.Primitives;
 
@@ -37,7 +38,7 @@ public class TaskDialogButtonHost : Avalonia.Controls.Button
 
         if (change.Property == IconSourceProperty)
         {
-            PseudoClasses.Set(":icon", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, change.NewValue != null);
         }
     }
 }

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -84,7 +84,7 @@ public partial class TaskDialog : ContentControl
         }
         else if (change.Property == HeaderProperty)
         {
-            PseudoClasses.Set(s_pcHeader, change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcHeader, change.NewValue != null);
         }
         else if (change.Property == SubHeaderProperty)
         {
@@ -586,23 +586,5 @@ public partial class TaskDialog : ContentControl
     internal bool _hasDeferralActive = false;
 
     private IInputElement _previousFocus;
-    private bool _ignoreWindowClosingEvent;
-
-    private const string s_tpButtonsHost = "ButtonsHost";
-    private const string s_tpCommandsHost = "CommandsHost";
-    private const string s_tpProgressBar = "ProgressBar";
-    private const string s_tpMoreDetailsButton = "MoreDetailsButton";
-
-    private const string s_pcHidden = ":hidden";
-    private const string s_pcHosted = ":hosted";
-    private const string s_pcHeader = ":header";
-    private const string s_pcSubheader = ":subheader";
-    private const string s_pcFooter = ":footer";
-    private const string s_pcFooterAuto = ":footerAuto";
-    private const string s_pcExpanded = ":expanded";
-    private const string s_pcProgress = ":progress";
-    private const string s_pcProgressError = ":progressError";
-    private const string s_pcProgressSuspend = ":progressSuspend";
-
-    private const string s_cFATDCom = "FA_TaskDialogCommand";
+    private bool _ignoreWindowClosingEvent;    
 }

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -17,13 +17,6 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace FluentAvalonia.UI.Controls;
 
-[PseudoClasses(s_pcHosted, s_pcHidden, s_pcOpen)]
-[PseudoClasses(s_pcHeader, s_pcSubheader, s_pcIcon, s_pcFooter, s_pcFooterAuto, s_pcExpanded)]
-[PseudoClasses(s_pcProgress, s_pcProgressError, s_pcProgressSuspend)]
-[TemplatePart(s_tpButtonsHost, typeof(ItemsPresenter))]
-[TemplatePart(s_tpCommandsHost, typeof(ItemsPresenter))]
-[TemplatePart(s_tpMoreDetailsButton, typeof(Button))]
-[TemplatePart(s_tpProgressBar, typeof(ProgressBar))]
 /// <summary>
 /// Represents and enhanced dialog with enhanced button, command, and progress support
 /// </summary>
@@ -87,7 +80,7 @@ public partial class TaskDialog : ContentControl
         }
         else if (change.Property == IconSourceProperty)
         {
-            PseudoClasses.Set(s_pcIcon, change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, change.NewValue != null);
         }
         else if (change.Property == HeaderProperty)
         {
@@ -205,7 +198,7 @@ public partial class TaskDialog : ContentControl
 
             TrySetInitialFocus();
 
-            PseudoClasses.Set(s_pcOpen, true);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, true);
             PseudoClasses.Set(s_pcHidden, false);
 
             result = await _tcs.Task;
@@ -359,7 +352,7 @@ public partial class TaskDialog : ContentControl
             w.Content = null;
             ReturnDialogToParent();
 
-            PseudoClasses.Set(s_pcOpen, false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, false);
             PseudoClasses.Set(s_pcHidden, true);
 
             // Fully close the dialog sending the result back
@@ -373,7 +366,7 @@ public partial class TaskDialog : ContentControl
 
             Focus();
 
-            PseudoClasses.Set(s_pcOpen, false);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, false);
             PseudoClasses.Set(s_pcHidden, true);
 
             // Let the close animation finish (now 0.167s in new WinUI update...)
@@ -466,7 +459,7 @@ public partial class TaskDialog : ContentControl
                     throw new InvalidOperationException("Cannot set 'IsDefault' property on more than one item in a TaskDialog");
 
                 foundDefault = true;
-                b.Classes.Add(ContentDialog.s_cAccent);
+                b.Classes.Add(SharedPseudoclasses.s_cAccent);
                 _defaultButton = b;
             }
             buttons.Add(b);
@@ -527,7 +520,7 @@ public partial class TaskDialog : ContentControl
                         throw new InvalidOperationException("Cannot set 'IsDefault' property on more than one item in a TaskDialog");
 
                     foundDefault = true;
-                    com.Classes.Add(ContentDialog.s_cAccent);
+                    com.Classes.Add(SharedPseudoclasses.s_cAccent);
                     _defaultButton = com;
                 }
 
@@ -601,11 +594,9 @@ public partial class TaskDialog : ContentControl
     private const string s_tpMoreDetailsButton = "MoreDetailsButton";
 
     private const string s_pcHidden = ":hidden";
-    private const string s_pcOpen = ":open";
     private const string s_pcHosted = ":hosted";
     private const string s_pcHeader = ":header";
     private const string s_pcSubheader = ":subheader";
-    private const string s_pcIcon = ":icon";
     private const string s_pcFooter = ":footer";
     private const string s_pcFooterAuto = ":footerAuto";
     private const string s_pcExpanded = ":expanded";

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
@@ -11,7 +11,7 @@ using FluentAvalonia.Core;
 namespace FluentAvalonia.UI.Controls;
 
 [PseudoClasses(s_pcHosted, s_pcHidden, SharedPseudoclasses.s_pcOpen)]
-[PseudoClasses(s_pcHeader, s_pcSubheader, SharedPseudoclasses.s_pcIcon, s_pcFooter, s_pcFooterAuto, s_pcExpanded)]
+[PseudoClasses(SharedPseudoclasses.s_pcHeader, s_pcSubheader, SharedPseudoclasses.s_pcIcon, s_pcFooter, s_pcFooterAuto, s_pcExpanded)]
 [PseudoClasses(s_pcProgress, s_pcProgressError, s_pcProgressSuspend)]
 [TemplatePart(s_tpButtonsHost, typeof(ItemsPresenter))]
 [TemplatePart(s_tpCommandsHost, typeof(ItemsPresenter))]
@@ -221,4 +221,21 @@ public partial class TaskDialog
 
     private IList<TaskDialogButton> _buttons;
     private IList<TaskDialogCommand> _commands;
+
+    private const string s_tpButtonsHost = "ButtonsHost";
+    private const string s_tpCommandsHost = "CommandsHost";
+    private const string s_tpProgressBar = "ProgressBar";
+    private const string s_tpMoreDetailsButton = "MoreDetailsButton";
+
+    private const string s_pcHidden = ":hidden";
+    private const string s_pcHosted = ":hosted";
+    private const string s_pcSubheader = ":subheader";
+    private const string s_pcFooter = ":footer";
+    private const string s_pcFooterAuto = ":footerAuto";
+    private const string s_pcExpanded = ":expanded";
+    private const string s_pcProgress = ":progress";
+    private const string s_pcProgressError = ":progressError";
+    private const string s_pcProgressSuspend = ":progressSuspend";
+
+    private const string s_cFATDCom = "FA_TaskDialogCommand";
 }

--- a/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
@@ -1,12 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using Avalonia;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
+[PseudoClasses(s_pcHosted, s_pcHidden, SharedPseudoclasses.s_pcOpen)]
+[PseudoClasses(s_pcHeader, s_pcSubheader, SharedPseudoclasses.s_pcIcon, s_pcFooter, s_pcFooterAuto, s_pcExpanded)]
+[PseudoClasses(s_pcProgress, s_pcProgressError, s_pcProgressSuspend)]
+[TemplatePart(s_tpButtonsHost, typeof(ItemsPresenter))]
+[TemplatePart(s_tpCommandsHost, typeof(ItemsPresenter))]
+[TemplatePart(s_tpMoreDetailsButton, typeof(Button))]
+[TemplatePart(s_tpProgressBar, typeof(ProgressBar))]
 public partial class TaskDialog
 {
     /// <summary>

--- a/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.cs
+++ b/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.cs
@@ -6,7 +6,6 @@ using Avalonia.Animation.Easings;
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls;
-using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
@@ -21,15 +20,6 @@ using FluentAvalonia.UI.Controls.Internal;
 
 namespace FluentAvalonia.UI.Controls;
 
-[PseudoClasses(":lightDismiss")]
-[PseudoClasses(":actionButton", ":closeButton")]
-[PseudoClasses(":content", ":icon")]
-[PseudoClasses(":footerClose")]
-[PseudoClasses(":heroContentTop", ":heroContentBottom")]
-[PseudoClasses(s_pcTop, s_pcBottom, s_pcLeft, s_pcRight, s_pcCenter)]
-[PseudoClasses(s_pcTopRight, s_pcTopLeft, s_pcBottomLeft, s_pcBottomRight)]
-[PseudoClasses(s_pcLeftTop, s_pcLeftBottom, s_pcRightTop, s_pcRightBottom)]
-[PseudoClasses(":showTitle", ":showSubTitle")]
 public partial class TeachingTip : ContentControl
 {
     public TeachingTip()
@@ -68,20 +58,20 @@ public partial class TeachingTip : ContentControl
 
         // All of these components are required, so we use Get instead of Find to throw
         // if not found and avoid null checks below
-        _container = e.NameScope.Get<Border>("Container");
+        _container = e.NameScope.Get<Border>(s_tpContainer);
         _rootElement = (Control)_container.Child;
-        _tailOcclusionGrid = e.NameScope.Get<Grid>("TailOcclusionGrid");
-        _contentRootGrid = e.NameScope.Get<Grid>("ContentRootGrid");
-        _nonHeroContentRootGrid = e.NameScope.Get<Grid>("NonHeroContentRootGrid");
-        _heroContentBorder = e.NameScope.Get<Border>("HeroContentBorder");
-        _actionButton = e.NameScope.Get<Button>("ActionButton");
-        _alternateCloseButton = e.NameScope.Get<Button>("AlternateCloseButton");
-        _closeButton = e.NameScope.Get<Button>("CloseButton");
+        _tailOcclusionGrid = e.NameScope.Get<Grid>(s_tpTailOcclusionGrid);
+        _contentRootGrid = e.NameScope.Get<Grid>(s_tpContentRootGrid);
+        _nonHeroContentRootGrid = e.NameScope.Get<Grid>(s_tpNonHeroContentRootGrid);
+        _heroContentBorder = e.NameScope.Get<Border>(s_tpHeroContentBorder);
+        _actionButton = e.NameScope.Get<Button>(s_tpActionButton);
+        _alternateCloseButton = e.NameScope.Get<Button>(s_tpAlternateCloseButton);
+        _closeButton = e.NameScope.Get<Button>(s_tpCloseButton);
         // This isn't used in Fluentv2
         // _tailEdgeBorder = e.NameScope.Get<Grid>("TailEdgeBorder");
-        _tailPolygon = e.NameScope.Get<Path>("TailPolygon");
-        ToggleVisibilityForEmptyContent(s_TitleTextVisibleStateName, Title);
-        ToggleVisibilityForEmptyContent(s_SubTitleTextVisibleStateName, Subtitle);
+        _tailPolygon = e.NameScope.Get<Path>(s_tpTailPolygon);
+        ToggleVisibilityForEmptyContent(s_pcShowTitle, Title);
+        ToggleVisibilityForEmptyContent(s_pcShowSubTitle, Subtitle);
 
         // We rip out the bulk of the template content and reparent it into a Popup. This allows declaring
         // the TeachingTip in Xaml without worrying about its parent and making sure it returns back in the
@@ -172,11 +162,11 @@ public partial class TeachingTip : ContentControl
         else if (change.Property == TitleProperty)
         {
             SetPopupAutomationProperties();
-            ToggleVisibilityForEmptyContent(s_TitleTextVisibleStateName, change.GetNewValue<string>());
+            ToggleVisibilityForEmptyContent(s_pcShowTitle, change.GetNewValue<string>());
         }
         else if (change.Property == SubtitleProperty)
         {
-            ToggleVisibilityForEmptyContent(s_TitleTextVisibleStateName, change.GetNewValue<string>());
+            ToggleVisibilityForEmptyContent(s_pcShowSubTitle, change.GetNewValue<string>());
         }
         else if (change.Property == ActionButtonContentProperty)
         {
@@ -190,7 +180,7 @@ public partial class TeachingTip : ContentControl
         }
         else if (change.Property == ContentProperty)
         {
-            PseudoClasses.Set(":content", change.NewValue != null);
+            PseudoClasses.Set(s_pcContent, change.NewValue != null);
         }
     }
 
@@ -962,11 +952,11 @@ public partial class TeachingTip : ContentControl
         var closeContent = CloseButtonContent;
         var isLightDismiss = IsLightDismissEnabled;
 
-        PseudoClasses.Set(":actionButton", actionContent != null);
-        PseudoClasses.Set(":closeButton", closeContent != null);
+        PseudoClasses.Set(s_pcActionButton, actionContent != null);
+        PseudoClasses.Set(s_pcCloseButton, closeContent != null);
 
         // HeaderCloseButton is the default state
-        PseudoClasses.Set(":footerClose", isLightDismiss || closeContent != null);
+        PseudoClasses.Set(s_pcFooterClose, isLightDismiss || closeContent != null);
     }
 
     private void UpdateDynamicHeroContentPlacementToTop()
@@ -979,8 +969,8 @@ public partial class TeachingTip : ContentControl
 
     private void UpdateDynamicHeroContentPlacementToTopImpl()
     {
-        PseudoClasses.Set(":heroContentTop", true);
-        PseudoClasses.Set(":heroContentBottom", false);
+        PseudoClasses.Set(s_pcHeroContentTop, true);
+        PseudoClasses.Set(s_pcHeroContentBottom, false);
 
         if (_currentHeroContentEffectivePlacementMode != TeachingTipHeroContentPlacementMode.Top)
         {
@@ -998,8 +988,8 @@ public partial class TeachingTip : ContentControl
 
     private void UpdateDynamicHeroContentPlacementToBottomImpl()
     {
-        PseudoClasses.Set(":heroContentTop", false);
-        PseudoClasses.Set(":heroContentBottom", true);
+        PseudoClasses.Set(s_pcHeroContentTop, false);
+        PseudoClasses.Set(s_pcHeroContentBottom, true);
 
         if (_currentHeroContentEffectivePlacementMode != TeachingTipHeroContentPlacementMode.Bottom)
         {
@@ -1204,7 +1194,7 @@ public partial class TeachingTip : ContentControl
             ts.IconElement = null;
         }
 
-        PseudoClasses.Set(":icon", ico != null);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, ico != null);
     }
 
     private void OnPlacementMarginChanged()
@@ -1218,7 +1208,7 @@ public partial class TeachingTip : ContentControl
     private void OnIsLightDismissEnabledChanged()
     {
         bool ld = IsLightDismissEnabled;
-        PseudoClasses.Set(":lightDismiss", ld);
+        PseudoClasses.Set(s_pcLightDismiss, ld);
 
         if (ld)
         {
@@ -2480,25 +2470,14 @@ public partial class TeachingTip : ContentControl
     //Ideally this would be computed from layout but it is difficult to do.
     private static readonly float s_tailOcclusionAmount = 2;
 
-    private static readonly string s_TitleTextVisibleStateName = ":showTitle";
-    private static readonly string s_SubTitleTextVisibleStateName = ":showSubtitle";
+    // These will just use the s_pc[] naming, but preserve these for reference from upstream
+    // private static readonly string s_TitleTextVisibleStateName = ":showTitle";
+    // private static readonly string s_SubTitleTextVisibleStateName = ":showSubtitle";
 
     private static readonly string SR_TeachingTipAlternateCloseButtonName = "TeachingTipAlternateCloseButtonName";
     private static readonly string SR_TeachingTipAlternateCloseButtonTooltip = "TeachingTipAlternateCloseButtonTooltip";
 
-    private const string s_pcTop = ":top";
-    private const string s_pcLeft = ":left";
-    private const string s_pcRight = ":right";
-    private const string s_pcBottom = ":bottom";
-    private const string s_pcTopLeft = ":topLeft";
-    private const string s_pcTopRight = ":topRight";
-    private const string s_pcBottomLeft = ":bottomLeft";
-    private const string s_pcBottomRight = ":bottomRight";
-    private const string s_pcLeftTop = ":leftTop";
-    private const string s_pcRightTop = ":rightTop";
-    private const string s_pcLeftBottom = ":leftBottom";
-    private const string s_pcRightBottom = ":rightBottom";
-    private const string s_pcCenter = ":center";
+    
 
     private class ScopedBatchHelper
     {

--- a/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
+++ b/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
@@ -5,6 +5,8 @@ using Avalonia.Controls;
 using FluentAvalonia.Core;
 using Avalonia.Styling;
 using FluentAvalonia.Core.Attributes;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Shapes;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -13,6 +15,24 @@ namespace FluentAvalonia.UI.Controls;
 /// It supports rich content (including titles, subtitles, icons, images, and text) and can be 
 /// configured for either explicit or light-dismiss.
 /// </summary>
+[PseudoClasses(s_pcLightDismiss)]
+[PseudoClasses(s_pcActionButton, s_pcCloseButton)]
+[PseudoClasses(s_pcContent, SharedPseudoclasses.s_pcIcon)]
+[PseudoClasses(s_pcFooterClose)]
+[PseudoClasses(s_pcHeroContentTop, s_pcHeroContentBottom)]
+[PseudoClasses(s_pcTop, s_pcBottom, s_pcLeft, s_pcRight, s_pcCenter)]
+[PseudoClasses(s_pcTopRight, s_pcTopLeft, s_pcBottomLeft, s_pcBottomRight)]
+[PseudoClasses(s_pcLeftTop, s_pcLeftBottom, s_pcRightTop, s_pcRightBottom)]
+[PseudoClasses(s_pcShowTitle, s_pcShowSubTitle)]
+[TemplatePart(s_tpContainer, typeof(Border))]
+[TemplatePart(s_tpTailOcclusionGrid, typeof(Grid))]
+[TemplatePart(s_tpContentRootGrid, typeof(Grid))]
+[TemplatePart(s_tpNonHeroContentRootGrid, typeof(Grid))]
+[TemplatePart(s_tpHeroContentBorder, typeof(Border))]
+[TemplatePart(s_tpActionButton, typeof(Button))]
+[TemplatePart(s_tpAlternateCloseButton, typeof(Button))]
+[TemplatePart(s_tpCloseButton, typeof(Button))]
+[TemplatePart(s_tpTailPolygon, typeof(Path))]
 public partial class TeachingTip : ContentControl
 {
     /// <summary>
@@ -361,4 +381,38 @@ public partial class TeachingTip : ContentControl
     public event TypedEventHandler<TeachingTip, TeachingTipClosedEventArgs> Closed;
 
     private bool _isOpen;
+
+    private const string s_tpContainer = "Container";
+    private const string s_tpTailOcclusionGrid = "TailOcclusionGrid";
+    private const string s_tpContentRootGrid = "ContentRootGrid";
+    private const string s_tpNonHeroContentRootGrid = "NonHeroContentRootGrid";
+    private const string s_tpHeroContentBorder = "HeroContentBorder";
+    private const string s_tpActionButton = "ActionButton";
+    private const string s_tpAlternateCloseButton = "AlternateCloseButton";
+    private const string s_tpCloseButton = "CloseButton";
+    private const string s_tpTailPolygon = "TailPolygon";
+
+    private const string s_pcContent = ":content";
+    private const string s_pcLightDismiss = ":lightDismiss";
+    private const string s_pcActionButton = ":actionButton";
+    private const string s_pcCloseButton = ":closeButton";
+    private const string s_pcFooterClose = ":footerClose";
+    private const string s_pcHeroContentTop = ":heroContentTop";
+    private const string s_pcHeroContentBottom = ":heroContentBottom";
+    private const string s_pcShowTitle = ":showTitle";
+    private const string s_pcShowSubTitle = ":showSubTitle";
+
+    private const string s_pcTop = ":top";
+    private const string s_pcLeft = ":left";
+    private const string s_pcRight = ":right";
+    private const string s_pcBottom = ":bottom";
+    private const string s_pcTopLeft = ":topLeft";
+    private const string s_pcTopRight = ":topRight";
+    private const string s_pcBottomLeft = ":bottomLeft";
+    private const string s_pcBottomRight = ":bottomRight";
+    private const string s_pcLeftTop = ":leftTop";
+    private const string s_pcRightTop = ":rightTop";
+    private const string s_pcLeftBottom = ":leftBottom";
+    private const string s_pcRightBottom = ":rightBottom";
+    private const string s_pcCenter = ":center";
 }


### PR DESCRIPTION
Adding support for the `TemplatePart` attribute for all controls and some missing `Pseudoclasses` attributes. Primarily needed for what I want to do with the new documentation pages, but may also be helpful to others.

As part of this change, I'm making all template parts and pseudoclasses const string references. Several controls share pseudoclasses with the same name, so I'm splitting them out into a "shared" class to cut down on duplicate strings. 

Other changes:
- ColorPickerButton
  - `MainButton` template part renamed to `ShowFlyoutButton`