### PR TITLE
Standardize to IconSource in all controls

### DIFF
--- a/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarButtonStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarButtonStyles.axaml
@@ -6,7 +6,7 @@
         <Border Width="400" Padding="50" Height="400">
             <StackPanel Spacing="5">
                 <Border Background="SteelBlue">
-                    <ui:CommandBarButton Label="Button1" Icon="Save" HotKey="Ctrl+S" IsCompact="True">
+                    <ui:CommandBarButton Label="Button1" IconSource="Save" HotKey="Ctrl+S" IsCompact="True">
                         <ui:CommandBarButton.Flyout>
                             <Flyout />
                         </ui:CommandBarButton.Flyout>
@@ -14,18 +14,18 @@
                 </Border>
 
                 <ui:CommandBarOverflowPresenter>
-                    <ui:CommandBarButton Label="Button1" Icon="Save">
+                    <ui:CommandBarButton Label="Button1" IconSource="Save">
                         <ui:CommandBarButton.Flyout>
                             <Flyout />
                         </ui:CommandBarButton.Flyout>
                     </ui:CommandBarButton>
-                    <ui:CommandBarButton Label="Button1" Icon="Save" />
+                    <ui:CommandBarButton Label="Button1" IconSource="Save" />
                 </ui:CommandBarOverflowPresenter>
 
                 <ui:CommandBar ClosedDisplayMode="Compact" IsOpen="False"
 							   DefaultLabelPosition="Right">
                     <ui:CommandBar.PrimaryCommands>
-                        <ui:CommandBarButton Label="Test" Icon="Save" IsCompact="False" />
+                        <ui:CommandBarButton Label="Test" IconSource="Save" IsCompact="False" />
                     </ui:CommandBar.PrimaryCommands>
                 </ui:CommandBar>
             </StackPanel>
@@ -91,7 +91,7 @@
                                  Margin="{DynamicResource AppBarButtonContentViewboxCollapsedMargin}"
                                  HorizontalAlignment="Stretch">
                             <ContentPresenter Name="Content"
-											  Content="{TemplateBinding Icon}"
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"
 											  Foreground="{TemplateBinding Foreground}" />
                         </Viewbox>
 

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarFlyoutCommandBarStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarFlyoutCommandBarStyles.axaml
@@ -6,13 +6,13 @@
         <Border Padding="20" Background="#E0E0E0">
             <ui:CommandBarFlyoutCommandBar IsOpen="True" Margin="30">
                 <ui:CommandBarFlyoutCommandBar.PrimaryCommands>
-                    <ui:CommandBarButton Icon="Save" />
-                    <ui:CommandBarToggleButton Icon="Globe" />
+                    <ui:CommandBarButton IconSource="Save" />
+                    <ui:CommandBarToggleButton IconSource="Globe" />
                 </ui:CommandBarFlyoutCommandBar.PrimaryCommands>
 
                 <ui:CommandBarFlyoutCommandBar.SecondaryCommands>
-                    <ui:CommandBarButton Icon="Save" Label="Save" HotKey="Ctrl+S" />
-                    <ui:CommandBarToggleButton Icon="ChevronUp" Label="Move Up" IsChecked="True" HotKey="Ctrl+F1" />
+                    <ui:CommandBarButton IconSource="Save" Label="Save" HotKey="Ctrl+S" />
+                    <ui:CommandBarToggleButton IconSource="ChevronUp" Label="Move Up" IsChecked="True" HotKey="Ctrl+F1" />
                 </ui:CommandBarFlyoutCommandBar.SecondaryCommands>
             </ui:CommandBarFlyoutCommandBar>
         </Border>
@@ -152,7 +152,7 @@
                                  Height="20"
                                  HorizontalAlignment="Stretch">
                             <ContentPresenter Name="Content"
-											  Content="{TemplateBinding Icon}"
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"
 											  Foreground="{TemplateBinding Foreground}" />
                         </Viewbox>
 
@@ -407,7 +407,7 @@
                                  Height="20"
                                  HorizontalAlignment="Stretch">
                             <ContentPresenter Name="Content"
-											  Content="{TemplateBinding Icon}"
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"
 											  Foreground="{TemplateBinding Foreground}" />
                         </Viewbox>
 

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarToggleButtonStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarToggleButtonStyles.axaml
@@ -6,17 +6,17 @@
         <Border Padding="20">
             <Border>
                 <StackPanel>
-                    <ui:CommandBarToggleButton Label="Button1" Icon="Save" HotKey="Ctrl+S" IsCompact="True"/>
+                    <ui:CommandBarToggleButton Label="Button1" IconSource="Save" HotKey="Ctrl+S" IsCompact="True"/>
 
                     <ui:CommandBarOverflowPresenter>
-                        <ui:CommandBarToggleButton Label="Button1" Icon="Save" />
-                        <ui:CommandBarToggleButton Label="Button1" Icon="Save" />
+                        <ui:CommandBarToggleButton Label="Button1" IconSource="Save" />
+                        <ui:CommandBarToggleButton Label="Button1" IconSource="Save" />
                     </ui:CommandBarOverflowPresenter>
 
                     <ui:CommandBar ClosedDisplayMode="Compact" IsOpen="False"
 							   DefaultLabelPosition="Right">
                         <ui:CommandBar.PrimaryCommands>
-                            <ui:CommandBarToggleButton Label="Test" Icon="Save" IsCompact="False" />
+                            <ui:CommandBarToggleButton Label="Test" IconSource="Save" IsCompact="False" />
                         </ui:CommandBar.PrimaryCommands>
                     </ui:CommandBar>
                 </StackPanel>
@@ -87,7 +87,7 @@
                                  Margin="{DynamicResource AppBarButtonContentViewboxCollapsedMargin}"
                                  HorizontalAlignment="Stretch">
                             <ContentPresenter Name="Content"
-											  Content="{TemplateBinding Icon}"
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"
 											  Foreground="{TemplateBinding Foreground}" />
                         </Viewbox>
 

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutItemStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutItemStyles.axaml
@@ -40,7 +40,7 @@
 								 Width="16" Height="16"
                                  IsVisible="False">
                             <ContentPresenter Name="IconContent"
-											  Content="{TemplateBinding Icon}"/>
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"/>
                         </Viewbox>
                         <TextBlock Name="TextBlock"
 								   Text="{TemplateBinding Text}"

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutSubItemStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutSubItemStyles.axaml
@@ -40,7 +40,7 @@
 								 Width="16" Height="16"
                                  IsVisible="False">
                             <ContentPresenter Name="IconContent"
-											  Content="{TemplateBinding Icon}"/>
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"/>
                         </Viewbox>
                         <TextBlock Name="TextBlock"
 								   Text="{TemplateBinding Text}"

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/RadioMenuFlyoutItemStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/RadioMenuFlyoutItemStyles.axaml
@@ -10,6 +10,8 @@
             </ui:FAMenuFlyoutPresenter>
         </Border>
     </Design.PreviewWith>
+    
+    <ui:PathIconSource x:Key="RadioMenuFlyoutItemCheckedIcon" Data="M0,2a2,2 0 1,0 4,0a2,2 0 1,0 -4,0" />
 
     <!-- All resources are in BaseResources.axaml -->
 
@@ -40,13 +42,13 @@
 						Also FluentIcons doesn't have a comparable icon to the WinUI one from Segoe MDL2 Assets
 						so we just use a path icon that draws a small circle and it basically looks the same
 						-->
-                        <ui:FAPathIcon Data="M0,2a2,2 0 1,0 4,0a2,2 0 1,0 -4,0"
-                                     Margin="6 0 16 0"
-                                     Name="CheckGlyph" 
-                                     UseLayoutRounding="False"
-									 VerticalAlignment="Center"
-                                     Opacity="0"
-                                     Foreground="{DynamicResource MenuFlyoutSubItemChevron}"/>
+                        <ui:IconSourceElement IconSource="{StaticResource RadioMenuFlyoutItemCheckedIcon}"
+                                              Margin="6 0 16 0"
+                                              Name="CheckGlyph"
+                                              UseLayoutRounding="False"
+                                              VerticalAlignment="Center"
+                                              Opacity="0"
+                                              Foreground="{DynamicResource MenuFlyoutSubItemChevron}" />
 
                         <Viewbox Name="IconRoot"
 								 Grid.Column="1"
@@ -55,7 +57,7 @@
 								 Width="16" Height="16"
                                  IsVisible="False">
                             <ContentPresenter Name="IconContent"
-											  Content="{TemplateBinding Icon}"/>
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"/>
                         </Viewbox>
                         <TextBlock Name="TextBlock"
 								   Grid.Column="1"
@@ -96,7 +98,7 @@
             <Style Selector="^ /template/ TextBlock#KeyboardAcceleratorTextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPointerOver}" />
             </Style>
-            <Style Selector="^ /template/ ui|FAPathIcon#CheckGlyph">
+            <Style Selector="^ /template/ ui|IconSourceElement#CheckGlyph">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundPointerOver}" />
             </Style>
         </Style>
@@ -114,7 +116,7 @@
             <Style Selector="^ /template/ TextBlock#KeyboardAcceleratorTextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed}" />
             </Style>
-            <Style Selector="^ /template/ ui|FAPathIcon#CheckGlyph">
+            <Style Selector="^ /template/ ui|IconSourceElement#CheckGlyph">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundPressed}" />
             </Style>
         </Style>
@@ -132,12 +134,12 @@
             <Style Selector="^ /template/ TextBlock#KeyboardAcceleratorTextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled}" />
             </Style>
-            <Style Selector="^ /template/ ui|FAPathIcon#CheckGlyph">
+            <Style Selector="^ /template/ ui|IconSourceElement#CheckGlyph">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundDisabled}" />
             </Style>
         </Style>
 
-        <Style Selector="^:checked /template/ ui|FAPathIcon#CheckGlyph">
+        <Style Selector="^:checked /template/ ui|IconSourceElement#CheckGlyph">
             <Setter Property="Opacity" Value="1" />
         </Style>
 

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/ToggleMenuFlyoutItemStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/ToggleMenuFlyoutItemStyles.axaml
@@ -11,6 +11,8 @@
         </Border>
     </Design.PreviewWith>
 
+    <ui:SymbolIconSource x:Key="ToggleMenuFlyoutCheckmarkIcon" Symbol="Checkmark" />
+    
     <!-- All resources are in BaseResources.axaml -->
 
     <ControlTheme x:Key="{x:Type ui:ToggleMenuFlyoutItem}" TargetType="ui:ToggleMenuFlyoutItem">
@@ -35,13 +37,13 @@
 						  Name="LayoutRootGrid"
                           Margin="{DynamicResource MenuFlyoutItemThemePaddingNarrow}">
 
-                        <ui:SymbolIcon Symbol="Checkmark"
-									   Margin="0 0 16 0"
-									   Name="CheckGlyph"
-                                       Opacity="0"
-                                       FlowDirection="LeftToRight"
-                                       Foreground="{DynamicResource MenuFlyoutSubItemChevron}"/>
-
+                        <ui:IconSourceElement IconSource="{StaticResource ToggleMenuFlyoutCheckmarkIcon}"
+                                              Margin="0 0 16 0"
+                                              Name="CheckGlyph"
+                                              Opacity="0"
+                                              FlowDirection="LeftToRight"
+                                              Foreground="{DynamicResource MenuFlyoutSubItemChevron}" />
+                        
                         <Viewbox Name="IconRoot"
 								 Grid.Column="1"
 								 HorizontalAlignment="Left"
