### PR TITLE
Refactor FATheme...again (prep for next preview)

### DIFF
--- a/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.windows.cs
+++ b/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.windows.cs
@@ -125,7 +125,7 @@ public partial class FluentAvaloniaTheme
             try
             {
                 var color = (Color)settings.UIElementColor(element);
-                (_themeResources.MergedDictionaries[1] as ResourceDictionary)[resKey] = color;
+                (Resources.MergedDictionaries[1] as ResourceDictionary)[resKey] = color;
             }
             catch
             {
@@ -170,9 +170,6 @@ public partial class FluentAvaloniaTheme
             LoadDefaultAccentColor();
         }
     }
-
-
-
 
     /// <summary>
     /// On Windows, forces a specific <see cref="Window"/> to the current theme


### PR DESCRIPTION
A coming change from upstream for preview 5 is going to make the current way FATheme works not work (most likely). Styling has had a refactoring which means the `TryAttach` API no longer exists publicly. Technically this API comes from an interface which is `[NotClientImplementable]` but because I want complete control over how FATheme loads/unloads theme components, I take this risk - and here we are. A lot of this comes from before ControlThemes were introduced and managing everything was a bit more tedious.

To fix this, and help future proof it, FATheme now inherits directly from `Styles` which is similar to how the upstream Simple and Fluent themes work. This also means that I no longer maintain the code that ensures styles are correctly attached and that is back upstream, which is also a big plus). Part of FATheme's behavior is to search the Application ResourceDictionary for resource overrides so we still have to implement `IResourceProvider` to override the non-virtual `TryGetResource` in Styles (which this is NotClientImplementable) but its the only way to ensure that this behavior still works.

There will probably be another refactoring in the future if/when ThemeDictionary support is added - but that's going to be a much bigger change and we'll deal with that when we get there.