### PR TITLE
Set ContentControlThemeFontFamily for unhandled platforms

### DIFF
--- a/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
+++ b/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.cs
@@ -330,6 +330,11 @@ public partial class FluentAvaloniaTheme : IStyle, IResourceProvider
         {
             theme = ResolveMacOSSystemSettings();
         }
+        else
+        {
+            // Needed for mobile/unhandled platforms
+            AddOrUpdateSystemResource("ContentControlThemeFontFamily", FontFamily.Default);
+        }
 
         // Load the SymbolThemeFontFamily
         AddOrUpdateSystemResource("SymbolThemeFontFamily", new FontFamily(new Uri("avares://FluentAvalonia"), "/Fonts/#Symbols"));


### PR DESCRIPTION
I use this library on mobile for its excellent ContentDialog control, but said control crashes on iOS with "Static resource 'ContentControlThemeFontFamily' not found."

I tracked this down to each call to `Resolve[Platform]SystemSettings()` setting at least `FontFamily.Default` as the default font, but since iOS isn't handled by any of the desktop platform checking branches, the static resource never gets added.