@@ -49,7 +51,7 @@
 								 Width="16" Height="16"
                                  IsVisible="False">
                             <ContentPresenter Name="IconContent"
-											  Content="{TemplateBinding Icon}"/>
+											  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"/>
                         </Viewbox>
                         <TextBlock Name="TextBlock"
 								   Grid.Column="1"
@@ -90,7 +92,7 @@
             <Style Selector="^ /template/ TextBlock#KeyboardAcceleratorTextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPointerOver}" />
             </Style>
-            <Style Selector="^ /template/ ui|SymbolIcon#CheckGlyph">
+            <Style Selector="^ /template/ ui|IconSourceElement#CheckGlyph">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundPointerOver}" />
             </Style>
         </Style>
@@ -108,7 +110,7 @@
             <Style Selector="^ /template/ TextBlock#KeyboardAcceleratorTextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed}" />
             </Style>
-            <Style Selector="^ /template/ ui|SymbolIcon#CheckGlyph">
+            <Style Selector="^ /template/ ui|IconSourceElement#CheckGlyph">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundPressed}" />
             </Style>
         </Style>
@@ -126,12 +128,12 @@
             <Style Selector="^ /template/ TextBlock#KeyboardAcceleratorTextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled}" />
             </Style>
-            <Style Selector="^ /template/ ui|SymbolIcon#CheckGlyph">
+            <Style Selector="^ /template/ ui|IconSourceElement#CheckGlyph">
                 <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundDisabled}" />
             </Style>
         </Style>
 
-        <Style Selector="^:checked /template/ ui|SymbolIcon#CheckGlyph">
+        <Style Selector="^:checked /template/ ui|IconSourceElement#CheckGlyph">
             <Setter Property="Opacity" Value="1" />
         </Style>
 

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
@@ -62,7 +62,7 @@
 										 HorizontalAlignment="Center"
                                          Margin="{DynamicResource NavigationViewItemOnLeftIconBoxMargin}">
                                     <ContentPresenter Name="Icon"
-                                                      Content="{TemplateBinding Icon}"
+                                                      Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"
                                                       Foreground="{DynamicResource NavigationViewItemForeground}"/>
                                 </Viewbox>
                             </Border>
@@ -247,7 +247,7 @@
                                      VerticalAlignment="Center"
                                      HorizontalAlignment="Center">
                                 <ContentPresenter Name="Icon"
-                                                  Content="{TemplateBinding Icon}"
+                                                  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"
                                                   Foreground="{DynamicResource TopNavigationViewItemForeground}"/>
                             </Viewbox>
 
@@ -467,7 +467,7 @@
                                      VerticalAlignment="Center"
                                      HorizontalAlignment="Center">
                                 <ContentPresenter Name="Icon"
-                                                  Content="{TemplateBinding Icon}"
+                                                  Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}"
                                                   Foreground="{DynamicResource TopNavigationViewItemForeground}" />
                             </Viewbox>
 

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemStyles.axaml
@@ -35,7 +35,7 @@
                     </Grid.Styles>
                     
                     <uip:NavigationViewItemPresenter Name="NVIPresenter"
-                                                     Icon="{TemplateBinding Icon}"
+                                                     IconSource="{TemplateBinding IconSource}"
 													 InfoBadge="{TemplateBinding InfoBadge}"
                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
                                                      Padding="{TemplateBinding Padding}"

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.cs
@@ -11,14 +11,21 @@ namespace FluentAvalonia.UI.Controls;
 
 public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
 {
+    public CommandBarButton()
+    {
+        TemplateSettings = new CommandBarButtonTemplateSettings();
+    }
+
     Type IStyleable.StyleKey => typeof(CommandBarButton);
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-        if (change.Property == IconProperty)
+
+        if (change.Property == IconSourceProperty)
         {
             PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, change.NewValue != null);
+            TemplateSettings.Icon = IconHelpers.CreateFromUnknown(change.GetNewValue<IconSource>());
         }
         else if (change.Property == LabelProperty)
         {
@@ -62,10 +69,6 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
                 {
                     Label = null;
                 }
-                if (Icon is IconSourceElement ise && ise.IconSource == xamlComOld.IconSource)
-                {
-                    Icon = null;
-                }
 
                 if (HotKey == xamlComOld.HotKey)
                 {
@@ -85,10 +88,7 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
                     Label = xamlCom.Label;
                 }
 
-                if (Icon == null)
-                {
-                    Icon = new IconSourceElement { IconSource = xamlCom.IconSource };
-                }
+                IconSource = xamlCom.IconSource;
 
                 if (HotKey == null)
                 {

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarButton.properties.cs
@@ -21,8 +21,8 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<FAIconElement> IconProperty =
-        AvaloniaProperty.Register<CommandBarButton, FAIconElement>(nameof(Icon));
+    public static readonly StyledProperty<IconSource> IconSourceProperty =
+        SettingsExpander.IconSourceProperty.AddOwner<CommandBarButton>();
 
     /// <summary>
     /// Defines the <see cref="Label"/> property
@@ -42,6 +42,12 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
     /// </summary>
     public static readonly StyledProperty<bool> IsCompactProperty =
         AvaloniaProperty.Register<CommandBarButton, bool>(nameof(IsCompact));
+
+    /// <summary>
+    /// Defines the <see cref="TemplateSettings"/> property
+    /// </summary>
+    public static readonly StyledProperty<CommandBarButtonTemplateSettings> TemplateSettingsProperty =
+        AvaloniaProperty.Register<CommandBarButton, CommandBarButtonTemplateSettings>(nameof(TemplateSettings));
 
     public bool IsCompact
     {
@@ -64,10 +70,10 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
     /// <summary>
     /// Gets or sets the graphic content of the app bar toggle button.
     /// </summary>
-    public FAIconElement Icon
+    public IconSource IconSource
     {
-        get => GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => GetValue(IconSourceProperty);
+        set => SetValue(IconSourceProperty, value);
     }
 
     /// <summary>
@@ -83,6 +89,15 @@ public partial class CommandBarButton : Button, ICommandBarElement, IStyleable
     {
         get => _dynamicOverflowOrder;
         set => SetAndRaise(DynamicOverflowOrderProperty, ref _dynamicOverflowOrder, value);
+    }
+
+    /// <summary>
+    /// Gets the template settings for this CommandBarButton
+    /// </summary>
+    public CommandBarButtonTemplateSettings TemplateSettings
+    {
+        get => GetValue(TemplateSettingsProperty);
+        private set => SetValue(TemplateSettingsProperty, value);
     }
 
     private bool _isInOverflow;

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarButtonTemplateSettings.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarButtonTemplateSettings.cs
@@ -1,0 +1,24 @@
+﻿using Avalonia;
+
+namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Stores settings for use in the template of a CommandBarButton
+/// </summary>
+public class CommandBarButtonTemplateSettings : AvaloniaObject
+{
+    /// <summary>
+    /// Defines the <see cref="Icon"/> property
+    /// </summary>
+    public static readonly StyledProperty<FAIconElement> IconProperty =
+        MenuFlyoutItemTemplateSettings.IconProperty.AddOwner<CommandBarButtonTemplateSettings>();
+
+    /// <summary>
+    /// Gets the Icon for the CommandBarButton
+    /// </summary>
+    public FAIconElement Icon
+    {
+        get => GetValue(IconProperty);
+        internal set => SetValue(IconProperty, value);
+    }
+}

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
@@ -77,7 +77,7 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
         {
             if (l[i] is CommandBarButton cbb)
             {
-                if (cbb.Icon != null)
+                if (cbb.IconSource != null)
                     _hasIcons++;
 
                 cbb.IsInOverflow = true;
@@ -86,7 +86,7 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
             {
                 _hasToggle++;
 
-                if (cbtb.Icon != null)
+                if (cbtb.IconSource != null)
                     _hasIcons++;
 
                 cbtb.IsInOverflow = true;
@@ -108,7 +108,7 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
         {
             if (l[i] is CommandBarButton cbb)
             {
-                if (cbb.Icon != null)
+                if (cbb.IconSource != null)
                     _hasIcons--;
 
                 cbb.IsInOverflow = false;
@@ -119,7 +119,7 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
             {
                 _hasToggle--;
 
-                if (cbtb.Icon != null)
+                if (cbtb.IconSource != null)
                     _hasIcons--;
 
                 cbtb.IsInOverflow = false;

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.cs
@@ -14,14 +14,21 @@ namespace FluentAvalonia.UI.Controls;
 /// </summary>
 public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, IStyleable
 {
+    public CommandBarToggleButton()
+    {
+        TemplateSettings = new CommandBarButtonTemplateSettings();
+    }
+
     Type IStyleable.StyleKey => typeof(CommandBarToggleButton);
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-        if (change.Property == IconProperty)
+
+        if (change.Property == IconSourceProperty)
         {
             PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, change.NewValue != null);
+            TemplateSettings.Icon = IconHelpers.CreateFromUnknown(change.GetNewValue<IconSource>());
         }
         else if (change.Property == LabelProperty)
         {
@@ -43,10 +50,6 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
                 {
                     Label = null;
                 }
-                if (Icon is IconSourceElement ise && ise.IconSource == xamlComOld.IconSource)
-                {
-                    Icon = null;
-                }
 
                 if (HotKey == xamlComOld.HotKey)
                 {
@@ -66,10 +69,7 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
                     Label = xamlCom.Label;
                 }
 
-                if (Icon == null)
-                {
-                    Icon = new IconSourceElement { IconSource = xamlCom.IconSource };
-                }
+                IconSource = xamlCom.IconSource;
 
                 if (HotKey == null)
                 {

--- a/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.properties.cs
+++ b/FluentAvalonia/UI/Controls/CommandBar/CommandBarToggleButton.properties.cs
@@ -18,8 +18,8 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<FAIconElement> IconProperty =
-        AvaloniaProperty.Register<CommandBarToggleButton, FAIconElement>(nameof(Icon));
+    public static readonly StyledProperty<IconSource> IconSourceProperty =
+        SettingsExpander.IconSourceProperty.AddOwner<CommandBarButton>();
 
     /// <summary>
     /// Defines the <see cref="Label"/> property
@@ -39,6 +39,12 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
     /// </summary>
     public static readonly StyledProperty<bool> IsCompactProperty =
         AvaloniaProperty.Register<CommandBarToggleButton, bool>(nameof(IsCompact));
+
+    /// <summary>
+    /// Defines the <see cref="TemplateSettings"/> property
+    /// </summary>
+    public static readonly StyledProperty<CommandBarButtonTemplateSettings> TemplateSettingsProperty =
+        AvaloniaProperty.Register<CommandBarToggleButton, CommandBarButtonTemplateSettings>(nameof(TemplateSettings));
 
     public bool IsCompact
     {
@@ -61,10 +67,10 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
     /// <summary>
     /// Gets or sets the graphic content of the command bar toggle button.
     /// </summary>
-    public FAIconElement Icon
+    public IconSource IconSource
     {
-        get => GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => GetValue(IconSourceProperty);
+        set => SetValue(IconSourceProperty, value);
     }
 
     /// <summary>
@@ -80,6 +86,15 @@ public partial class CommandBarToggleButton : ToggleButton, ICommandBarElement, 
     {
         get => _dynamicOverflowOrder;
         set => SetAndRaise(DynamicOverflowOrderProperty, ref _dynamicOverflowOrder, value);
+    }
+
+    /// <summary>
+    /// Gets the template settings for this CommandBarButton
+    /// </summary>
+    public CommandBarButtonTemplateSettings TemplateSettings
+    {
+        get => GetValue(TemplateSettingsProperty);
+        private set => SetValue(TemplateSettingsProperty, value);
     }
 
     private bool _isInOverflow;

--- a/FluentAvalonia/UI/Controls/InfoBadge/InfoBadge.properties.cs
+++ b/FluentAvalonia/UI/Controls/InfoBadge/InfoBadge.properties.cs
@@ -22,7 +22,7 @@ public partial class InfoBadge : TemplatedControl
     /// Defines the <see cref="IconSource"/> property
     /// </summary>
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        AvaloniaProperty.Register<InfoBadge, IconSource>(nameof(IconSource));
+        SettingsExpander.IconSourceProperty.AddOwner<InfoBadge>();
 
     /// <summary>
     /// Defines the <see cref="TemplateSettings"/> property

--- a/FluentAvalonia/UI/Controls/InfoBar/InfoBar.properties.cs
+++ b/FluentAvalonia/UI/Controls/InfoBar/InfoBar.properties.cs
@@ -48,7 +48,7 @@ public partial class InfoBar : ContentControl
     /// Defines the <see cref="IconSource"/> property
     /// </summary>
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        AvaloniaProperty.Register<InfoBar, IconSource>(nameof(IconSource));
+        SettingsExpander.IconSourceProperty.AddOwner<IconSource>();
 
     /// <summary>
     /// Defines the <see cref="IsIconVisible"/> property

--- a/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
@@ -96,7 +96,7 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
         {
             if (e.Containers[i].ContainerControl is ToggleMenuFlyoutItem tmfi)
             {
-                if (tmfi.Icon != null)
+                if (tmfi.IconSource != null)
                 {
                     iconCount++;
                 }
@@ -105,7 +105,7 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
             }
             else if (e.Containers[i].ContainerControl is RadioMenuFlyoutItem rmfi)
             {
-                if (rmfi.Icon != null)
+                if (rmfi.IconSource != null)
                 {
                     iconCount++;
                 }
@@ -114,14 +114,14 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
             }
             else if (e.Containers[i].ContainerControl is MenuFlyoutItem mfi)
             {
-                if (mfi.Icon != null)
+                if (mfi.IconSource != null)
                 {
                     iconCount++;
                 }
             }
             else if (e.Containers[i].ContainerControl is MenuFlyoutSubItem mfsi)
             {
-                if (mfsi.Icon != null)
+                if (mfsi.IconSource != null)
                 {
                     iconCount++;
                 }
@@ -151,7 +151,7 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
         {
             if (e.Containers[i].ContainerControl is ToggleMenuFlyoutItem tmfi)
             {
-                if (tmfi.Icon != null)
+                if (tmfi.IconSource != null)
                 {
                     iconCount--;
                 }
@@ -160,7 +160,7 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
             }
             else if (e.Containers[i].ContainerControl is RadioMenuFlyoutItem rmfi)
             {
-                if (rmfi.Icon != null)
+                if (rmfi.IconSource != null)
                 {
                     iconCount--;
                 }
@@ -169,14 +169,14 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
             }
             else if (e.Containers[i].ContainerControl is MenuFlyoutItem mfi)
             {
-                if (mfi.Icon != null)
+                if (mfi.IconSource != null)
                 {
                     iconCount--;
                 }
             }
             else if (e.Containers[i].ContainerControl is MenuFlyoutSubItem mfsi)
             {
-                if (mfsi.Icon != null)
+                if (mfsi.IconSource != null)
                 {
                     iconCount--;
                 }

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Metadata;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
@@ -16,6 +15,11 @@ namespace FluentAvalonia.UI.Controls;
 /// </summary>
 public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSource
 {
+    public MenuFlyoutItem()
+    {
+        TemplateSettings = new MenuFlyoutItemTemplateSettings();
+    }
+
     protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
     {
         if (_hotkey != null)
@@ -68,11 +72,6 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
                     Text = null;
                 }
 
-                if (Icon is IconSourceElement ele && ele.IconSource == oldXaml.IconSource)
-                {
-                    Icon = null;
-                }
-
                 if (InputGesture == oldXaml.HotKey)
                 {
                     HotKey = null;
@@ -88,7 +87,7 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
 
                 if (Icon == null)
                 {
-                    Icon = new IconSourceElement { IconSource = newXaml.IconSource };
+                    Icon = newXaml.IconSource;
                 }
 
                 if (InputGesture == null)
@@ -124,6 +123,10 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
         {
             var kg = change.GetNewValue<KeyGesture>();
             InputGesture = kg;
+        }
+        else if (change.Property == IconProperty)
+        {
+            TemplateSettings.Icon = IconHelpers.CreateFromUnknown(change.GetNewValue<IconSource>());
         }
     }
 

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -85,9 +85,9 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
                     Text = newXaml.Label;
                 }
 
-                if (Icon == null)
+                if (IconSource == null)
                 {
-                    Icon = newXaml.IconSource;
+                    IconSource = newXaml.IconSource;
                 }
 
                 if (InputGesture == null)
@@ -124,7 +124,7 @@ public partial class MenuFlyoutItem : MenuFlyoutItemBase, IMenuItem, ICommandSou
             var kg = change.GetNewValue<KeyGesture>();
             InputGesture = kg;
         }
-        else if (change.Property == IconProperty)
+        else if (change.Property == IconSourceProperty)
         {
             TemplateSettings.Icon = IconHelpers.CreateFromUnknown(change.GetNewValue<IconSource>());
         }

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
@@ -25,7 +25,7 @@ public partial class MenuFlyoutItem
     /// Defines the <see cref="Icon"/> property
     /// </summary>
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        AvaloniaProperty.Register<MenuFlyoutItem, IconSource>(nameof(IconSource));
+        SettingsExpander.IconSourceProperty.AddOwner<MenuFlyoutItem>();
 
     /// <summary>
     /// Defines the <see cref="Command"/> property

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
@@ -24,8 +24,8 @@ public partial class MenuFlyoutItem
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<FAIconElement> IconProperty =
-        AvaloniaProperty.Register<MenuFlyoutItem, FAIconElement>(nameof(Icon));
+    public static readonly StyledProperty<IconSource> IconProperty =
+        AvaloniaProperty.Register<MenuFlyoutItem, IconSource>(nameof(Icon));
 
     /// <summary>
     /// Defines the <see cref="Command"/> property
@@ -53,6 +53,12 @@ public partial class MenuFlyoutItem
         AvaloniaProperty.Register<MenuFlyoutItem, KeyGesture>(nameof(InputGesture));
 
     /// <summary>
+    /// Defines the <see cref="TemplateSettings"/> property
+    /// </summary>
+    public static readonly StyledProperty<MenuFlyoutItemTemplateSettings> TemplateSettingsProperty =
+        AvaloniaProperty.Register<MenuFlyoutItem, MenuFlyoutItemTemplateSettings>(nameof(TemplateSettings));
+
+    /// <summary>
     /// Gets or sets the text content of a MenuFlyoutItem.
     /// </summary>
     public string Text
@@ -64,7 +70,7 @@ public partial class MenuFlyoutItem
     /// <summary>
     /// Gets or sets the graphic content of the menu flyout item.
     /// </summary>
-    public FAIconElement Icon
+    public IconSource Icon
     {
         get => GetValue(IconProperty);
         set => SetValue(IconProperty, value);
@@ -109,6 +115,15 @@ public partial class MenuFlyoutItem
     {
         get => GetValue(CommandParameterProperty);
         set => SetValue(CommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the template settings for this MenuFlyoutItem
+    /// </summary>
+    public MenuFlyoutItemTemplateSettings TemplateSettings
+    {
+        get => GetValue(TemplateSettingsProperty);
+        private set => SetValue(TemplateSettingsProperty, value);
     }
 
     protected override bool IsEnabledCore => base.IsEnabledCore && _canExecute;

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItem.properties.cs
@@ -24,8 +24,8 @@ public partial class MenuFlyoutItem
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<IconSource> IconProperty =
-        AvaloniaProperty.Register<MenuFlyoutItem, IconSource>(nameof(Icon));
+    public static readonly StyledProperty<IconSource> IconSourceProperty =
+        AvaloniaProperty.Register<MenuFlyoutItem, IconSource>(nameof(IconSource));
 
     /// <summary>
     /// Defines the <see cref="Command"/> property
@@ -70,10 +70,10 @@ public partial class MenuFlyoutItem
     /// <summary>
     /// Gets or sets the graphic content of the menu flyout item.
     /// </summary>
-    public IconSource Icon
+    public IconSource IconSource
     {
-        get => GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => GetValue(IconSourceProperty);
+        set => SetValue(IconSourceProperty, value);
     }
 
     /// <summary>

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemContainerGenerator.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemContainerGenerator.cs
@@ -43,7 +43,7 @@ internal class MenuFlyoutPresenterItemContainerGenerator : ItemContainerGenerato
                 var iconSelector = mfsit.IconSelector(item);
                 if (iconSelector != null)
                 {
-                    BindingOperations.Apply(mfsi, MenuFlyoutSubItem.IconProperty, iconSelector, null);
+                    BindingOperations.Apply(mfsi, MenuFlyoutSubItem.IconSourceProperty, iconSelector, null);
                 }
 
                 return mfsi;

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemTemplateSettings.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemTemplateSettings.cs
@@ -1,0 +1,18 @@
+﻿using Avalonia;
+
+namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Defines objects used in the template of a <see cref="MenuFlyoutItem"/> and related classes
+/// </summary>
+public class MenuFlyoutItemTemplateSettings : AvaloniaObject
+{
+    public static readonly StyledProperty<FAIconElement> IconProperty =
+        AvaloniaProperty.Register<MenuFlyoutItemTemplateSettings, FAIconElement>(nameof(Icon));
+
+    public FAIconElement Icon
+    {
+        get => GetValue(IconProperty);
+        internal set => SetValue(IconProperty, value);
+    }
+}

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Collections;
+﻿using Avalonia;
+using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -14,6 +15,16 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     public MenuFlyoutSubItem()
     {
         _items = new AvaloniaList<object>();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == IconProperty)
+        {
+            TemplateSettings.Icon = IconHelpers.CreateFromUnknown(change.GetNewValue<IconSource>());
+        }
     }
 
     protected override void OnPointerEntered(PointerEventArgs e)

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.cs
@@ -21,7 +21,7 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     {
         base.OnPropertyChanged(change);
 
-        if (change.Property == IconProperty)
+        if (change.Property == IconSourceProperty)
         {
             TemplateSettings.Icon = IconHelpers.CreateFromUnknown(change.GetNewValue<IconSource>());
         }

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
@@ -21,8 +21,8 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<IconSource> IconProperty =
-        MenuFlyoutItem.IconProperty.AddOwner<MenuFlyoutSubItem>();
+    public static readonly StyledProperty<IconSource> IconSourceProperty =
+        MenuFlyoutItem.IconSourceProperty.AddOwner<MenuFlyoutSubItem>();
 
     /// <summary>
     /// Defines the <see cref="Items"/> property
@@ -55,10 +55,10 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     /// <summary>
     /// Gets or sets the graphic content of the menu flyout subitem.
     /// </summary>
-    public IconSource Icon
+    public IconSource IconSource
     {
-        get => GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => GetValue(IconSourceProperty);
+        set => SetValue(IconSourceProperty, value);
     }
 
     /// <summary>

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
@@ -21,8 +21,8 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<FAIconElement> IconProperty =
-        AvaloniaProperty.Register<MenuFlyoutItem, FAIconElement>(nameof(Icon));
+    public static readonly StyledProperty<IconSource> IconProperty =
+        MenuFlyoutItem.IconProperty.AddOwner<MenuFlyoutSubItem>();
 
     /// <summary>
     /// Defines the <see cref="Items"/> property
@@ -38,6 +38,12 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
         ItemsControl.ItemTemplateProperty.AddOwner<MenuFlyoutSubItem>();
 
     /// <summary>
+    /// Defines the <see cref="TemplateSettings"/> property
+    /// </summary>
+    public static readonly StyledProperty<MenuFlyoutItemTemplateSettings> TemplateSettingsProperty =
+        MenuFlyoutItem.TemplateSettingsProperty.AddOwner<MenuFlyoutSubItem>();
+
+    /// <summary>
     /// Gets or sets the text content of a MenuFlyoutSubItem.
     /// </summary>
     public string Text
@@ -49,7 +55,7 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     /// <summary>
     /// Gets or sets the graphic content of the menu flyout subitem.
     /// </summary>
-    public FAIconElement Icon
+    public IconSource Icon
     {
         get => GetValue(IconProperty);
         set => SetValue(IconProperty, value);
@@ -63,6 +69,15 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     {
         get => _items;
         set => SetAndRaise(ItemsProperty, ref _items, value);
+    }
+
+    /// <summary>
+    /// Gets the template settings for this MenuFlyoutItem
+    /// </summary>
+    public MenuFlyoutItemTemplateSettings TemplateSettings
+    {
+        get => GetValue(TemplateSettingsProperty);
+        private set => SetValue(TemplateSettingsProperty, value);
     }
 
     public bool HasSubMenu => true;

--- a/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutSubItem.properties.cs
@@ -22,7 +22,7 @@ public partial class MenuFlyoutSubItem : MenuFlyoutItemBase, IMenuItem
     /// Defines the <see cref="Icon"/> property
     /// </summary>
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        MenuFlyoutItem.IconSourceProperty.AddOwner<MenuFlyoutSubItem>();
+        SettingsExpander.IconSourceProperty.AddOwner<MenuFlyoutSubItem>();
 
     /// <summary>
     /// Defines the <see cref="Items"/> property

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.cs
@@ -135,7 +135,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-        if (change.Property == IconProperty)
+        if (change.Property == IconSourceProperty)
         {
             OnIconPropertyChanged(change);
         }

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.properties.cs
@@ -35,8 +35,8 @@ public partial class NavigationViewItem
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<FAIconElement> IconProperty =
-        AvaloniaProperty.Register<NavigationViewItem, FAIconElement>(nameof(Icon));
+    public static readonly StyledProperty<IconSource> IconSourceProperty =
+        SettingsExpander.IconSourceProperty.AddOwner<NavigationViewItem>();
 
     /// <summary>
     /// Defines the <see cref="IsChildSelected"/> property
@@ -99,10 +99,10 @@ public partial class NavigationViewItem
     /// <summary>
     /// Gets or sets the icon to show next to the menu item text.
     /// </summary>
-    public FAIconElement Icon
+    public IconSource IconSource
     {
-        get => GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => GetValue(IconSourceProperty);
+        set => SetValue(IconSourceProperty, value);
     }
 
     /// <summary>
@@ -170,7 +170,7 @@ public partial class NavigationViewItem
 
     private bool HasChildren => (MenuItems != null && MenuItems.Count() > 0) || HasUnrealizedChildren;
 
-    private bool ShouldShowIcon => Icon != null;
+    private bool ShouldShowIcon => IconSource != null;
 
     private bool ShouldEnableToolTip => IsOnLeftNav && _isClosedCompact;
 

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.cs
@@ -54,6 +54,16 @@ public partial class NavigationViewItemPresenter : ContentControl
         UpdateMargin();
     }
 
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == IconSourceProperty)
+        {
+            TemplateSettings.Icon = IconHelpers.CreateFromUnknown(change.GetNewValue<IconSource>());
+        }
+    }
+
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.cs
@@ -20,6 +20,16 @@ public partial class NavigationViewItemPresenter : ContentControl
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
+        // HACK: Bug in Viewbox doesn't disconnect its child when its removed from the tree
+        //       causing a crash when switching pane mode. Force disconnect the icon and 
+        //       reapply it after applying the template.
+        var ts = TemplateSettings;
+        var icoSrc = IconSource;
+        if (icoSrc != null)
+        {
+            ts.Icon = null;
+        }
+
         base.OnApplyTemplate(e);
 
         _selectionIndicator = e.NameScope.Find<Border>(s_tpSelectionIndicator);
@@ -52,6 +62,12 @@ public partial class NavigationViewItemPresenter : ContentControl
         }
 
         UpdateMargin();
+
+        // HACK
+        if (icoSrc != null)
+        {
+            ts.Icon = IconHelpers.CreateFromUnknown(icoSrc);
+        }
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.properties.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenter.properties.cs
@@ -17,8 +17,8 @@ public partial class NavigationViewItemPresenter
     /// <summary>
     /// Defines the <see cref="Icon"/> property
     /// </summary>
-    public static readonly StyledProperty<FAIconElement> IconProperty =
-        AvaloniaProperty.Register<NavigationViewItemPresenter, FAIconElement>(nameof(Icon));
+    public static readonly StyledProperty<IconSource> IconSourceProperty =
+        SettingsExpander.IconSourceProperty.AddOwner<NavigationViewItemPresenter>();
 
     /// <summary>
     /// Defines the <see cref="TemplateSettings"/> property
@@ -35,10 +35,10 @@ public partial class NavigationViewItemPresenter
     /// <summary>
     /// Gets or sets the icon in a NavigationView item.
     /// </summary>
-    public FAIconElement Icon
+    public IconSource IconSource
     {
-        get => GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => GetValue(IconSourceProperty);
+        set => SetValue(IconSourceProperty, value);
     }
 
     /// <summary>

--- a/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenterTemplateSettings.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItemPresenterTemplateSettings.cs
@@ -22,6 +22,12 @@ public class NavigationViewItemPresenterTemplateSettings : AvaloniaObject
         AvaloniaProperty.Register<NavigationViewItemPresenterTemplateSettings, double>(nameof(SmallerIconWidth));
 
     /// <summary>
+    /// Defines the <see cref="Icon"/> property
+    /// </summary>
+    public static readonly StyledProperty<FAIconElement> IconProperty =
+        MenuFlyoutItemTemplateSettings.IconProperty.AddOwner<NavigationViewItemPresenterTemplateSettings>();
+
+    /// <summary>
     /// TODO: Get docs from MS - relatively new setting
     /// </summary>
     public double IconWidth
@@ -37,5 +43,14 @@ public class NavigationViewItemPresenterTemplateSettings : AvaloniaObject
     {
         get => GetValue(SmallerIconWidthProperty);
         internal set => SetValue(SmallerIconWidthProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="FAIconElement"/> used in the NavigationViewItem
+    /// </summary>
+    public FAIconElement Icon
+    {
+        get => GetValue(IconProperty);
+        internal set => SetValue(IconProperty, value);
     }
 }

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -3325,7 +3325,8 @@ public partial class NavigationView : HeaderedContentControl
         if (_settingsItem == null)
             return;
 
-        _settingsItem.Icon = new SymbolIcon { Symbol = Symbol.Settings };
+        // TODO: Cache this
+        _settingsItem.IconSource = new SymbolIconSource { Symbol = Symbol.Settings };
 
         var localizedSettingsName = FALocalizationHelper.Instance.GetLocalizedStringResource(SR_SettingsButtonName);
 

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -3325,8 +3325,7 @@ public partial class NavigationView : HeaderedContentControl
         if (_settingsItem == null)
             return;
 
-        // TODO: Cache this
-        _settingsItem.IconSource = new SymbolIconSource { Symbol = Symbol.Settings };
+        _settingsItem.IconSource = _settingsIconSource;
 
         var localizedSettingsName = FALocalizationHelper.Instance.GetLocalizedStringResource(SR_SettingsButtonName);
 

--- a/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
+++ b/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
@@ -730,6 +730,8 @@ public partial class NavigationView : HeaderedContentControl
 
     private bool _initialNonForcedModeUpdate = true;
 
+    private static readonly SymbolIconSource _settingsIconSource = new SymbolIconSource { Symbol = Symbol.Settings };
+
 
     private const int _backButtonHeight = 40;
     private const int _backButtonWidth = 40;

--- a/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
+++ b/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
@@ -31,7 +31,7 @@ public partial class TabViewItem
     /// Defines the <see cref="IconSource"/> property
     /// </summary>
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        AvaloniaProperty.Register<TabViewItem, IconSource>(nameof(IconSource));
+        SettingsExpander.IconSourceProperty.AddOwner<TabViewItem>();
 
     /// <summary>
     /// Defines the <see cref="IsClosable"/> property

--- a/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
@@ -14,7 +14,7 @@ namespace FluentAvalonia.UI.Controls.Primitives;
 public class TaskDialogButtonHost : Button
 {
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        SettingsExpander.IconSourceProperty.AddOwner<MenuFlyoutItem>();
+        SettingsExpander.IconSourceProperty.AddOwner<TaskDialogButtonHost>();
 
     public IconSource IconSource
     {

--- a/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
+++ b/FluentAvalonia/UI/Controls/TaskDialog/Controls/TaskDialogButtonHost.cs
@@ -11,10 +11,10 @@ namespace FluentAvalonia.UI.Controls.Primitives;
 /// This type should not be used directly and is generated automatically
 /// by a TaskDialog
 /// </remarks>
-public class TaskDialogButtonHost : Avalonia.Controls.Button
+public class TaskDialogButtonHost : Button
 {
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        AvaloniaProperty.Register<TaskDialogButtonHost, IconSource>(nameof(IconSource));
+        SettingsExpander.IconSourceProperty.AddOwner<MenuFlyoutItem>();
 
     public IconSource IconSource
     {

--- a/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
+++ b/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
@@ -155,7 +155,7 @@ public partial class TeachingTip : ContentControl
     /// Defines the <see cref="IconSource"/> property
     /// </summary>
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        AvaloniaProperty.Register<TeachingTip, IconSource>(nameof(IconSource));
+        SettingsExpander.IconSourceProperty.AddOwner<MenuFlyoutItem>();
 
     /// <summary>
     /// Defines the <see cref="TemplateSettings"/> property

--- a/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
+++ b/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
@@ -155,7 +155,7 @@ public partial class TeachingTip : ContentControl
     /// Defines the <see cref="IconSource"/> property
     /// </summary>
     public static readonly StyledProperty<IconSource> IconSourceProperty =
-        SettingsExpander.IconSourceProperty.AddOwner<MenuFlyoutItem>();
+        SettingsExpander.IconSourceProperty.AddOwner<TeachingTip>();
 
     /// <summary>
     /// Defines the <see cref="TemplateSettings"/> property

--- a/FluentAvaloniaSamples/Controls/ControlExample.cs
+++ b/FluentAvaloniaSamples/Controls/ControlExample.cs
@@ -206,7 +206,7 @@ public class ControlExample : HeaderedContentControl
                         var docsItem = new MenuFlyoutItem
                         {
                             Text = DocsLinkHeader,
-                            Icon = new SymbolIconSource { Symbol = Symbol.Link }
+                            IconSource = new SymbolIconSource { Symbol = Symbol.Link }
                         };
 
                         docsItem.Click += LaunchAvaloniaDocs;
@@ -220,7 +220,7 @@ public class ControlExample : HeaderedContentControl
                     var defItem = new MenuFlyoutItem
                     {
                         Text = "Show Definition",
-                        Icon = new SymbolIconSource { Symbol = Symbol.CodeFilled }
+                        IconSource = new SymbolIconSource { Symbol = Symbol.CodeFilled }
                     };
 
                     defItem.Click += ShowControlDefintion;

--- a/FluentAvaloniaSamples/Controls/ControlExample.cs
+++ b/FluentAvaloniaSamples/Controls/ControlExample.cs
@@ -206,7 +206,7 @@ public class ControlExample : HeaderedContentControl
                         var docsItem = new MenuFlyoutItem
                         {
                             Text = DocsLinkHeader,
-                            Icon = new SymbolIcon { Symbol = Symbol.Link }
+                            Icon = new SymbolIconSource { Symbol = Symbol.Link }
                         };
 
                         docsItem.Click += LaunchAvaloniaDocs;
@@ -220,7 +220,7 @@ public class ControlExample : HeaderedContentControl
                     var defItem = new MenuFlyoutItem
                     {
                         Text = "Show Definition",
-                        Icon = new SymbolIcon { Symbol = Symbol.CodeFilled }
+                        Icon = new SymbolIconSource { Symbol = Symbol.CodeFilled }
                     };
 
                     defItem.Click += ShowControlDefintion;

--- a/FluentAvaloniaSamples/Pages/FAControlPages/CommandBarFlyoutPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/CommandBarFlyoutPage.axaml
@@ -10,9 +10,9 @@
 
     <UserControl.Resources>
         <ui:CommandBarFlyout Placement="Right" x:Key="CommandBarFlyout1">
-            <ui:CommandBarButton Label="Share" Icon="Share" ToolTip.Tip="Share" Command="{Binding FlyoutCommands}" CommandParameter="Share" />
-            <ui:CommandBarButton Label="Save" Icon="Save" ToolTip.Tip="Save" Command="{Binding FlyoutCommands}" CommandParameter="Save" />
-            <ui:CommandBarButton Label="Delete" Icon="Delete" ToolTip.Tip="Delete" Command="{Binding FlyoutCommands}" CommandParameter="Delete" />
+            <ui:CommandBarButton Label="Share" IconSource="Share" ToolTip.Tip="Share" Command="{Binding FlyoutCommands}" CommandParameter="Share" />
+            <ui:CommandBarButton Label="Save" IconSource="Save" ToolTip.Tip="Save" Command="{Binding FlyoutCommands}" CommandParameter="Save" />
+            <ui:CommandBarButton Label="Delete" IconSource="Delete" ToolTip.Tip="Delete" Command="{Binding FlyoutCommands}" CommandParameter="Delete" />
             <ui:CommandBarFlyout.SecondaryCommands>
                 <ui:CommandBarButton Label="Resize" Command="{Binding FlyoutCommands}" CommandParameter="Resize" />
                 <ui:CommandBarButton Label="Move" Command="{Binding FlyoutCommands}" CommandParameter="Move" />

--- a/FluentAvaloniaSamples/Pages/FAControlPages/CommandBarPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/CommandBarPage.axaml
@@ -27,17 +27,17 @@ Some notes:
                               XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/CommandBar1.xaml.txt">
             <ui:CommandBar>
                 <ui:CommandBar.PrimaryCommands>
-                    <ui:CommandBarButton Icon="Save" Label="Save" />
-                    <ui:CommandBarButton Icon="Undo" Label="Undo" />
+                    <ui:CommandBarButton IconSource="Save" Label="Save" />
+                    <ui:CommandBarButton IconSource="Undo" Label="Undo" />
                     <ui:CommandBarSeparator />
-                    <ui:CommandBarToggleButton Icon="Bold" Label="Bold" />
-                    <ui:CommandBarToggleButton Icon="Italic" Label="Italic" />
-                    <ui:CommandBarToggleButton Icon="Underline" Label="Underline" />
+                    <ui:CommandBarToggleButton IconSource="Bold" Label="Bold" />
+                    <ui:CommandBarToggleButton IconSource="Italic" Label="Italic" />
+                    <ui:CommandBarToggleButton IconSource="Underline" Label="Underline" />
                 </ui:CommandBar.PrimaryCommands>
                 <ui:CommandBar.SecondaryCommands>
-                    <ui:CommandBarButton Icon="Cut" Label="Cut" />
-                    <ui:CommandBarButton Icon="Copy" Label="Copy" />
-                    <ui:CommandBarButton Icon="Paste" Label="Paste" />
+                    <ui:CommandBarButton IconSource="Cut" Label="Cut" />
+                    <ui:CommandBarButton IconSource="Copy" Label="Copy" />
+                    <ui:CommandBarButton IconSource="Paste" Label="Paste" />
                 </ui:CommandBar.SecondaryCommands>
             </ui:CommandBar>
         </ctrls:ControlExample>
@@ -46,17 +46,17 @@ Some notes:
                               XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/CommandBar2.xaml.txt">
             <ui:CommandBar DefaultLabelPosition="Right">
                 <ui:CommandBar.PrimaryCommands>
-                    <ui:CommandBarButton Icon="Save" Label="Save" />
-                    <ui:CommandBarButton Icon="Undo" Label="Undo" />
+                    <ui:CommandBarButton IconSource="Save" Label="Save" />
+                    <ui:CommandBarButton IconSource="Undo" Label="Undo" />
                     <ui:CommandBarSeparator />
-                    <ui:CommandBarToggleButton Icon="Bold" Label="Bold" />
-                    <ui:CommandBarToggleButton Icon="Italic" Label="Italic" />
-                    <ui:CommandBarToggleButton Icon="Underline" Label="Underline" />
+                    <ui:CommandBarToggleButton IconSource="Bold" Label="Bold" />
+                    <ui:CommandBarToggleButton IconSource="Italic" Label="Italic" />
+                    <ui:CommandBarToggleButton IconSource="Underline" Label="Underline" />
                 </ui:CommandBar.PrimaryCommands>
                 <ui:CommandBar.SecondaryCommands>
-                    <ui:CommandBarButton Icon="Cut" Label="Cut" />
-                    <ui:CommandBarButton Icon="Copy" Label="Copy" />
-                    <ui:CommandBarButton Icon="Paste" Label="Paste" />
+                    <ui:CommandBarButton IconSource="Cut" Label="Cut" />
+                    <ui:CommandBarButton IconSource="Copy" Label="Copy" />
+                    <ui:CommandBarButton IconSource="Paste" Label="Paste" />
                 </ui:CommandBar.SecondaryCommands>
             </ui:CommandBar>
         </ctrls:ControlExample>
@@ -65,17 +65,17 @@ Some notes:
                                   XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/CommandBar3.xaml.txt">
             <ui:CommandBar DefaultLabelPosition="Right">
                 <ui:CommandBar.PrimaryCommands>
-                    <ui:CommandBarButton Icon="Save" Label="Save" />
-                    <ui:CommandBarButton Icon="Undo" Label="Undo" />
+                    <ui:CommandBarButton IconSource="Save" Label="Save" />
+                    <ui:CommandBarButton IconSource="Undo" Label="Undo" />
                 </ui:CommandBar.PrimaryCommands>
                 <ui:CommandBar.SecondaryCommands>
-                    <ui:CommandBarButton Icon="Cut" Label="Cut" />
-                    <ui:CommandBarButton Icon="Copy" Label="Copy" />
-                    <ui:CommandBarButton Icon="Paste" Label="Paste" />
+                    <ui:CommandBarButton IconSource="Cut" Label="Cut" />
+                    <ui:CommandBarButton IconSource="Copy" Label="Copy" />
+                    <ui:CommandBarButton IconSource="Paste" Label="Paste" />
                     <ui:CommandBarSeparator />
-                    <ui:CommandBarToggleButton Icon="Bold" Label="Bold" />
-                    <ui:CommandBarToggleButton Icon="Italic" Label="Italic" />
-                    <ui:CommandBarToggleButton Icon="Underline" Label="Underline" />
+                    <ui:CommandBarToggleButton IconSource="Bold" Label="Bold" />
+                    <ui:CommandBarToggleButton IconSource="Italic" Label="Italic" />
+                    <ui:CommandBarToggleButton IconSource="Underline" Label="Underline" />
                 </ui:CommandBar.SecondaryCommands>
             </ui:CommandBar>
         </ctrls:ControlExample>
@@ -84,10 +84,10 @@ Some notes:
                               TargetType="ui:CommandBarButton"
                               EnableShowDefinitionLink="True">
             
-            <ui:CommandBarButton Label="Label" Icon="Save" />
+            <ui:CommandBarButton Label="Label" IconSource="Save" />
 
             <ctrls:ControlExample.XamlSource>
-                &lt;ui:CommandBarButton Label="Label" Icon="Save" /&gt;
+                &lt;ui:CommandBarButton Label="Label" IconSource="Save" /&gt;
             </ctrls:ControlExample.XamlSource>
 
             <ctrls:ControlExample.UsageNotes>
@@ -107,10 +107,10 @@ Note: While CommandBarButtons can be used outside of the CommandBar, Label on th
                               TargetType="ui:CommandBarToggleButton"
                               EnableShowDefinitionLink="True">
 
-            <ui:CommandBarToggleButton Label="Label" Icon="Save" />
+            <ui:CommandBarToggleButton Label="Label" IconSource="Save" />
 
             <ctrls:ControlExample.XamlSource>
-                &lt;ui:CommandBarToggleButton Label="Label" Icon="Save" /&gt;
+                &lt;ui:CommandBarToggleButton Label="Label" IconSource="Save" /&gt;
             </ctrls:ControlExample.XamlSource>
 
             <ctrls:ControlExample.UsageNotes>
@@ -128,13 +128,13 @@ Note: In WinUI, indeterminate looks like checked, I don't handle that case so it
 
             <ui:CommandBar DefaultLabelPosition="Right">
                 <ui:CommandBar.PrimaryCommands>
-                    <ui:CommandBarButton Icon="Save" Label="Save" />
+                    <ui:CommandBarButton IconSource="Save" Label="Save" />
                     <ui:CommandBarSeparator />
-                    <ui:CommandBarButton Icon="Cut" Label="Cut" />
-                    <ui:CommandBarButton Icon="Copy" Label="Copy" />
-                    <ui:CommandBarButton Icon="Paste" Label="Paste" />
+                    <ui:CommandBarButton IconSource="Cut" Label="Cut" />
+                    <ui:CommandBarButton IconSource="Copy" Label="Copy" />
+                    <ui:CommandBarButton IconSource="Paste" Label="Paste" />
                     <ui:CommandBarSeparator />
-                    <ui:CommandBarButton Icon="Delete" Label="Delete" />
+                    <ui:CommandBarButton IconSource="Delete" Label="Delete" />
                 </ui:CommandBar.PrimaryCommands>
             </ui:CommandBar>
 
@@ -155,7 +155,7 @@ A CommandBarSeparator creates a vertical line to visually separate groups of com
 
             <ui:CommandBar DefaultLabelPosition="Right">
                 <ui:CommandBar.PrimaryCommands>
-                    <ui:CommandBarButton Icon="Save" Label="Save" />
+                    <ui:CommandBarButton IconSource="Save" Label="Save" />
                     <ui:CommandBarSeparator />
                     <ui:CommandBarElementContainer>
                         <ComboBox VerticalAlignment="Center" MinWidth="125">

--- a/FluentAvaloniaSamples/Pages/FAControlPages/InfoBadgePage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/InfoBadgePage.axaml
@@ -12,9 +12,9 @@
             <ui:NavigationView x:Name="nvSample1" Height="300" 
 								   PaneDisplayMode="{Binding #DisplayModeBox.SelectedItem.Content}">
                 <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Content="Home" Icon="Home"/>
-                    <ui:NavigationViewItem Content="Account" Icon="Contact"/>
-                    <ui:NavigationViewItem x:Name="InboxPage" Content="Inbox" Icon="Mail">
+                    <ui:NavigationViewItem Content="Home" IconSource="Home"/>
+                    <ui:NavigationViewItem Content="Account" IconSource="Contact"/>
+                    <ui:NavigationViewItem x:Name="InboxPage" Content="Inbox" IconSource="Mail">
                         <ui:NavigationViewItem.InfoBadge>
                             <ui:InfoBadge x:Name="infoBadge1" Value="5"
                                           Opacity="{Binding InfoBadgeOpacity, Mode=OneWay}" />

--- a/FluentAvaloniaSamples/Pages/FAControlPages/MenuFlyoutPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/MenuFlyoutPage.axaml
@@ -10,7 +10,7 @@
              PreviewImage="/Assets/PageIcons/MenuFlyout.jpg">
     <UserControl.DataTemplates> 
         <DataTemplate DataType="{x:Type vm:TempMenuItem}">
-            <ui:MenuFlyoutItem Text="{Binding Text}" Icon="{Binding Icon}" />
+            <ui:MenuFlyoutItem Text="{Binding Text}" IconSource="{Binding Icon}" />
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:TempMenuSeparator}">
             <ui:MenuFlyoutSeparator />
@@ -57,8 +57,8 @@ Note: these revamped items will not work in default menus of Avalonia, and are o
             <Button Content="Click me for flyout!">
                 <Button.Flyout>
                     <ui:FAMenuFlyout Placement="Bottom">
-                        <ui:MenuFlyoutItem Text="Item 1" Icon="Copy" />
-                        <ui:MenuFlyoutItem Text="Item 2" Icon="Paste" />
+                        <ui:MenuFlyoutItem Text="Item 1" IconSource="Copy" />
+                        <ui:MenuFlyoutItem Text="Item 2" IconSource="Paste" />
                         <ui:MenuFlyoutSeparator />
                         <ui:MenuFlyoutSubItem Text="SubMenu">
                             <ui:MenuFlyoutItem Text="Subitem 1" />
@@ -66,13 +66,13 @@ Note: these revamped items will not work in default menus of Avalonia, and are o
                             <ui:MenuFlyoutItem Text="Subitem 3" />
                         </ui:MenuFlyoutSubItem>
                         <ui:MenuFlyoutSeparator />
-                        <ui:ToggleMenuFlyoutItem Text="Toggle Item" Icon="Bold" />
+                        <ui:ToggleMenuFlyoutItem Text="Toggle Item" IconSource="Bold" />
                         <ui:MenuFlyoutSeparator />
                         <ui:RadioMenuFlyoutItem Text="Radio Menu Item" IsChecked="True"
                                                 GroupName="Test Group"
-                                                Icon="Games"/>
+                                                IconSource="Games"/>
                         <ui:RadioMenuFlyoutItem Text="Radio Menu Item 2"
-                                                Icon="Icons"
+                                                IconSource="Icons"
                                                 GroupName="Test Group" />
                     </ui:FAMenuFlyout>
                 </Button.Flyout>

--- a/FluentAvaloniaSamples/Pages/FAControlPages/NavigationViewPage.axaml
+++ b/FluentAvaloniaSamples/Pages/FAControlPages/NavigationViewPage.axaml
@@ -32,10 +32,10 @@ Known issues:
                               XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/NavView1.xaml.txt">
             <ui:NavigationView x:Name="nvSample1" Height="460" PaneDisplayMode="Left">
                 <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" Icon="Play"/>
-                    <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" Icon="Save" />
-                    <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" Icon="Refresh" />
-                    <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" Icon="Download" />
+                    <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" IconSource="Play"/>
+                    <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" IconSource="Save" />
+                    <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" IconSource="Refresh" />
+                    <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" IconSource="Download" />
                 </ui:NavigationView.MenuItems>
             </ui:NavigationView>
         </ctrls:ControlExample>
@@ -44,10 +44,10 @@ Known issues:
                               XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/NavView2.xaml.txt">
             <ui:NavigationView x:Name="nvSample2" Height="460" PaneDisplayMode="Auto">
                 <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" />
-                    <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" />
-                    <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" />
-                    <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" />
+                    <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" IconSource="Play"/>
+                    <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" IconSource="Save" />
+                    <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" IconSource="Refresh" />
+                    <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" IconSource="Download" />
                 </ui:NavigationView.MenuItems>
             </ui:NavigationView>
         </ctrls:ControlExample>
@@ -81,7 +81,7 @@ Known issues:
 						MenuItemTemplateSelector
 						-->
                         <DataTemplate DataType="{x:Type vm:Category}">
-                            <ui:NavigationViewItem Content="{Binding Name}" Icon="{Binding Icon}" ToolTip.Tip="{Binding ToolTip}" />
+                            <ui:NavigationViewItem Content="{Binding Name}" IconSource="{Binding Icon}" ToolTip.Tip="{Binding ToolTip}" />
                         </DataTemplate>
 
                         <vm:MenuItemTemplateSelector.SeparatorTemplate>
@@ -99,17 +99,17 @@ Known issues:
                               XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/NavView4.xaml.txt">
             <ui:NavigationView x:Name="nvSample4" PaneDisplayMode="Left" Height="460">
                 <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Content="Home" Tag="SamplePage1" Icon="Home" />
-                    <ui:NavigationViewItem Content="Account" Tag="SamplePage2" Icon="Home">
+                    <ui:NavigationViewItem Content="Home" Tag="SamplePage1" IconSource="Home" />
+                    <ui:NavigationViewItem Content="Account" Tag="SamplePage2" IconSource="Home">
                         <ui:NavigationViewItem.MenuItems>
-                            <ui:NavigationViewItem Content="Mail" Icon="Mail" Tag="SamplePage3" />
-                            <ui:NavigationViewItem Content="Calendar" Icon="Calendar" Tag="SamplePage4" />
+                            <ui:NavigationViewItem Content="Mail" IconSource="Mail" Tag="SamplePage3" />
+                            <ui:NavigationViewItem Content="Calendar" IconSource="Calendar" Tag="SamplePage4" />
                         </ui:NavigationViewItem.MenuItems>
                     </ui:NavigationViewItem>
-                    <ui:NavigationViewItem Content="Document options" Tag="SamplePage3" Icon="Document" SelectsOnInvoked="False">
+                    <ui:NavigationViewItem Content="Document options" Tag="SamplePage3" IconSource="Document" SelectsOnInvoked="False">
                         <ui:NavigationViewItem.MenuItems>
-                            <ui:NavigationViewItem Content="Create new" Icon="New" Tag="SamplePage5" />
-                            <ui:NavigationViewItem Content="Upload file" Icon="Upload" Tag="SamplePage6" />
+                            <ui:NavigationViewItem Content="Create new" IconSource="New" Tag="SamplePage5" />
+                            <ui:NavigationViewItem Content="Upload file" IconSource="Upload" Tag="SamplePage6" />
                         </ui:NavigationViewItem.MenuItems>
                     </ui:NavigationViewItem>
                 </ui:NavigationView.MenuItems>
@@ -125,14 +125,14 @@ Known issues:
                                IsTabStop="False"
                                IsSettingsVisible="False">
                 <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Content="Browse" Tag="SamplePage1" Icon="Library" />
-                    <ui:NavigationViewItem Content="Track an Order" Tag="SamplePage2" Icon="Map" />
-                    <ui:NavigationViewItem Content="Order History" Tag="SamplePage3" Icon="Tag" />
+                    <ui:NavigationViewItem Content="Browse" Tag="SamplePage1" IconSource="Library" />
+                    <ui:NavigationViewItem Content="Track an Order" Tag="SamplePage2" IconSource="Map" />
+                    <ui:NavigationViewItem Content="Order History" Tag="SamplePage3" IconSource="Tag" />
                 </ui:NavigationView.MenuItems>
                 <ui:NavigationView.FooterMenuItems>
-                    <ui:NavigationViewItem Content="Account" Tag="SamplePage4" Icon="Contact" />
-                    <ui:NavigationViewItem Content="Your Cart" Tag="SamplePage5" Icon="Shop" />
-                    <ui:NavigationViewItem Content="Help" Tag="SamplePage6" Icon="Help" />
+                    <ui:NavigationViewItem Content="Account" Tag="SamplePage4" IconSource="Contact" />
+                    <ui:NavigationViewItem Content="Your Cart" Tag="SamplePage5" IconSource="Shop" />
+                    <ui:NavigationViewItem Content="Help" Tag="SamplePage6" IconSource="Help" />
                 </ui:NavigationView.FooterMenuItems>
             </ui:NavigationView>
 
@@ -157,10 +157,10 @@ Known issues:
             <ui:NavigationView x:Name="nvSample6" Height="460"
                                PaneDisplayMode="{Binding #DispModeAPIBox.SelectedItem.Content}">
                 <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" Icon="Play" />
+                    <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" IconSource="Play" />
                     <ui:NavigationViewItemHeader Content="Actions" />
-                    <ui:NavigationViewItem Name="MenuItem2" Content="Menu Item2" Tag="SamplePage2" Icon="Download" />
-                    <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" Icon="Refresh" />
+                    <ui:NavigationViewItem Name="MenuItem2" Content="Menu Item2" Tag="SamplePage2" IconSource="Download" />
+                    <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" IconSource="Refresh" />
                 </ui:NavigationView.MenuItems>
 
                 <ui:NavigationView.AutoCompleteBox>
@@ -173,8 +173,8 @@ Known issues:
 
                 <ui:NavigationView.PaneFooter>
                     <StackPanel Name="FooterStackPanel" Orientation="Vertical" IsVisible="False">
-                        <ui:NavigationViewItem Icon="Download" />
-                        <ui:NavigationViewItem Icon="Alert" />
+                        <ui:NavigationViewItem IconSource="Download" />
+                        <ui:NavigationViewItem IconSource="Alert" />
                     </StackPanel>
                 </ui:NavigationView.PaneFooter>
 

--- a/FluentAvaloniaSamples/Pages/SampleCode/CommandBar1.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/CommandBar1.xaml.txt
@@ -1,15 +1,15 @@
 ﻿ <ui:CommandBar>
     <ui:CommandBar.PrimaryCommands>
-        <ui:CommandBarButton Icon="Save" Label="Save" />
-        <ui:CommandBarButton Icon="Undo" Label="Undo" />
+        <ui:CommandBarButton IconSource="Save" Label="Save" />
+        <ui:CommandBarButton IconSource="Undo" Label="Undo" />
         <ui:CommandBarSeparator />
-        <ui:CommandBarToggleButton Icon="Bold" Label="Bold" />
-        <ui:CommandBarToggleButton Icon="Italic" Label="Italic" />
-        <ui:CommandBarToggleButton Icon="Underline" Label="Underline" />
+        <ui:CommandBarToggleButton IconSource="Bold" Label="Bold" />
+        <ui:CommandBarToggleButton IconSource="Italic" Label="Italic" />
+        <ui:CommandBarToggleButton IconSource="Underline" Label="Underline" />
     </ui:CommandBar.PrimaryCommands>
     <ui:CommandBar.SecondaryCommands>
-        <ui:CommandBarButton Icon="Cut" Label="Cut" />
-        <ui:CommandBarButton Icon="Copy" Label="Copy" />
-        <ui:CommandBarButton Icon="Paste" Label="Paste" />
+        <ui:CommandBarButton IconSource="Cut" Label="Cut" />
+        <ui:CommandBarButton IconSource="Copy" Label="Copy" />
+        <ui:CommandBarButton IconSource="Paste" Label="Paste" />
     </ui:CommandBar.SecondaryCommands>
 </ui:CommandBar>

--- a/FluentAvaloniaSamples/Pages/SampleCode/CommandBar2.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/CommandBar2.xaml.txt
@@ -1,15 +1,15 @@
 ﻿<ui:CommandBar DefaultLabelPosition="Right">
     <ui:CommandBar.PrimaryCommands>
-        <ui:CommandBarButton Icon="Save" Label="Save" />
-        <ui:CommandBarButton Icon="Undo" Label="Undo" />
+        <ui:CommandBarButton IconSource="Save" Label="Save" />
+        <ui:CommandBarButton IconSource="Undo" Label="Undo" />
         <ui:CommandBarSeparator />
-        <ui:CommandBarToggleButton Icon="Bold" Label="Bold" />
-        <ui:CommandBarToggleButton Icon="Italic" Label="Italic" />
-        <ui:CommandBarToggleButton Icon="Underline" Label="Underline" />
+        <ui:CommandBarToggleButton IconSource="Bold" Label="Bold" />
+        <ui:CommandBarToggleButton IconSource="Italic" Label="Italic" />
+        <ui:CommandBarToggleButton IconSource="Underline" Label="Underline" />
     </ui:CommandBar.PrimaryCommands>
     <ui:CommandBar.SecondaryCommands>
-        <ui:CommandBarButton Icon="Cut" Label="Cut" />
-        <ui:CommandBarButton Icon="Copy" Label="Copy" />
-        <ui:CommandBarButton Icon="Paste" Label="Paste" />
+        <ui:CommandBarButton IconSource="Cut" Label="Cut" />
+        <ui:CommandBarButton IconSource="Copy" Label="Copy" />
+        <ui:CommandBarButton IconSource="Paste" Label="Paste" />
     </ui:CommandBar.SecondaryCommands>
 </ui:CommandBar>

--- a/FluentAvaloniaSamples/Pages/SampleCode/CommandBar3.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/CommandBar3.xaml.txt
@@ -1,15 +1,15 @@
 ﻿<ui:CommandBar DefaultLabelPosition="Right">
     <ui:CommandBar.PrimaryCommands>
-        <ui:CommandBarButton Icon="Save" Label="Save" />
-        <ui:CommandBarButton Icon="Undo" Label="Undo" />
+        <ui:CommandBarButton IconSource="Save" Label="Save" />
+        <ui:CommandBarButton IconSource="Undo" Label="Undo" />
     </ui:CommandBar.PrimaryCommands>
     <ui:CommandBar.SecondaryCommands>
-        <ui:CommandBarButton Icon="Cut" Label="Cut" />
-        <ui:CommandBarButton Icon="Copy" Label="Copy" />
-        <ui:CommandBarButton Icon="Paste" Label="Paste" />
+        <ui:CommandBarButton IconSource="Cut" Label="Cut" />
+        <ui:CommandBarButton IconSource="Copy" Label="Copy" />
+        <ui:CommandBarButton IconSource="Paste" Label="Paste" />
         <ui:CommandBarSeparator />
-        <ui:CommandBarToggleButton Icon="Bold" Label="Bold" />
-        <ui:CommandBarToggleButton Icon="Italic" Label="Italic" />
-        <ui:CommandBarToggleButton Icon="Underline" Label="Underline" />
+        <ui:CommandBarToggleButton IconSource="Bold" Label="Bold" />
+        <ui:CommandBarToggleButton IconSource="Italic" Label="Italic" />
+        <ui:CommandBarToggleButton IconSource="Underline" Label="Underline" />
     </ui:CommandBar.SecondaryCommands>
 </ui:CommandBar>

--- a/FluentAvaloniaSamples/Pages/SampleCode/CommandBarFlyout.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/CommandBarFlyout.xaml.txt
@@ -1,8 +1,8 @@
 ﻿<UserControl.Resources>
     <ui:CommandBarFlyout Placement="Right" x:Key="CommandBarFlyout1">
-        <ui:CommandBarButton Label="Share" Icon="Share" ToolTip.Tip="Share" Command="{Binding Share}" />
-        <ui:CommandBarButton Label="Save" Icon="Save" ToolTip.Tip="Save" Command="{Binding Save}" />
-        <ui:CommandBarButton Label="Delete" Icon="Delete" ToolTip.Tip="Delete" Command="{Binding Delete}" />
+        <ui:CommandBarButton Label="Share" IconSource="Share" ToolTip.Tip="Share" Command="{Binding Share}" />
+        <ui:CommandBarButton Label="Save" IconSource="Save" ToolTip.Tip="Save" Command="{Binding Save}" />
+        <ui:CommandBarButton Label="Delete" IconSource="Delete" ToolTip.Tip="Delete" Command="{Binding Delete}" />
         <ui:CommandBarFlyout.SecondaryCommands>
             <ui:CommandBarButton Label="Resize"  Command="{Binding Resize}" />
             <ui:CommandBarButton Label="Move" Command="{Binding Move}" />

--- a/FluentAvaloniaSamples/Pages/SampleCode/MenuFlyout.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/MenuFlyout.xaml.txt
@@ -1,7 +1,7 @@
 ﻿<Button.Flyout>
     <ui:FAMenuFlyout Placement="Bottom">
-        <ui:MenuFlyoutItem Text="Item 1" Icon="Copy" />
-        <ui:MenuFlyoutItem Text="Item 2" Icon="Paste" />
+        <ui:MenuFlyoutItem Text="Item 1" IconSource="Copy" />
+        <ui:MenuFlyoutItem Text="Item 2" IconSource="Paste" />
         <ui:MenuFlyoutSeparator />
         <ui:MenuFlyoutSubItem Text="SubMenu">
             <ui:MenuFlyoutItem Text="Subitem 1" />
@@ -9,13 +9,13 @@
             <ui:MenuFlyoutItem Text="Subitem 3" />
         </ui:MenuFlyoutSubItem>
         <ui:MenuFlyoutSeparator />
-        <ui:ToggleMenuFlyoutItem Text="Toggle Item" Icon="Bold" />
+        <ui:ToggleMenuFlyoutItem Text="Toggle Item" IconSource="Bold" />
         <ui:MenuFlyoutSeparator />
         <ui:RadioMenuFlyoutItem Text="Radio Menu Item" IsChecked="True"
                                 GroupName="Test Group"
-                                Icon="Games"/>
+                                IconSource="Games"/>
         <ui:RadioMenuFlyoutItem Text="Radio Menu Item 2"
-                                Icon="Icons"
+                                IconSource="Icons"
                                 GroupName="Test Group" />
     </ui:FAMenuFlyout>
 </Button.Flyout>

--- a/FluentAvaloniaSamples/Pages/SampleCode/MenuFlyout2.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/MenuFlyout2.xaml.txt
@@ -11,7 +11,7 @@
 <!-- Define the DataTemplates for the items -->
 <UserControl.DataTemplates>
     <DataTemplate DataType="{x:Type vm:TempMenuItem}">
-        <ui:MenuFlyoutItem Text="{Binding Text}" Icon="{Binding Icon}" />
+        <ui:MenuFlyoutItem Text="{Binding Text}" IconSource="{Binding Icon}" />
     </DataTemplate>
     <DataTemplate DataType="{x:Type vm:TempMenuSeparator}">
         <ui:MenuFlyoutSeparator />

--- a/FluentAvaloniaSamples/Pages/SampleCode/NavView1.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/NavView1.xaml.txt
@@ -1,8 +1,8 @@
 ﻿<ui:NavigationView x:Name="nvSample" Height="460" PaneDisplayMode="Left">
     <ui:NavigationView.MenuItems>
-        <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" Icon="Play"/>
-        <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" Icon="Save" />
-        <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" Icon="Refresh" />
-        <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" Icon="Download" />
+        <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" IconSource="Play"/>
+        <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" IconSource="Save" />
+        <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" IconSource="Refresh" />
+        <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" IconSource="Download" />
     </ui:NavigationView.MenuItems>
 </ui:NavigationView>

--- a/FluentAvaloniaSamples/Pages/SampleCode/NavView2.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/NavView2.xaml.txt
@@ -1,8 +1,8 @@
 ﻿<ui:NavigationView x:Name="nvSample2" Height="460" PaneDisplayMode="Auto">
     <ui:NavigationView.MenuItems>
-        <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" />
-        <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" />
-        <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" />
-        <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" />
+        <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" IconSource="Play"/>
+        <ui:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" IconSource="Save" />
+        <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" IconSource="Refresh" />
+        <ui:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" IconSource="Download" />
     </ui:NavigationView.MenuItems>
 </ui:NavigationView>

--- a/FluentAvaloniaSamples/Pages/SampleCode/NavView3.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/NavView3.xaml.txt
@@ -8,7 +8,7 @@
 	If you only need NavigationViewItems, you can just set the ItemTemplate:
 	<ui:NavigationView.MenuItemTemplate>
         <DataTemplate DataType="{x:Type vm:Category}">
-            <ui:NavigationViewItem Content="{Binding Name}" Icon="{Binding Icon}" ToolTip.Tip="{Binding ToolTip}" />
+            <ui:NavigationViewItem Content="{Binding Name}" IconSource="{Binding Icon}" ToolTip.Tip="{Binding ToolTip}" />
         </DataTemplate>
     </ui:NavigationView.MenuItemTemplate>
     -->
@@ -27,7 +27,7 @@
 			MenuItemTemplateSelector
 			-->
             <DataTemplate DataType="{x:Type vm:Category}">
-                <ui:NavigationViewItem Content="{Binding Name}" Icon="{Binding Icon}" ToolTip.Tip="{Binding ToolTip}" />
+                <ui:NavigationViewItem Content="{Binding Name}" IconSource="{Binding Icon}" ToolTip.Tip="{Binding ToolTip}" />
             </DataTemplate>
 
             <vm:MenuItemTemplateSelector.SeparatorTemplate>

--- a/FluentAvaloniaSamples/Pages/SampleCode/NavView4.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/NavView4.xaml.txt
@@ -1,16 +1,16 @@
 ﻿<ui:NavigationView x:Name="nvSample5" PaneDisplayMode="Left" Height="460">
     <ui:NavigationView.MenuItems>
-        <ui:NavigationViewItem Content="Home" Tag="SamplePage1" Icon="Home" />
-        <ui:NavigationViewItem Content="Account" Tag="SamplePage2" Icon="Home">
+        <ui:NavigationViewItem Content="Home" Tag="SamplePage1" IconSource="Home" />
+        <ui:NavigationViewItem Content="Account" Tag="SamplePage2" IconSource="Home">
             <ui:NavigationViewItem.MenuItems>
-                <ui:NavigationViewItem Content="Mail" Icon="Mail" Tag="SamplePage3" />
-                <ui:NavigationViewItem Content="Calendar" Icon="Calendar" Tag="SamplePage4" />
+                <ui:NavigationViewItem Content="Mail" IconSource="Mail" Tag="SamplePage3" />
+                <ui:NavigationViewItem Content="Calendar" IconSource="Calendar" Tag="SamplePage4" />
             </ui:NavigationViewItem.MenuItems>
         </ui:NavigationViewItem>
-        <ui:NavigationViewItem Content="Document options" Tag="SamplePage3" Icon="Document" SelectsOnInvoked="False">
+        <ui:NavigationViewItem Content="Document options" Tag="SamplePage3" IconSource="Document" SelectsOnInvoked="False">
             <ui:NavigationViewItem.MenuItems>
-                <ui:NavigationViewItem Content="Create new" Icon="New" Tag="SamplePage5" />
-                <ui:NavigationViewItem Content="Upload file" Icon="Upload" Tag="SamplePage6" />
+                <ui:NavigationViewItem Content="Create new" IconSource="New" Tag="SamplePage5" />
+                <ui:NavigationViewItem Content="Upload file" IconSource="Upload" Tag="SamplePage6" />
             </ui:NavigationViewItem.MenuItems>
         </ui:NavigationViewItem>
     </ui:NavigationView.MenuItems>

--- a/FluentAvaloniaSamples/Pages/SampleCode/NavView5.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/NavView5.xaml.txt
@@ -1,12 +1,12 @@
 ﻿<ui:NavigationView x:Name="nvSample5" Height="460">
     <ui:NavigationView.MenuItems>
-        <ui:NavigationViewItem Content="Browse" Tag="SamplePage1" Icon="Library" />
-        <ui:NavigationViewItem Content="Track an Order" Tag="SamplePage2" Icon="Map" />
-        <ui:NavigationViewItem Content="Order History" Tag="SamplePage3" Icon="Tag" />
+        <ui:NavigationViewItem Content="Browse" Tag="SamplePage1" IconSource="Library" />
+        <ui:NavigationViewItem Content="Track an Order" Tag="SamplePage2" IconSource="Map" />
+        <ui:NavigationViewItem Content="Order History" Tag="SamplePage3" IconSource="Tag" />
     </ui:NavigationView.MenuItems>
     <ui:NavigationView.FooterMenuItems>
-        <ui:NavigationViewItem Content="Account" Tag="SamplePage4" Icon="Contact" />
-        <ui:NavigationViewItem Content="Your Cart" Tag="SamplePage5" Icon="Shop" />
-        <ui:NavigationViewItem Content="Help" Tag="SamplePage6" Icon="Help" />
+        <ui:NavigationViewItem Content="Account" Tag="SamplePage4" IconSource="Contact" />
+        <ui:NavigationViewItem Content="Your Cart" Tag="SamplePage5" IconSource="Shop" />
+        <ui:NavigationViewItem Content="Help" Tag="SamplePage6" IconSource="Help" />
     </ui:NavigationView.FooterMenuItems>
 </ui:NavigationView>

--- a/FluentAvaloniaSamples/Pages/SampleCode/NavView6.xaml.txt
+++ b/FluentAvaloniaSamples/Pages/SampleCode/NavView6.xaml.txt
@@ -7,10 +7,10 @@
                    PaneTitle="$(PaneTitle)"
                    IsSettingsVisible="$(Settings)">
     <ui:NavigationView.MenuItems>
-        <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" Icon="Play" />
+        <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" IconSource="Play" />
         <ui:NavigationViewItemHeader Content="Actions" />
-        <ui:NavigationViewItem Name="MenuItem2" Content="Menu Item2" Tag="SamplePage2" Icon="Download" $(NoSelection) />
-        <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" Icon="Refresh" />
+        <ui:NavigationViewItem Name="MenuItem2" Content="Menu Item2" Tag="SamplePage2" IconSource="Download" $(NoSelection) />
+        <ui:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" IconSource="Refresh" />
     </ui:NavigationView.MenuItems>
 
     <ui:NavigationView.AutoCompleteBox>
@@ -23,8 +23,8 @@
 
     <ui:NavigationView.PaneFooter>
         <StackPanel Name="FooterStackPanel" Orientation="Vertical" IsVisible="$(PaneFooter)">
-            <ui:NavigationViewItem Icon="Download" />
-            <ui:NavigationViewItem Icon="Alert" />
+            <ui:NavigationViewItem IconSource="Download" />
+            <ui:NavigationViewItem IconSource="Alert" />
         </StackPanel>
     </ui:NavigationView.PaneFooter>
 

--- a/FluentAvaloniaSamples/Views/MainView.axaml
+++ b/FluentAvaloniaSamples/Views/MainView.axaml
@@ -67,7 +67,7 @@
 										 HorizontalAlignment="Center"
                                          VerticalAlignment="Center">
                                     <ContentPresenter Name="Icon" 
-                                                      Content="{TemplateBinding Icon}" />
+                                                      Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}" />
                                 </Viewbox>
                                                                
                             </DockPanel>

--- a/FluentAvaloniaSamples/Views/MainView.axaml.cs
+++ b/FluentAvaloniaSamples/Views/MainView.axaml.cs
@@ -120,7 +120,7 @@ public partial class MainView : UserControl
             {
                 Content = "Home",
                 Tag = typeof(HomePage),
-                Icon = new IconSourceElement { IconSource = (IconSource)this.FindResource("HomeIcon") },
+                IconSource = (IconSource)this.FindResource("HomeIcon"),
                 Classes =
                 {
                     "SampleAppNav"
@@ -130,7 +130,7 @@ public partial class MainView : UserControl
             {
                 Content = "Core Controls",
                 Tag = typeof(CoreControlsPage),
-                Icon = new IconSourceElement { IconSource = (IconSource)this.FindResource("CoreCtrlsIcon") },
+                IconSource = (IconSource)this.FindResource("CoreCtrlsIcon"),
                 Classes =
                 {
                     "SampleAppNav"
@@ -140,7 +140,7 @@ public partial class MainView : UserControl
             {
                 Content = "New Controls",
                 Tag = typeof(NewControlsPage),
-                Icon = new IconSourceElement { IconSource = (IconSource)this.FindResource("CtrlsIcon") },
+                IconSource = (IconSource)this.FindResource("CtrlsIcon"),
                 Classes =
                 {
                     "SampleAppNav"
@@ -150,7 +150,7 @@ public partial class MainView : UserControl
             {
                 Content = "Resources",
                 Tag = typeof(ResourcesPage),
-                Icon = new IconSourceElement { IconSource = (IconSource)this.FindResource("ResourcesIcon") },
+                IconSource = (IconSource)this.FindResource("ResourcesIcon"),
                 Classes =
                 {
                     "SampleAppNav"
@@ -167,7 +167,7 @@ public partial class MainView : UserControl
             {
                 Content = "Settings",
                 Tag = typeof(SettingsPage),
-                Icon = new IconSourceElement { IconSource = (IconSource)this.FindResource("SettingsIcon") },
+                IconSource = (IconSource)this.FindResource("SettingsIcon"),
                 Classes =
                 {
                     "SampleAppNav"
@@ -235,23 +235,23 @@ public partial class MainView : UserControl
 
         if (t == typeof(HomePage))
         {
-            (item.Icon as IconSourceElement).IconSource = this.TryFindResource(selected ? "HomeIconFilled" : "HomeIcon", out var value) ?
+            item.IconSource = this.TryFindResource(selected ? "HomeIconFilled" : "HomeIcon", out var value) ?
                 (IconSource)value : null;
         }
         else if (t == typeof(CoreControlsPage))
         {
-            (item.Icon as IconSourceElement).IconSource = this.TryFindResource(selected ? "CoreCtrlsIconFilled" : "CoreCtrlsIcon", out var value) ?
+            item.IconSource = this.TryFindResource(selected ? "CoreCtrlsIconFilled" : "CoreCtrlsIcon", out var value) ?
                 (IconSource)value : null;
         }
         // Skip NewControlsPage as its icon is the same for both
         else if (t == typeof(ResourcesPage))
         {
-            (item.Icon as IconSourceElement).IconSource = this.TryFindResource(selected ? "ResourcesIconFilled" : "ResourcesIcon", out var value) ?
+            item.IconSource = this.TryFindResource(selected ? "ResourcesIconFilled" : "ResourcesIcon", out var value) ?
                 (IconSource)value : null;
         }
         else if (t == typeof(SettingsPage))
         {
-            (item.Icon as IconSourceElement).IconSource = this.TryFindResource(selected ? "SettingsIconFilled" : "SettingsIcon", out var value) ?
+            item.IconSource = this.TryFindResource(selected ? "SettingsIconFilled" : "SettingsIcon", out var value) ?
                (IconSource)value : null;
         }
     }


### PR DESCRIPTION
This PR moves NavigationViewItem (and NavigationViewItemPresenter), CommandBarButton/ToggleButton, and MenuFlyoutItem (and all related items) to use `IconSource`s instead of `FAIconElement`. This enables making icons resources and allows sharing them across your app and also standardizes IconSource in all controls to bring parity to newer controls where this is already done. 

This is a breaking change! The `Icon` property on these controls has been renamed `IconSource` and now expects an `IconSource`. Note that if you're using something like `Icon="Save"` to use the typeconverter, this also works with IconSource so you just need to rename the property: `IconSource="Save"`. Each of these controls now has a `TemplateSettings` property that stores the actual used FAIconElement. 

Also included:
- All controls using `IconSource` have been updated to AddOwner the `IconSource` AvaloniaProperty from `SettingsExpander`
- For `RadioMenuFlyoutItem` and `ToggleMenuFlyoutItem`, the check/dot glyph is now an IconSource resource to be shared.
- This PR includes a hack fix for #250, caused by a bug in the viewbox. The hack is just to disconnect the icon and re-add it when reapplying the template.

Closes #255