### PR TITLE
FluentAvalonia Episode VI: Return of the FAComboBox

### DIFF
--- a/FluentAvalonia/Core/FACompositeDisposable.cs
+++ b/FluentAvalonia/Core/FACompositeDisposable.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Collections;
+
+namespace FluentAvalonia.Core;
+
+internal class FACompositeDisposable : ICollection<IDisposable>, IEnumerable<IDisposable>, IEnumerable, IDisposable
+{
+    public FACompositeDisposable()
+    {
+        _list = new List<IDisposable>();
+    }
+
+    public FACompositeDisposable(int capacity)
+    {
+        _list = new List<IDisposable>(capacity);
+    }
+
+    public FACompositeDisposable(params IDisposable[] disposables)
+    {
+        _list = new List<IDisposable>(disposables);
+    }
+
+    public FACompositeDisposable(IEnumerable<IDisposable> disposables)
+    {
+        _list = new List<IDisposable>(disposables);
+    }
+
+    public int Count => _list.Count;
+
+    bool ICollection<IDisposable>.IsReadOnly => false;
+
+    public void Add(IDisposable item) => _list.Add(item);
+
+    public void Clear()
+    {
+        Dispose();
+    }
+
+    public bool Contains(IDisposable item) => _list.Contains(item);
+
+    public void CopyTo(IDisposable[] array, int arrayIndex) =>
+        _list.CopyTo(array, arrayIndex);
+
+    public void Dispose()
+    {
+        for (int i = _list.Count - 1; i >= 0; i--)
+        {
+            _list[i].Dispose();
+            _list.RemoveAt(i);
+        }
+    }
+
+    public IEnumerator<IDisposable> GetEnumerator() => _list.GetEnumerator();
+
+    public bool Remove(IDisposable item)
+    {
+        var index = _list.IndexOf(item);
+        if (index == -1)
+            return false;
+
+        _list.RemoveAt(index);
+
+        item.Dispose();
+        return true;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+
+    private readonly List<IDisposable> _list;
+}

--- a/FluentAvalonia/Core/SimpleObserver.cs
+++ b/FluentAvalonia/Core/SimpleObserver.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace FluentAvalonia.Core;
+
+internal class SimpleObserver<T> : IObserver<T>
+{
+    private readonly Action<T> _listener;
+    public SimpleObserver(Action<T> listener) => _listener = listener;
+    public void OnCompleted() { }
+    public void OnError(Exception error) { }
+    public void OnNext(T value) => _listener(value);
+}

--- a/FluentAvalonia/Styling/ControlThemes/Controls.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/Controls.axaml
@@ -104,6 +104,10 @@
 
                 <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderStyles.axaml" />
                 <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderItemStyles.axaml" />
+
+                <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml" />
+                <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxItemStyles.axaml" />
+                
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Styles.Resources>

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxItemStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxItemStyles.axaml
@@ -1,0 +1,145 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ui="using:FluentAvalonia.UI.Controls">
+    
+    <ControlTheme x:Key="{x:Type ui:FAComboBoxItem}"
+                 TargetType="ui:FAComboBoxItem">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForeground}" />
+        <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackground}" />
+        <Setter Property="Padding" Value="{DynamicResource ComboBoxItemThemePadding}" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
+        <Setter Property="FocusAdorner">
+            <FocusAdornerTemplate>
+                <Border BorderThickness="{DynamicResource SystemControlFocusVisualPrimaryThickness}"
+						BorderBrush="Red"
+						Margin="-3">
+                    <Border BorderThickness="{DynamicResource SystemControlFocusVisualSecondaryThickness}"
+							BorderBrush="{DynamicResource SystemControlFocusVisualSecondaryBrush}" />
+                </Border>
+            </FocusAdornerTemplate>
+        </Setter>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Name="LayoutRoot"
+						Background="{TemplateBinding Background}"
+						BorderBrush="{TemplateBinding BorderBrush}"
+						BorderThickness="{TemplateBinding BorderThickness}"
+						Margin="5 2"
+						CornerRadius="{TemplateBinding CornerRadius}"
+						TemplatedControl.IsTemplateFocusTarget="True">
+                    <Panel>
+                        <Rectangle Name="Pill"
+								   Theme="{StaticResource ComboBoxItemPill}"
+								   Opacity="0"
+								   RenderTransform="scaleY(1)">
+                            <Rectangle.Transitions>
+                                <Transitions>
+                                    <TransformOperationsTransition Duration="00:00:00.167"
+																   Property="RenderTransform"
+																   Easing="0,0 0,1" />
+                                </Transitions>
+                            </Rectangle.Transitions>
+                        </Rectangle>
+
+                        <ContentPresenter Name="ContentPresenter"
+										  Content="{TemplateBinding Content}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  Foreground="{TemplateBinding Foreground}"
+										  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+										  Margin="{TemplateBinding Padding}" />
+                    </Panel>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ Border#LayoutRoot">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
+            </Style>
+
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPointerOver}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ Border#LayoutRoot">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPressed}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPressed}" />
+            </Style>
+
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPressed}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Border#LayoutRoot">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundDisabled}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushDisabled}" />
+            </Style>
+
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:selected">
+            <Style Selector="^ /template/ Border#LayoutRoot">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundSelected}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushSelected}" />
+            </Style>
+
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundSelected}" />
+            </Style>
+
+            <Style Selector="^ /template/ Rectangle#Pill">
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+
+            <!-- Ignore SelectedUnfocused VisualState -->
+
+            <Style Selector="^:pointerover">
+                <Style Selector="^ /template/ Border#LayoutRoot">
+                    <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundSelectedPointerOver}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushSelectedPointerOver}" />
+                </Style>
+
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundSelectedPointerOver}" />
+                </Style>
+            </Style>
+
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ Rectangle#Pill">
+                    <Setter Property="RenderTransform" Value="scaleY(0.625)" />
+                </Style>
+                <Style Selector="^ /template/ Border#LayoutRoot">
+                    <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundSelectedPressed}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushSelectedPressed}" />
+                </Style>
+
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundSelectedPressed}" />
+                </Style>
+            </Style>
+
+            <Style Selector="^:disabled">
+                <Style Selector="^ /template/ Border#LayoutRoot">
+                    <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundSelectedDisabled}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushSelectedDisabled}" />
+                </Style>
+
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundSelectedDisabled}" />
+                </Style>
+            </Style>
+
+        </Style>
+    </ControlTheme>
+
+</ResourceDictionary>

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
@@ -260,6 +260,10 @@
             <!-- Skip FocusedDropDown state-->
         </Style>
 
+        <Style Selector="^:header /template/ ContentPresenter#HeaderContentPresenter">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+
         <!-- Editable states -->
         <Style Selector="^:editable">
             <Style Selector="^ /template/ TextBox#EditableText">

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
@@ -165,6 +165,7 @@
 									 HorizontalAlignment="Stretch"
 									 CornerRadius="{DynamicResource OverlayCornerRadius}">
                             <ScrollViewer Name="ScrollViewer"
+                                          AutomationProperties.AccessibilityView="Raw"
 										  Foreground="{DynamicResource ComboBoxDropDownForeground}"
 										  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
 										  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
@@ -1,0 +1,329 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ui="using:FluentAvalonia.UI.Controls">
+    <Design.PreviewWith>
+        <Border Padding="20">
+            <ui:FAComboBox Width="150" IsEditable="True" Text="asdg">
+
+            </ui:FAComboBox>
+        </Border>
+    </Design.PreviewWith>
+
+    <ControlTheme TargetType="TextBox"
+				  x:Key="ComboBoxTextBoxStyle"
+				  BasedOn="{StaticResource {x:Type TextBox}}">
+
+    </ControlTheme>
+
+    <ControlTheme x:Key="{x:Type ui:FAComboBox}"
+				  TargetType="{x:Type ui:FAComboBox}">
+        <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
+        <Setter Property="MaxDropDownHeight" Value="504" />
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxForeground}" />
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource ComboBoxBorderThemeThickness}" />
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="Once" />
+        <Setter Property="TextBoxTheme" Value="{StaticResource ComboBoxTextBoxStyle}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="ItemsPanel">
+            <ItemsPanelTemplate>
+                <VirtualizingStackPanel />
+            </ItemsPanelTemplate>
+        </Setter>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Grid Name="LayoutRoot"
+					  RowDefinitions="Auto,*,Auto"
+					  ColumnDefinitions="*,38">
+                    <ContentPresenter Name="HeaderContentPresenter"
+									  Grid.Row="0"
+									  Grid.Column="0"
+									  Grid.ColumnSpan="2"
+									  Content="{TemplateBinding Header}"
+									  ContentTemplate="{TemplateBinding HeaderTemplate}"
+									  FlowDirection="{TemplateBinding FlowDirection}"
+									  Foreground="{DynamicResource ComboBoxHeaderForeground}"
+									  FontWeight="{DynamicResource ComboBoxHeaderThemeFontWeight}"
+									  LineHeight="20"
+									  Margin="{DynamicResource ComboBoxTopHeaderMargin}"
+									  TextWrapping="Wrap"
+									  VerticalAlignment="Top"
+									  IsVisible="False" />
+
+                    <Border Name="HighlightBackground"
+							Grid.Row="1"
+							Grid.Column="0"
+							Grid.ColumnSpan="2"
+							Margin="-4"
+							Background="{DynamicResource ComboBoxBackgroundFocused}"
+							BorderBrush="{DynamicResource ComboBoxBackgroundBorderBrushFocused}"
+							BorderThickness="{DynamicResource ComboBoxBackgroundBorderThicknessFocused}"
+							CornerRadius="{DynamicResource ComboBoxHighlightBorderCornerRadius}"
+							Opacity="0" />
+
+                    <Border Name="Background"
+							Grid.Row="1"
+							Grid.Column="0"
+							Grid.ColumnSpan="2"
+							Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							CornerRadius="{TemplateBinding CornerRadius}"
+							TemplatedControl.IsTemplateFocusTarget="True"
+							MinWidth="{DynamicResource ComboBoxThemeMinWidth}" />
+
+                    <Rectangle Name="Pill"
+							   Theme="{StaticResource ComboBoxItemPill}"
+							   Margin="1 0 0 0"
+							   Grid.Row="1" Grid.Column="0"
+							   Opacity="0"
+							   RenderTransform="scaleY(1)" />
+
+                    <ContentPresenter Name="ContentPresenter"
+									  Grid.Row="1"
+									  Grid.Column="0"
+									  Margin="{TemplateBinding Padding}"
+									  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+									  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+									  Content="{TemplateBinding SelectionBoxItem}"
+									  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"/>
+                    <!-- WinUI can place this in the ContentPresenter, we can't, so we place it here as if its in the CP -->
+                    <TextBlock Name="PlaceholderTextBlock"
+							   Grid.Row="1"
+							   Grid.Column="0"
+							   Margin="{TemplateBinding Padding}"
+							   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+							   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+							   Text="{TemplateBinding PlaceholderText}"
+							   Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForeground}}" />
+
+                    <TextBox Name="EditableText"
+							 Grid.Row="1"
+							 Grid.Column="0"
+							 Grid.ColumnSpan="2"
+							 Theme="{TemplateBinding TextBoxTheme}"
+							 Margin="0,0,0,0"
+							 Padding="{DynamicResource ComboBoxEditableTextPadding}"
+							 BorderBrush="Transparent"
+							 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+							 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+							 Watermark="{TemplateBinding PlaceholderText}"
+							 Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForeground}}"
+							 Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Text, Mode=TwoWay}"
+							 IsVisible="False"
+							 AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
+							 CornerRadius="{TemplateBinding CornerRadius}"  />
+
+                    <Border Name="DropDownOverlay"
+							Grid.Row="1"
+							Grid.Column="1"
+							Background="Transparent"
+							Margin="4,4,4,4"
+							IsVisible="False"
+							CornerRadius="{StaticResource ComboBoxDropDownButtonBackgroundCornerRadius}"
+							Width="30"
+							HorizontalAlignment="Right" />
+
+                    <ui:FontIcon Name="DropDownGlyph"
+								 MinHeight="{DynamicResource ComboBoxMinHeight}"
+								 Grid.Row="1"
+								 Grid.Column="1"
+								 IsHitTestVisible="False"
+								 Margin="0 0 14 0"
+								 Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}"
+								 HorizontalAlignment="Right"
+								 VerticalAlignment="Center"
+								 Width="12" Height="12"
+								 FontSize="12"
+								 FontFamily="{StaticResource SymbolThemeFontFamily}"
+								 Glyph="&#xE70D;" />
+
+                    <!-- Skipping description property -->
+
+                    <Popup Name="Popup"
+						   WindowManagerAddShadowHint="False"
+						   IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
+						   MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
+						   MaxHeight="{TemplateBinding MaxDropDownHeight}"
+						   PlacementTarget="Background"
+						   IsLightDismissEnabled="True"
+						   InheritsTransform="True">
+                        <ui:FABorder Name="PopupBorder"
+									 Background="{DynamicResource ComboBoxDropDownBackground}"
+									 BackgroundSizing="InnerBorderEdge"
+									 BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+									 BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
+									 Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
+									 HorizontalAlignment="Stretch"
+									 CornerRadius="{DynamicResource OverlayCornerRadius}">
+                            <ScrollViewer Name="ScrollViewer"
+										  Foreground="{DynamicResource ComboBoxDropDownForeground}"
+										  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+										  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                <ItemsPresenter Margin="{DynamicResource ComboBoxDropdownContentMargin}"
+												ItemsPanel="{TemplateBinding ItemsPanel}"/>
+                            </ScrollViewer>
+                        </ui:FABorder>
+                    </Popup>
+
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ Border#Background">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundPointerOver}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPointerOver}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundPointerOver}" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxPlaceHolderForegroundPointerOver}" />
+                <!--<Setter Property="Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForegroundPointerOver}}" />-->
+            </Style>
+        </Style>
+
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ Border#Background">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundPressed}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushPressed}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundPressed}" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxPlaceHolderForegroundPressed}" />
+                <!--<Setter Property="Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForegroundPressed}}" />-->
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Border#Background">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter#HeaderContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxHeaderForegroundDisabled}" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxPlaceHolderForegroundDisabled}" />
+                <!--<Setter Property="Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForegroundDisabled}}" />-->
+            </Style>
+            <Style Selector="^ /template/ ui|FontIcon#DropDownGlyph">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:focus-visible">
+            <Style Selector="^ /template/ Border#HighlightBackground">
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+            <Style Selector="^ /template/ Rectangle#Pill">
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxPlaceHolderForegroundFocused}" />
+                <!--<Setter Property="Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForegroundFocused}}" />-->
+            </Style>
+            <Style Selector="^ /template/ ui|FontIcon#DropDownGlyph">
+                <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
+            </Style>
+
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundFocusedPressed}" />
+                </Style>
+                <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+                    <Setter Property="Foreground" Value="{DynamicResource ComboBoxPlaceHolderForegroundFocusedPressed}" />
+                    <!--<Setter Property="Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForegroundFocusedPressed}}" />-->
+                </Style>
+                <Style Selector="^ /template/ ui|FontIcon#DropDownGlyph">
+                    <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
+                </Style>
+            </Style>
+
+            <!-- Skip FocusedDropDown state-->
+        </Style>
+
+        <!-- Editable states -->
+        <Style Selector="^:editable">
+            <Style Selector="^ /template/ TextBox#EditableText">
+                <Setter Property="IsVisible" Value="True" />
+                <!-- 
+				This isn't a hack, this is what WinUI does
+				When not focused, they set the width to 0 to hide the TextBox
+				Its done in code but you can see this in the live visual tree &
+				property explorer of UWP -->
+                <Setter Property="Width" Value="0" />
+                <Setter Property="MinWidth" Value="0" />
+            </Style>
+            <Style Selector="^ /template/ Popup#Popup">
+                <Setter Property="PlacementConstraintAdjustment" Value="FlipY" />
+            </Style>
+
+            <Style Selector="^:focus-within /template/ TextBox#EditableText,
+				             ^:dropdownopen /template/ TextBox#EditableText">
+                <Setter Property="IsVisible" Value="True" />
+                <Setter Property="Width" Value="NaN" />
+            </Style>
+
+            <Style Selector="^:dropdownopen /template/ ContentPresenter#ContentPresenter,
+				             ^:focus-within /template/ ContentPresenter#ContentPresenter">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+
+            <Style Selector="^ /template/ Border#DropDownOverlay">
+                <Setter Property="IsVisible" Value="True" />
+
+
+            </Style>
+            <Style Selector="^ /template/ Border#DropDownOverlay:pointerover">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPointerOver}" />
+            </Style>
+
+            <Style Selector="^ /template/ Border#DropDownOverlay:pressed">
+                <Setter Property="Background" Value="{DynamicResource ComboBoxDropDownBackgroundPressed}" />
+            </Style>
+
+            <Style Selector="^:dropdownopen">
+                <Style Selector="^ /template/ Border#HighlightBackground">
+                    <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                </Style>
+                <Style Selector="^ /template/ TextBox#EditableText">
+                    <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                </Style>
+                <Style Selector="^ /template/ ui|FABorder#PopupBorder">
+                    <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                </Style>
+
+                <Style Selector="^:popupAbove">
+                    <Style Selector="^ /template/ Border#HighlightBackground">
+                        <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                    </Style>
+                    <Style Selector="^ /template/ TextBox#EditableText">
+                        <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                    </Style>
+                    <Style Selector="^ /template/ ui|FABorder#PopupBorder">
+                        <Setter Property="CornerRadius" Value="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                    </Style>
+                </Style>
+            </Style>
+        </Style>
+    </ControlTheme>
+
+</ResourceDictionary>

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -326,6 +326,8 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
                 }
             }
         }
+
+        UpdateIsSelectionBoxHighlighted();
     }
 
     protected override void OnLostFocus(RoutedEventArgs e)
@@ -744,6 +746,16 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
                 }
             }
         }
+    }
+
+    private void UpdateIsSelectionBoxHighlighted()
+    {
+        // Per WPF:
+        // !comboBox.IsDropDownOpen && comboBox.IsKeyboardFocusWithin ||
+        // comboBox.HighlightedElement != null && highlightedElement.Content == comboBox._clonedElement
+        // Not sure how to handle that second clause, as this is different implementation
+        // so we'll just use the first
+        IsSelectionBoxHighlighted = !IsDropDownOpen && IsKeyboardFocusWithin;
     }
 
 

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -1,0 +1,1056 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAvalonia.Core;
+using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace FluentAvalonia.UI.Controls;
+
+public partial class FAComboBox : HeaderedSelectingItemsControl
+{
+    public FAComboBox()
+    {
+    }
+
+
+    static FAComboBox()
+    {
+        FocusableProperty.OverrideDefaultValue<FAComboBox>(true);
+        IsTextSearchEnabledProperty.OverrideDefaultValue<FAComboBox>(true);
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        if (_popup != null)
+        {
+            _popup.Opened -= OnPopupOpened;
+            _popup.Closed -= OnPopupClosed;
+        }
+
+        if (_textBox != null)
+        {
+            _textBox.TextChanged -= OnTextBoxTextChanged;
+            _textBox.KeyDown -= OnTextBoxKeyDown;
+        }
+
+        if (_dropDownOverlay != null)
+        {
+            _dropDownOverlay.PointerPressed -= OnDropDownOverlayPointerPressed;
+            _dropDownOverlay.PointerReleased -= OnDropDownOverlayPointerReleased;
+            _dropDownOverlay.PointerCaptureLost -= OnDropDownOverlayPointerCaptureLost;
+        }
+
+        base.OnApplyTemplate(e);
+
+        _popup = e.NameScope.Get<Popup>("Popup");
+        _popup.Opened += OnPopupOpened;
+        _popup.Closed += OnPopupClosed;
+
+        _textBox = e.NameScope.Find<TextBox>("EditableText");
+        if (_textBox != null)
+        {
+            _textBox.TextChanged += OnTextBoxTextChanged;
+            _textBox.KeyDown += OnTextBoxKeyDown;
+        }
+
+        _dropDownOverlay = e.NameScope.Find<Border>("DropDownOverlay");
+        if (_dropDownOverlay != null)
+        {
+            // Pointerover can be handled in xaml automatically, so we only need to worry
+            // about the pressed state & clicking
+            _dropDownOverlay.PointerPressed += OnDropDownOverlayPointerPressed;
+            _dropDownOverlay.PointerReleased += OnDropDownOverlayPointerReleased;
+            _dropDownOverlay.PointerCaptureLost += OnDropDownOverlayPointerCaptureLost;
+        }
+
+        var text = Text;
+        if (IsEditable && !string.IsNullOrEmpty(text))
+        {
+            UpdateSelectionBoxItem(text);
+        }
+        else
+        {
+            UpdateSelectionBoxItem(SelectedItem);
+        }
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == SelectedItemProperty)
+        {
+            OnSelectedItemChanged(change);
+        }
+        else if (change.Property == DisplayMemberBindingProperty)
+        {
+            var temp = change.GetNewValue<IBinding>();
+            if (temp != null)
+            {
+                _displayMemberTemplate = new FuncDataTemplate<object>((_, _) =>
+                {
+                    return new TextBlock
+                    {
+                        [!TextBlock.TextProperty] = temp
+                    };
+                });
+            }
+            else
+            {
+                _displayMemberTemplate = null;
+            }
+        }
+        else if (change.Property == ItemTemplateProperty)
+        {
+            var temp = change.GetNewValue<IDataTemplate>();
+            SelectionBoxItemTemplate = temp;
+        }
+        else if (change.Property == IsEditableProperty)
+        {
+            PseudoClasses.Set(":editable", change.GetNewValue<bool>());
+            UpdateSelectionBoxItem(SelectedItem ?? Text);
+        }
+        else if (change.Property == TextProperty)
+        {
+            if (_textBox != null && IsEditable)
+            {
+                OnTextChanged(change.GetNewValue<string>());
+            }
+        }
+    }
+
+    protected override Control CreateContainerForItemOverride() => new FAComboBoxItem();
+
+    protected override bool IsItemItsOwnContainerOverride(Control item) =>
+        item is FAComboBoxItem;
+
+    public override void InvalidateMirrorTransform()
+    {
+        base.InvalidateMirrorTransform();
+        UpdateFlowDirection();
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+
+        if (e.Handled)
+            return;
+
+        bool isOpen = IsDropDownOpen;
+        bool isEditable = IsEditable;
+
+        if ((e.Key == Key.F4 && e.KeyModifiers.HasAllFlags(KeyModifiers.Alt) == false) ||
+                ((e.Key == Key.Down || e.Key == Key.Up) && e.KeyModifiers.HasAllFlags(KeyModifiers.Alt)))
+        {
+            IsDropDownOpen = !isOpen;
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            if (isOpen)
+            {
+                IsDropDownOpen = false;
+            }
+
+            // Two cases for this:
+            // 1- If isOpen, since we change the selection box based on keyboard navigaton without changing
+            //    the SelectedItem, we need to revert to the actual selection if its cancelled
+            // 2- If !isOpen, and editable, user can revert their text change by pressing escape
+            UpdateSelectionBoxItem(SelectedItem);
+            if (isEditable && SelectedItem is null)
+            {
+                // UWP behavior - even if text is set, hitting escape will clear the text if no
+                // item is selected
+                Text = null;
+            }
+            e.Handled = true;
+        }
+        else if (!isOpen && !isEditable && (e.Key == Key.Enter || e.Key == Key.Space))
+        {
+            IsDropDownOpen = true;
+            e.Handled = true;
+        }
+        else if (isEditable && e.Key == Key.Enter)
+        {
+            if (_textBox is not null && _textBox.IsFocused)
+            {
+                OnTextSubmittedCore();
+            }
+            else
+            {
+                SelectFocusedItem();
+            }
+            IsDropDownOpen = false;
+            e.Handled = true;
+        }
+        else if (isOpen && (e.Key == Key.Enter || e.Key == Key.Space))
+        {
+            SelectFocusedItem();
+            IsDropDownOpen = false;
+            e.Handled = true;
+        }
+        else if (!isOpen)
+        {
+            if (e.Key == Key.Down)
+            {
+                if (!isEditable)
+                {
+                    SelectNext();
+                }
+                else
+                {
+                    IsDropDownOpen = true;
+                }
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Up)
+            {
+                if (!isEditable)
+                {
+                    SelectPrev();
+                }
+                else
+                {
+                    IsDropDownOpen = true;
+                }
+                e.Handled = true;
+            }
+        }
+        // This part of code is needed just to acquire initial focus, subsequent focus navigation will be done by ItemsControl.
+        else if (isOpen && SelectedIndex < 0 && ItemCount > 0 &&
+                 (e.Key == Key.Up || e.Key == Key.Down) && IsFocused == true)
+        {
+            var firstChild = Presenter?.Panel?.Children.FirstOrDefault(c => CanFocus(c));
+            if (firstChild != null)
+            {
+                FocusManager.Instance?.Focus(firstChild, NavigationMethod.Directional);
+                e.Handled = true;
+            }
+        }
+    }
+
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        base.OnPointerWheelChanged(e);
+
+        if (!e.Handled)
+        {
+            if (!IsDropDownOpen)
+            {
+                if (IsFocused)
+                {
+                    if (e.Delta.Y < 0)
+                        SelectNext();
+                    else
+                        SelectPrev();
+
+                    e.Handled = true;
+                }
+            }
+            else
+            {
+                e.Handled = true;
+            }
+        }
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+
+        if (!e.Handled && e.Source is Visual src)
+        {
+            if (_popup?.IsInsidePopup(src) == true)
+                return;
+        }
+        PseudoClasses.Set(":pressed", true);
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        if (!e.Handled && e.Source is Visual src)
+        {
+            if (_popup?.IsInsidePopup(src) == true)
+            {
+                if (UpdateSelectionFromEventSource(e.Source))
+                {
+                    _popup.Close();
+                    e.Handled = true;
+                }
+            }
+            else
+            {
+                if (!IsEditable)
+                {
+                    // Only open the dropdown here if we're not editable
+                    // Editable CB requires clicking on the DropDownOverlay
+                    bool open = IsDropDownOpen;
+                    IsDropDownOpen = !open;
+                }
+
+                e.Handled = true;
+            }
+        }
+        PseudoClasses.Set(":pressed", false);
+        base.OnPointerReleased(e);
+    }
+
+    protected override void OnGotFocus(GotFocusEventArgs e)
+    {
+        base.OnGotFocus(e);
+        if (IsEditable && _textBox != null)
+        {
+            if (!IsDropDownOpen)
+            {
+                FocusManager.Instance.Focus(_textBox, e.NavigationMethod);
+                HighlightTextBoxText();
+            }
+            else
+            {
+                if (!_textBox.IsFocused)
+                {
+                    // If focus moves to the dropdown, keep the textbox style looking
+                    // like its focused
+                    ((IPseudoClasses)_textBox.Classes).Set(":focus", true);
+                }
+            }
+        }
+    }
+
+    protected override void OnLostFocus(RoutedEventArgs e)
+    {
+        base.OnLostFocus(e);
+
+        if (IsDropDownOpen && e.Source is FAComboBoxItem)
+        {
+            return;
+        }
+
+        if (IsEditable && !HasImplicitFocus())
+        {
+            if (_hasUnsubmittedText)
+            {
+                OnTextSubmittedCore();
+            }
+
+            if (IsDropDownOpen && _popup.IsLightDismissEnabled)
+            {
+                IsDropDownOpen = false;
+            }
+
+            ClearTextBoxSelection();
+        }
+
+        bool HasImplicitFocus()
+        {
+            var c = FocusManager.Instance.Current as Control;
+            // FAComboBoxItem is the only container we allow, so if it has focus
+            // we know we're in this ComboBox's dropdown and have implicit focus
+            if (c is FAComboBoxItem)
+                return true;
+
+            return c != null && c.FindAncestorOfType<FAComboBox>(true) == this;
+        }
+    }
+
+    protected override void PrepareContainerForItemOverride(Control element, object item, int index)
+    {
+        base.PrepareContainerForItemOverride(element, item, index);
+
+        if (IsEditable)
+        {
+            // When the ComboBox is editable, we don't use the FocusAdorner in the ComboBox dropdown
+            // and use the "selected" visual state as the indicator
+            element.FocusAdorner = _noFocusAdornerTemplate;
+        }
+    }
+
+    protected override void ClearContainerForItemOverride(Control element)
+    {
+        base.ClearContainerForItemOverride(element);
+
+        if (IsEditable)
+        {
+            element.ClearValue(FocusAdornerProperty);
+        }
+    }
+
+    //protected override AutomationPeer OnCreateAutomationPeer()
+    //{
+    //    return new ComboBoxAutomationPeer(this)
+    //}
+
+    internal void ItemFocused(FAComboBoxItem item)
+    {
+        if (IsDropDownOpen && item.IsFocused && item.IsArrangeValid)
+        {
+            item.BringIntoView();
+
+            var oldContainer = ContainerFromIndex(_dropDownSelectedIndex);
+            if (oldContainer != null)
+            {
+                ((IPseudoClasses)oldContainer.Classes).Set(":selected", false);
+            }
+
+            var changeType = SelectionChangedTrigger;
+            if (changeType == FAComboBoxSelectionChangedTrigger.Always)
+            {
+                SelectedIndex = IndexFromContainer(item);
+            }
+            else
+            {
+                _dropDownSelectedIndex = IndexFromContainer(item);
+                ((IPseudoClasses)item.Classes).Set(":selected", true);
+                UpdateSelectionBoxItem(ItemsView[_dropDownSelectedIndex]);
+            }
+        }
+    }
+
+    protected virtual void OnSelectedItemChanged(AvaloniaPropertyChangedEventArgs args)
+    {
+        UpdateSelectionBoxItem(args.NewValue ?? Text);
+        TryFocusSelectedItem();
+    }
+
+    protected virtual void OnTextSubmitted(FAComboBoxTextSubmittedEventArgs args)
+    {
+
+    }
+
+    private void OnPopupOpened(object sender, EventArgs e)
+    {
+        TryFocusSelectedItem();
+
+        if (SelectionChangedTrigger == FAComboBoxSelectionChangedTrigger.Committed)
+            _dropDownSelectedIndex = SelectedIndex;
+
+        _subscriptionsOnOpen.Clear();
+
+        var toplevel = this.GetVisualRoot() as TopLevel;
+        if (toplevel != null)
+        {
+            _subscriptionsOnOpen.Add(
+                toplevel.AddDisposableHandler(PointerWheelChangedEvent, (s, ev) =>
+                {
+                    if (IsDropDownOpen && (ev.Source as Visual)?.GetVisualRoot() == toplevel)
+                        ev.Handled = true;
+                }, RoutingStrategies.Tunnel));
+        }
+
+        _subscriptionsOnOpen.Add(
+            this.GetObservable(IsVisibleProperty).Subscribe(
+                new SimpleObserver<bool>(IsVisibleChanged)));
+
+        foreach (var parent in this.GetVisualAncestors().OfType<Control>())
+        {
+            _subscriptionsOnOpen.Add(
+                parent.GetObservable(IsVisibleProperty).Subscribe(
+                    new SimpleObserver<bool>(IsVisibleChanged)));
+        }
+
+        UpdateFlowDirection();
+
+        DropDownOpened?.Invoke(this, EventArgs.Empty);
+        PseudoClasses.Set(":dropdownopen", true);
+
+        if (!IsEditable)
+        {
+            var si = SelectedIndex;
+            double dropDownDelta = 0;
+            if (si == -1)
+            {
+                // If nothing's selected, we'll center the popup over the ComboBox
+                dropDownDelta = _popup.Child.DesiredSize.Height / 2;
+            }
+            else
+            {
+                // Find the selected item container, and center it over the ComboBox
+                // TryFocusSelectedItem above should handle materializing the item if
+                // it isn't already (it calls ScrollIntoView)
+                var container = ContainerFromIndex(si);
+                if (container is null) // If this happens for any reason, just bail out
+                    return;
+
+                var root = container.GetVisualRoot() as Visual;
+                var transform = container.TransformToVisual(root);
+                if (!transform.HasValue) // Also bail out if this fails for any reason
+                    return;
+
+                var y = new Point(0, 0).Transform(transform.Value).Y; // Top of container
+                // Popup is normally positioned below ComboBox, so also move up container height
+                dropDownDelta = y + container.DesiredSize.Height;
+            }
+
+            _popup.VerticalOffset = -dropDownDelta;
+
+            var contentRoot = _popup.Child.GetVisualRoot();
+            if (contentRoot is PopupRoot)
+            {
+                // HACK: Windowed popups appear to be +1 offset on x-axis for some reason
+                // which makes the popup look off center. Overlay popups are fine
+                _popup.HorizontalOffset = -1;
+            }
+        }
+        else
+        {
+            UpdateCornerRadius();
+        }
+    }
+
+    private void UpdateCornerRadius()
+    {
+        var child = _popup.Child as Visual;
+        var thisRoot = this.GetVisualRoot();
+        var popupRoot = child.GetVisualRoot();
+
+        bool isPopupAbove = false;
+        if (popupRoot is OverlayPopupHost oph)
+        {
+            Debug.Assert(thisRoot == popupRoot);
+            // Overlay popups are in use, this is the easiest
+            var pt = new Point(0, 0).Transform(this.TransformToVisual(thisRoot as Visual).Value);
+            var pt2 = new Point(0, 0).Transform(child.TransformToVisual(thisRoot as Visual).Value);
+
+            isPopupAbove = pt2.Y < pt.Y;
+        }
+        else
+        {
+            var popupPosition = (_popup?.Host as PopupRoot)?.PlatformImpl?.Position;
+
+            // If we can't get the screen position of the popup, cancel now, the result will
+            // be the default behavior of unrounded bottom ComboBox and unrounded top popup
+            if (!popupPosition.HasValue)
+                return;
+
+            var pt = child.PointToScreen(new Point(0, 0));
+            var thisInScreenSpace = this.PointToScreen(new Point(0, 0));
+
+            isPopupAbove = pt.Y < thisInScreenSpace.Y;
+
+            // HACK: Windowed popups appear to be +1 offset on x-axis for some reason
+            // which makes the popup look off center. Overlay popups are fine
+            _popup.HorizontalOffset = -1;
+        }
+
+        PseudoClasses.Set(":popupAbove", isPopupAbove);
+    }
+
+    private void OnPopupClosed(object sender, EventArgs e)
+    {
+        _subscriptionsOnOpen.Clear();
+
+        if (CanFocus(this))
+        {
+            if (IsEditable && _textBox != null)
+            {
+                _textBox.Focus();
+            }
+            else
+            {
+                Focus();
+            }
+        }
+
+        DropDownClosed?.Invoke(this, EventArgs.Empty);
+
+        UpdateSelectionBoxItem(SelectedItem ?? Text);
+
+        if (_dropDownSelectedIndex != SelectedIndex)
+        {
+            var container = ContainerFromIndex(_dropDownSelectedIndex);
+            if (container != null)
+            {
+                ((IPseudoClasses)container.Classes).Set(":selected", false);
+            }
+        }
+        _dropDownSelectedIndex = -1;
+        PseudoClasses.Set(":dropdownopen", false);
+        PseudoClasses.Set(":popupAbove", false);
+    }
+
+    private void IsVisibleChanged(bool isVisible)
+    {
+        if (!isVisible && IsDropDownOpen)
+            IsDropDownOpen = false;
+    }
+
+    private void TryFocusSelectedItem()
+    {
+        var sIdx = SelectedIndex;
+        if (IsDropDownOpen && sIdx != -1)
+        {
+            var container = ContainerFromIndex(sIdx);
+
+            if (container == null && sIdx != -1)
+            {
+                ScrollIntoView(Selection.SelectedIndex);
+                container = ContainerFromIndex(sIdx);
+            }
+
+            if (container != null && CanFocus(container))
+                container.Focus();
+        }
+    }
+
+    private bool CanFocus(Control control) =>
+        control.Focusable && control.IsEffectivelyEnabled && control.IsVisible;
+
+    private void UpdateSelectionBoxItem(object item)
+    {
+        if (!this.IsAttachedToVisualTree())
+        {
+            return;
+        }
+
+        if (IsEditable && item != null)
+        {
+            UpdateTextValue(FormatValue(item), false);
+        }
+
+        var contentControl = item as ContentControl;
+
+        if (contentControl != null)
+        {
+            item = contentControl.Content;
+        }
+
+        var control = item as Control;
+
+        if (control != null)
+        {
+            control.Measure(Size.Infinity);
+
+            var sbi = SelectionBoxItem;
+            var displayItem = (sbi as Rectangle) ?? new Rectangle();
+
+            displayItem.Width = control.DesiredSize.Width;
+            displayItem.Height = control.DesiredSize.Height;
+
+            if (displayItem.Fill is VisualBrush vb)
+            {
+                vb.Visual = control;
+            }
+            else
+            {
+                displayItem.Fill = new VisualBrush
+                {
+                    Visual = control,
+                    Stretch = Stretch.None,
+                    AlignmentX = AlignmentX.Left,
+                };
+            }
+
+            if (sbi != displayItem)
+            {
+                SelectionBoxItem = displayItem;
+            }
+
+            UpdateFlowDirection();
+        }
+        else
+        {
+            if (item is string)
+            {
+                // If the item is a raw string, don't use the template or nothing will show
+                SelectionBoxItemTemplate = null;
+                SelectionBoxItem = item;
+            }
+            else
+            {
+                var template = _displayMemberTemplate ?? ItemTemplate;
+                if (template is not null)
+                    SelectionBoxItemTemplate = template;
+
+                SelectionBoxItem = item;
+            }
+        }
+    }
+
+    private void UpdateFlowDirection()
+    {
+        if (SelectionBoxItem is Rectangle rectangle)
+        {
+            if ((rectangle.Fill as VisualBrush)?.Visual is Visual content)
+            {
+                var flowDirection = (content.GetVisualParent() as Control)?.FlowDirection ?? FlowDirection.LeftToRight;
+                rectangle.FlowDirection = flowDirection;
+            }
+        }
+    }
+
+    private void SelectNext()
+    {
+        if (ItemCount >= 1)
+        {
+            MoveSelection(NavigationDirection.Next, WrapSelection);
+        }
+    }
+
+    private void SelectPrev()
+    {
+        if (ItemCount >= 1)
+        {
+            MoveSelection(NavigationDirection.Previous, WrapSelection);
+        }
+    }
+
+    private void SelectFocusedItem()
+    {
+        var change = SelectionChangedTrigger;
+        if (change == FAComboBoxSelectionChangedTrigger.Committed)
+        {
+            SelectedIndex = _dropDownSelectedIndex;
+            _dropDownSelectedIndex = -1;
+        }
+        else
+        {
+            foreach (var item in GetRealizedContainers())
+            {
+                if (item.IsFocused)
+                {
+                    SelectedIndex = IndexFromContainer(item);
+                    break;
+                }
+            }
+        }
+    }
+
+
+
+    //////////////////////////////////////////////////////////////
+    // Editable ComboBox related
+    //////////////////////////////////////////////////////////////
+
+
+    private void OnTextBoxKeyDown(object sender, KeyEventArgs e)
+    {
+        if (IsDropDownOpen && (e.Key == Key.Up || e.Key == Key.Down))
+        {
+            var first = ContainerFromIndex(0);
+            if (first != null)
+            {
+                FocusManager.Instance.Focus(first, NavigationMethod.Directional);
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void OnDropDownOverlayPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(_dropDownOverlay).Properties.IsLeftButtonPressed)
+        {
+            ((IPseudoClasses)_dropDownOverlay.Classes).Set(":pressed", true);
+            e.Handled = true;
+        }
+    }
+
+    private void OnDropDownOverlayPointerReleased(object sender, PointerReleasedEventArgs e)
+    {
+        if (e.GetCurrentPoint(_dropDownOverlay).Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased)
+        {
+            ((IPseudoClasses)_dropDownOverlay.Classes).Set(":pressed", false);
+            IsDropDownOpen = !IsDropDownOpen;
+            UpdateSelectionBoxItem(SelectedItem);
+            e.Handled = true;
+        }
+    }
+
+    private void OnDropDownOverlayPointerCaptureLost(object sender, PointerCaptureLostEventArgs e)
+    {
+        ((IPseudoClasses)_dropDownOverlay.Classes).Set(":pressed", false);
+    }
+
+    private string FormatValue(object item)
+    {
+        if (item is ContentControl cc)
+        {
+            return cc.Content.ToString();
+        }
+        else if (item is string s)
+        {
+            return s;
+        }
+        else
+        {
+            return _bindingHelper.Evaluate(DisplayMemberBinding, item).ToString();
+        }
+    }
+
+    private void OnTextBoxTextChanged(object sender, TextChangedEventArgs e)
+    {
+        // Per AutoComplete, post to dispatcher so textbox selection updates before
+        // we process this...TODO: do we need to do that?
+        Dispatcher.UIThread.Post(() => TextUpdated(_textBox.Text, true));
+    }
+
+    private void OnTextChanged(string newValue)
+    {
+        TextUpdated(newValue, false);
+    }
+
+    private void UpdateTextValue(string value, bool? user)
+    {
+        if ((user ?? true) && Text != value)
+        {
+            _ignoreTextPropertyChange++;
+            Text = value;
+        }
+
+        if ((user == null || user == false) && _textBox != null && _textBox.Text != value)
+        {
+            _ignoreTextPropertyChange++;
+            _textBox.Text = value ?? string.Empty;
+        }
+    }
+
+    private void TextUpdated(string newText, bool user)
+    {
+        if (_ignoreTextPropertyChange > 0)
+        {
+            _ignoreTextPropertyChange--;
+            return;
+        }
+
+        if (newText is null)
+            newText = string.Empty;
+
+        var start = _textBox.SelectionStart;
+        var end = _textBox.SelectionEnd;
+
+        if (IsTextSearchEnabled && _textBox != null && (end - start) > 0 &&
+            start != _textBox.Text.Length)
+        {
+            return;
+        }
+
+        _hasUnsubmittedText = true;
+
+        UpdateTextValue(newText, user);
+
+        if (!string.IsNullOrEmpty(newText) && newText.Length > 0)
+        {
+            _ignoreTextSelectionChange = true;
+            UpdateTextCompletion(true);
+        }
+    }
+
+    private void UpdateTextCompletion(bool user)
+    {
+        string text = Text;
+        if (ItemCount > 0)
+        {
+            if (IsTextSearchEnabled && _textBox != null && user)
+            {
+                int curLen = _textBox.Text.Length;
+                int selStart = _textBox.SelectionStart;
+
+                if (selStart == text.Length && selStart > _currentTextSelectionStart)
+                {
+                    var firstMatch = TryGetMatch(text, out int index);
+
+                    if (firstMatch is not null)
+                    {
+                        var value = FormatValue(firstMatch);
+                        int minLength = Math.Min(value.Length, text.Length);
+                        if (Compare(text, value, minLength))
+                        {
+                            UpdateTextValue(value, null);
+
+                            _textBox.SelectionStart = curLen;
+                            _textBox.SelectionEnd = value.Length;
+
+                            if (IsDropDownOpen)
+                            {
+                                _dropDownSelectedIndex = index;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (_ignoreTextSelectionChange)
+        {
+            _ignoreTextSelectionChange = false;
+            if (_textBox != null)
+            {
+                _currentTextSelectionStart = _textBox.SelectionStart;
+            }
+        }
+
+        static bool Compare(string text1, string text2, int minLength)
+        {
+            var sp1 = text1.AsSpan().Slice(0, minLength);
+            var sp2 = text2.AsSpan().Slice(0, minLength);
+            return MemoryExtensions.Equals(sp1, sp2, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private object TryGetMatch(string currentText, out int index)
+    {
+        index = -1;
+        var items = ItemsView;
+        int count = items.Count;
+
+        for (int i = 0; i < count; i++)
+        {
+            var item = items[i];
+            var value = FormatValue(item);
+
+            if (!string.IsNullOrEmpty(value) && value.StartsWith(currentText, StringComparison.OrdinalIgnoreCase))
+            {
+                index = i;
+                return item;
+            }
+        }
+
+        return null;
+    }
+
+    private void OnTextSubmittedCore()
+    {
+        var args = new FAComboBoxTextSubmittedEventArgs(Text);
+        OnTextSubmitted(args);
+        TextSubmitted?.Invoke(this, args);
+
+        if (args.Handled)
+        {
+            _hasUnsubmittedText = false;
+            ClearTextBoxSelection();
+            return;
+        }
+
+        // In UWP, they will attempt to set the SelectedItem to the text, which may
+        // produce an InvalidCastException and crashes the app
+        // In WPF, this doesn't happen and the existing selection is cleared
+        // We'll follow WPF b/c that's a much nicer behavior
+        var idx = FindItemFromTextValue(args.Text);
+        var oldIdx = SelectedIndex;
+        SelectedIndex = idx;
+
+        // However, UWP raises the SelectionChanged event for text submissions that aren't 
+        // in the items collection
+        if (oldIdx == -1 && idx == -1)
+        {
+            // However, if an item is selected previously, in UWP
+            //   RemovedItems => Old Selected Item
+            //   AddedItems => Text
+            // Since we can't control the SelectionChangedEvent in Avalonia, here it will be 
+            //   RemovedItems => Old Selected Item
+            //   AddedItems => null
+
+            // For consistency, we'll raise the event, but both Removed & AddedItems will be null
+            RaiseEvent(new SelectionChangedEventArgs(SelectionChangedEvent, null, null));
+        }
+
+        _hasUnsubmittedText = false;
+        ClearTextBoxSelection();
+    }
+
+    private void HighlightTextBoxText()
+    {
+        _textBox.SelectAll();
+    }
+
+    private void ClearTextBoxSelection()
+    {
+        if (_textBox == null)
+            return;
+
+        var len = _textBox.Text?.Length ?? 0;
+        _textBox.SelectionStart = _textBox.SelectionEnd = len;
+    }
+
+    private int FindItemFromTextValue(string text)
+    {
+        var items = ItemsView;
+        var ct = items.Count;
+        var binding = DisplayMemberBinding;
+
+        for (int i = 0; i < ct; i++)
+        {
+            var item = items[i];
+
+            if (item is ContentControl cc)
+            {
+                // If the item is a ContentControl (ComboBoxItem), directly search its content
+                // we don't need to go through the binding path here since DisplayMemberBinding
+                // isn't active when item = container
+                if (cc.Content.ToString().Equals(text))
+                {
+                    return i;
+                }
+            }
+            else
+            {
+                // Item is a ViewModel
+                var value = binding is null ? item.ToString() : _bindingHelper.Evaluate(binding, item);
+
+                if (value != null && value.Equals(text))
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+
+    private Popup _popup;
+    private TextBox _textBox;
+    private Border _dropDownOverlay;
+    private IDataTemplate _displayMemberTemplate;
+    private int _dropDownSelectedIndex = -1;
+    private int _ignoreTextPropertyChange = 0;
+    private bool _ignoreTextSelectionChange = false;
+    private bool _hasUnsubmittedText;
+    private int _currentTextSelectionStart;
+    private readonly ITemplate<Control> _noFocusAdornerTemplate = new FuncTemplate<Control>(() => new Decorator());
+
+    private readonly BindingHelper _bindingHelper = new BindingHelper();
+    private FACompositeDisposable _subscriptionsOnOpen = new FACompositeDisposable();
+
+    private class BindingHelper : StyledElement
+    {
+        public static readonly StyledProperty<object> ValueProperty =
+            AvaloniaProperty.Register<BindingHelper, object>("Value");
+
+        public object Evaluate(IBinding binding, object dataContext)
+        {
+            dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
+
+            if (binding is null)
+            {
+                _lastBinding = null;
+                return dataContext;
+            }
+
+            if (!dataContext.Equals(DataContext))
+                DataContext = dataContext;
+
+            if (_lastBinding != binding)
+            {
+                _lastBinding = binding;
+                var ib = binding.Initiate(this, ValueProperty);
+                BindingOperations.Apply(this, ValueProperty, ib, null);
+            }
+
+            return GetValue(ValueProperty);
+        }
+
+        private IBinding _lastBinding;
+    }
+}

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
@@ -388,10 +390,10 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         }
     }
 
-    //protected override AutomationPeer OnCreateAutomationPeer()
-    //{
-    //    return new ComboBoxAutomationPeer(this)
-    //}
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new FAComboBoxAutomationPeer(this);
+    }
 
     internal void ItemFocused(FAComboBoxItem item)
     {

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -19,11 +19,6 @@ namespace FluentAvalonia.UI.Controls;
 
 public partial class FAComboBox : HeaderedSelectingItemsControl
 {
-    public FAComboBox()
-    {
-    }
-
-
     static FAComboBox()
     {
         FocusableProperty.OverrideDefaultValue<FAComboBox>(true);
@@ -53,18 +48,18 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
 
         base.OnApplyTemplate(e);
 
-        _popup = e.NameScope.Get<Popup>("Popup");
+        _popup = e.NameScope.Get<Popup>(s_tpPopup);
         _popup.Opened += OnPopupOpened;
         _popup.Closed += OnPopupClosed;
 
-        _textBox = e.NameScope.Find<TextBox>("EditableText");
+        _textBox = e.NameScope.Find<TextBox>(s_tpEditableText);
         if (_textBox != null)
         {
             _textBox.TextChanged += OnTextBoxTextChanged;
             _textBox.KeyDown += OnTextBoxKeyDown;
         }
 
-        _dropDownOverlay = e.NameScope.Find<Border>("DropDownOverlay");
+        _dropDownOverlay = e.NameScope.Find<Border>(s_tpDropDownOverlay);
         if (_dropDownOverlay != null)
         {
             // Pointerover can be handled in xaml automatically, so we only need to worry
@@ -118,7 +113,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         }
         else if (change.Property == IsEditableProperty)
         {
-            PseudoClasses.Set(":editable", change.GetNewValue<bool>());
+            PseudoClasses.Set(s_pcEditable, change.GetNewValue<bool>());
             UpdateSelectionBoxItem(SelectedItem ?? Text);
         }
         else if (change.Property == TextProperty)
@@ -275,7 +270,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
             if (_popup?.IsInsidePopup(src) == true)
                 return;
         }
-        PseudoClasses.Set(":pressed", true);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, true);
     }
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
@@ -303,7 +298,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
                 e.Handled = true;
             }
         }
-        PseudoClasses.Set(":pressed", false);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
         base.OnPointerReleased(e);
     }
 
@@ -323,7 +318,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
                 {
                     // If focus moves to the dropdown, keep the textbox style looking
                     // like its focused
-                    ((IPseudoClasses)_textBox.Classes).Set(":focus", true);
+                    ((IPseudoClasses)_textBox.Classes).Set(s_pcFocus, true);
                 }
             }
         }
@@ -401,7 +396,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
             var oldContainer = ContainerFromIndex(_dropDownSelectedIndex);
             if (oldContainer != null)
             {
-                ((IPseudoClasses)oldContainer.Classes).Set(":selected", false);
+                ((IPseudoClasses)oldContainer.Classes).Set(s_pcSelected, false);
             }
 
             var changeType = SelectionChangedTrigger;
@@ -412,7 +407,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
             else
             {
                 _dropDownSelectedIndex = IndexFromContainer(item);
-                ((IPseudoClasses)item.Classes).Set(":selected", true);
+                ((IPseudoClasses)item.Classes).Set(s_pcSelected, true);
                 UpdateSelectionBoxItem(ItemsView[_dropDownSelectedIndex]);
             }
         }
@@ -463,7 +458,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         UpdateFlowDirection();
 
         DropDownOpened?.Invoke(this, EventArgs.Empty);
-        PseudoClasses.Set(":dropdownopen", true);
+        PseudoClasses.Set(s_pcDropDownOpen, true);
 
         if (!IsEditable)
         {
@@ -544,7 +539,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
             _popup.HorizontalOffset = -1;
         }
 
-        PseudoClasses.Set(":popupAbove", isPopupAbove);
+        PseudoClasses.Set(s_pcPopupAbove, isPopupAbove);
     }
 
     private void OnPopupClosed(object sender, EventArgs e)
@@ -572,12 +567,12 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
             var container = ContainerFromIndex(_dropDownSelectedIndex);
             if (container != null)
             {
-                ((IPseudoClasses)container.Classes).Set(":selected", false);
+                ((IPseudoClasses)container.Classes).Set(s_pcSelected, false);
             }
         }
         _dropDownSelectedIndex = -1;
-        PseudoClasses.Set(":dropdownopen", false);
-        PseudoClasses.Set(":popupAbove", false);
+        PseudoClasses.Set(s_pcDropDownOpen, false);
+        PseudoClasses.Set(s_pcPopupAbove, false);
     }
 
     private void IsVisibleChanged(bool isVisible)
@@ -751,7 +746,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
     {
         if (e.GetCurrentPoint(_dropDownOverlay).Properties.IsLeftButtonPressed)
         {
-            ((IPseudoClasses)_dropDownOverlay.Classes).Set(":pressed", true);
+            ((IPseudoClasses)_dropDownOverlay.Classes).Set(SharedPseudoclasses.s_pcPressed, true);
             e.Handled = true;
         }
     }
@@ -760,7 +755,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
     {
         if (e.GetCurrentPoint(_dropDownOverlay).Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased)
         {
-            ((IPseudoClasses)_dropDownOverlay.Classes).Set(":pressed", false);
+            ((IPseudoClasses)_dropDownOverlay.Classes).Set(SharedPseudoclasses.s_pcPressed, false);
             IsDropDownOpen = !IsDropDownOpen;
             UpdateSelectionBoxItem(SelectedItem);
             e.Handled = true;
@@ -769,7 +764,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
 
     private void OnDropDownOverlayPointerCaptureLost(object sender, PointerCaptureLostEventArgs e)
     {
-        ((IPseudoClasses)_dropDownOverlay.Classes).Set(":pressed", false);
+        ((IPseudoClasses)_dropDownOverlay.Classes).Set(SharedPseudoclasses.s_pcPressed, false);
     }
 
     private string FormatValue(object item)

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -123,6 +123,10 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
                 OnTextChanged(change.GetNewValue<string>());
             }
         }
+        else if (change.Property == HeaderProperty)
+        {
+            PseudoClasses.Set(SharedPseudoclasses.s_pcHeader, change.NewValue is not null);
+        }
     }
 
     protected override Control CreateContainerForItemOverride() => new FAComboBoxItem();

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -214,7 +214,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
             {
                 if (!isEditable)
                 {
-                    SelectPrev();
+                    SelectPrevious();
                 }
                 else
                 {
@@ -249,7 +249,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
                     if (e.Delta.Y < 0)
                         SelectNext();
                     else
-                        SelectPrev();
+                        SelectPrevious();
 
                     e.Handled = true;
                 }
@@ -685,19 +685,39 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         }
     }
 
-    private void SelectNext()
-    {
-        if (ItemCount >= 1)
-        {
-            MoveSelection(NavigationDirection.Next, WrapSelection);
-        }
-    }
+    private void SelectNext() => MoveSelection(SelectedIndex, 1, WrapSelection);
+    private void SelectPrevious() => MoveSelection(SelectedIndex, -1, WrapSelection);
 
-    private void SelectPrev()
+    private void MoveSelection(int startIndex, int step, bool wrap)
     {
-        if (ItemCount >= 1)
+        static bool IsSelectable(object o) => (o as AvaloniaObject)?.GetValue(IsEnabledProperty) ?? true;
+
+        var count = ItemCount;
+        for (int i = startIndex + step; i != startIndex; i += step)
         {
-            MoveSelection(NavigationDirection.Previous, WrapSelection);
+            if (i < 0 || i >= count)
+            {
+                if (wrap)
+                {
+                    if (i < 0)
+                        i += count;
+                    else if (i >= count)
+                        i %= count;
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            var item = ItemsView[i];
+            var container = ContainerFromIndex(i);
+
+            if (IsSelectable(item) && IsSelectable(container))
+            {
+                SelectedIndex = i;
+                break;
+            }
         }
     }
 

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
@@ -19,7 +19,7 @@ namespace FluentAvalonia.UI.Controls;
 [TemplatePart(s_tpEditableText, typeof(TextBox))]
 [TemplatePart(s_tpDropDownOverlay, typeof(ComboBox))]
 [PseudoClasses(s_pcSelected, s_pcFocus, SharedPseudoclasses.s_pcPressed)]
-[PseudoClasses(s_pcEditable, s_pcDropDownOpen, s_pcPopupAbove)]
+[PseudoClasses(s_pcEditable, s_pcDropDownOpen, s_pcPopupAbove, SharedPseudoclasses.s_pcHeader)]
 public partial class FAComboBox : HeaderedSelectingItemsControl
 {
     /// <summary>

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
@@ -153,10 +153,7 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         get => GetValue(IsDropDownOpenProperty);
         set => SetValue(IsDropDownOpenProperty, value);
     }
-
-    // Per WPF:
-    // !comboBox.IsDropDownOpen && comboBox.IsKeyboardFocusWithin ||
-    // comboBox.HighlightedElement != null && highlightedElement.Content == comboBox._clonedElement
+        
     /// <summary>
     /// Gets whether the SelectionBox is hightlighted
     /// </summary>

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Layout;
@@ -10,77 +11,143 @@ using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
+/// <summary>
+/// Represents a selection control that combines a non-editable text box and a drop-down list box that 
+/// allows users to select an item from a list.
+/// </summary>
+[TemplatePart(s_tpPopup, typeof(Popup))]
+[TemplatePart(s_tpEditableText, typeof(TextBox))]
+[TemplatePart(s_tpDropDownOverlay, typeof(ComboBox))]
+[PseudoClasses(s_pcSelected, s_pcFocus, SharedPseudoclasses.s_pcPressed)]
+[PseudoClasses(s_pcEditable, s_pcDropDownOpen, s_pcPopupAbove)]
 public partial class FAComboBox : HeaderedSelectingItemsControl
 {
+    /// <summary>
+    /// Defines the <see cref="MaxDropDownHeight"/> property
+    /// </summary>
     public static StyledProperty<double> MaxDropDownHeightProperty =
         ComboBox.MaxDropDownHeightProperty.AddOwner<FAComboBox>();
 
+    /// <summary>
+    /// Defines the <see cref="IsEditable"/> property
+    /// </summary>
     public static StyledProperty<bool> IsEditableProperty =
         AvaloniaProperty.Register<FAComboBox, bool>(nameof(IsEditable));
 
+    /// <summary>
+    /// Defines the <see cref="IsDropDownOpen"/> property
+    /// </summary>
     public static StyledProperty<bool> IsDropDownOpenProperty =
         AvaloniaProperty.Register<FAComboBox, bool>(nameof(IsDropDownOpen));
 
+    /// <summary>
+    /// Defines the <see cref="IsSelectionBoxHighlighted"/> property
+    /// </summary>
     public static DirectProperty<FAComboBox, bool> IsSelectionBoxHighlightedProperty =
         AvaloniaProperty.RegisterDirect<FAComboBox, bool>(nameof(IsSelectionBoxHighlighted),
             x => x.IsSelectionBoxHighlighted);
 
+    /// <summary>
+    /// Defines the <see cref="SelectionBoxItem"/> property
+    /// </summary>
     public static DirectProperty<FAComboBox, object> SelectionBoxItemProperty =
         AvaloniaProperty.RegisterDirect<FAComboBox, object>(nameof(SelectionBoxItem),
             x => x.SelectionBoxItem);
 
+    /// <summary>
+    /// Defines the <see cref="SelectionBoxItemTemplate"/> property
+    /// </summary>
     public static DirectProperty<FAComboBox, IDataTemplate> SelectionBoxItemTemplateProperty =
         AvaloniaProperty.RegisterDirect<FAComboBox, IDataTemplate>(nameof(SelectionBoxItemTemplate),
             x => x.SelectionBoxItemTemplate);
 
+    /// <summary>
+    /// Defines the <see cref="PlaceholderText"/> property
+    /// </summary>
     public static StyledProperty<string> PlaceholderTextProperty =
         ComboBox.PlaceholderTextProperty.AddOwner<FAComboBox>();
 
+    /// <summary>
+    /// Defines the <see cref="HeaderTemplate"/> property
+    /// </summary>
     public static StyledProperty<IDataTemplate> HeaderTemplateProperty =
         HeaderedContentControl.HeaderTemplateProperty.AddOwner<FAComboBox>();
 
+    /// <summary>
+    /// Defines the <see cref="SelectionChangedTrigger"/> property
+    /// </summary>
     public static StyledProperty<FAComboBoxSelectionChangedTrigger> SelectionChangedTriggerProperty =
         AvaloniaProperty.Register<FAComboBox, FAComboBoxSelectionChangedTrigger>(nameof(SelectionChangedTrigger));
 
+    /// <summary>
+    /// Defines the <see cref="PlaceholderForeground"/> property
+    /// </summary>
     public static StyledProperty<IBrush> PlaceholderForegroundProperty =
         ComboBox.PlaceholderForegroundProperty.AddOwner<FAComboBox>();
 
+    /// <summary>
+    /// Defines the <see cref="TextBoxTheme"/> property
+    /// </summary>
     public static StyledProperty<ControlTheme> TextBoxThemeProperty =
         AvaloniaProperty.Register<FAComboBox, ControlTheme>(nameof(TextBoxTheme));
 
+    /// <summary>
+    /// Defines the <see cref="Text"/> property
+    /// </summary>
     public static StyledProperty<string> TextProperty =
         AvaloniaProperty.Register<FAComboBox, string>(nameof(Text));
 
+    /// <summary>
+    /// Defines the <see cref="HorizontalContentAlignment"/> property
+    /// </summary>
     public static StyledProperty<HorizontalAlignment> HorizontalContentAlignmentProperty =
         ContentControl.HorizontalContentAlignmentProperty.AddOwner<FAComboBox>();
 
+    /// <summary>
+    /// Defines the <see cref="VerticalContentAlignment"/> property
+    /// </summary>
     public static StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
         ContentControl.VerticalContentAlignmentProperty.AddOwner<FAComboBox>();
 
+    /// <summary>
+    /// Gets or sets the <see cref="HorizontalAlignment"/> of the content in the ComboBox
+    /// </summary>
     public HorizontalAlignment HorizontalContentAlignment
     {
         get => GetValue(HorizontalContentAlignmentProperty);
         set => SetValue(HorizontalContentAlignmentProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the <see cref="VerticalAlignment"/> of the content in the ComboBox
+    /// </summary>
     public VerticalAlignment VerticalContentAlignment
     {
         get => GetValue(VerticalContentAlignmentProperty);
         set => SetValue(VerticalContentAlignmentProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the maximum allowed height of the dropdown
+    /// </summary>
     public double MaxDropDownHeight
     {
         get => GetValue(MaxDropDownHeightProperty);
         set => SetValue(MaxDropDownHeightProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets whether this ComboBox is editable
+    /// </summary>
     public bool IsEditable
     {
         get => GetValue(IsEditableProperty);
         set => SetValue(IsEditableProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets whether this ComboBox's dropdown is open
+    /// </summary>
     public bool IsDropDownOpen
     {
         get => GetValue(IsDropDownOpenProperty);
@@ -90,66 +157,114 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
     // Per WPF:
     // !comboBox.IsDropDownOpen && comboBox.IsKeyboardFocusWithin ||
     // comboBox.HighlightedElement != null && highlightedElement.Content == comboBox._clonedElement
+    /// <summary>
+    /// Gets whether the SelectionBox is hightlighted
+    /// </summary>
     public bool IsSelectionBoxHighlighted
     {
         get => _isSelectionBoxHighlighted;
         private set => SetAndRaise(IsSelectionBoxHighlightedProperty, ref _isSelectionBoxHighlighted, value);
     }
 
+    /// <summary>
+    /// Gets the item shown whne the ComboBox is closed
+    /// </summary>
     public object SelectionBoxItem
     {
         get => _selectionBoxItem;
         private set => SetAndRaise(SelectionBoxItemProperty, ref _selectionBoxItem, value);
     }
 
+    /// <summary>
+    /// Gets the template applied to the selection box content.
+    /// </summary>
     public IDataTemplate SelectionBoxItemTemplate
     {
         get => _selectionBoxItemTemplate;
         private set => SetAndRaise(SelectionBoxItemTemplateProperty, ref _selectionBoxItemTemplate, value);
     }
 
+    /// <summary>
+    /// Gets or sets the text that is displayed in the control until the value is changed by a user action 
+    /// or some other operation.
+    /// </summary>
     public string PlaceholderText
     {
         get => GetValue(PlaceholderTextProperty);
         set => SetValue(PlaceholderTextProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the DataTemplate used to display the content of the control's header.
+    /// </summary>
     public IDataTemplate HeaderTemplate
     {
         get => GetValue(HeaderTemplateProperty);
         set => SetValue(HeaderTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value that indicates what action causes a SelectionChanged event to occur.
+    /// </summary>
     public FAComboBoxSelectionChangedTrigger SelectionChangedTrigger
     {
         get => GetValue(SelectionChangedTriggerProperty);
         set => SetValue(SelectionChangedTriggerProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a brush that describes the color of placeholder text.
+    /// </summary>
     public IBrush PlaceholderForeground
     {
         get => GetValue(PlaceholderForegroundProperty);
         set => SetValue(PlaceholderForegroundProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the <see cref="ControlTheme"/> used for the TextBox part of the ComboBox
+    /// </summary>
     public ControlTheme TextBoxTheme
     {
         get => GetValue(TextBoxThemeProperty);
         set => SetValue(TextBoxThemeProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the text in the ComboBox.
+    /// </summary>
     public string Text
     {
         get => GetValue(TextProperty);
         set => SetValue(TextProperty, value);
     }
 
-
+    /// <summary>
+    /// Occurs when the drop-down portion of the ComboBox opens.
+    /// </summary>
     public event EventHandler<EventArgs> DropDownOpened;
+
+    /// <summary>
+    /// Occurs when the drop-down portion of the ComboBox closes.
+    /// </summary>
     public event EventHandler<EventArgs> DropDownClosed;
+
+    /// <summary>
+    /// Occurs when the user submits some text that does not correspond to an item in the ComboBox dropdown list.
+    /// </summary>
     public event TypedEventHandler<FAComboBox, FAComboBoxTextSubmittedEventArgs> TextSubmitted;
 
     private bool _isSelectionBoxHighlighted;
     private object _selectionBoxItem;
     private IDataTemplate _selectionBoxItemTemplate;
+
+    private const string s_tpPopup = "Popup";
+    private const string s_tpEditableText = "EditableText";
+    private const string s_tpDropDownOverlay = "DropDownOverlay";
+
+    private const string s_pcEditable = ":editable";
+    private const string s_pcFocus = ":focus";
+    private const string s_pcSelected = ":selected";
+    private const string s_pcDropDownOpen = ":dropdownopen";
+    private const string s_pcPopupAbove = ":popupAbove";
 }

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Styling;
+using FluentAvalonia.Core;
+
+namespace FluentAvalonia.UI.Controls;
+
+public partial class FAComboBox : HeaderedSelectingItemsControl
+{
+    public static StyledProperty<double> MaxDropDownHeightProperty =
+        ComboBox.MaxDropDownHeightProperty.AddOwner<FAComboBox>();
+
+    public static StyledProperty<bool> IsEditableProperty =
+        AvaloniaProperty.Register<FAComboBox, bool>(nameof(IsEditable));
+
+    public static StyledProperty<bool> IsDropDownOpenProperty =
+        AvaloniaProperty.Register<FAComboBox, bool>(nameof(IsDropDownOpen));
+
+    public static DirectProperty<FAComboBox, bool> IsSelectionBoxHighlightedProperty =
+        AvaloniaProperty.RegisterDirect<FAComboBox, bool>(nameof(IsSelectionBoxHighlighted),
+            x => x.IsSelectionBoxHighlighted);
+
+    public static DirectProperty<FAComboBox, object> SelectionBoxItemProperty =
+        AvaloniaProperty.RegisterDirect<FAComboBox, object>(nameof(SelectionBoxItem),
+            x => x.SelectionBoxItem);
+
+    public static DirectProperty<FAComboBox, IDataTemplate> SelectionBoxItemTemplateProperty =
+        AvaloniaProperty.RegisterDirect<FAComboBox, IDataTemplate>(nameof(SelectionBoxItemTemplate),
+            x => x.SelectionBoxItemTemplate);
+
+    public static StyledProperty<string> PlaceholderTextProperty =
+        ComboBox.PlaceholderTextProperty.AddOwner<FAComboBox>();
+
+    public static StyledProperty<IDataTemplate> HeaderTemplateProperty =
+        HeaderedContentControl.HeaderTemplateProperty.AddOwner<FAComboBox>();
+
+    public static StyledProperty<FAComboBoxSelectionChangedTrigger> SelectionChangedTriggerProperty =
+        AvaloniaProperty.Register<FAComboBox, FAComboBoxSelectionChangedTrigger>(nameof(SelectionChangedTrigger));
+
+    public static StyledProperty<IBrush> PlaceholderForegroundProperty =
+        ComboBox.PlaceholderForegroundProperty.AddOwner<FAComboBox>();
+
+    public static StyledProperty<ControlTheme> TextBoxThemeProperty =
+        AvaloniaProperty.Register<FAComboBox, ControlTheme>(nameof(TextBoxTheme));
+
+    public static StyledProperty<string> TextProperty =
+        AvaloniaProperty.Register<FAComboBox, string>(nameof(Text));
+
+    public static StyledProperty<HorizontalAlignment> HorizontalContentAlignmentProperty =
+        ContentControl.HorizontalContentAlignmentProperty.AddOwner<FAComboBox>();
+
+    public static StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
+        ContentControl.VerticalContentAlignmentProperty.AddOwner<FAComboBox>();
+
+    public HorizontalAlignment HorizontalContentAlignment
+    {
+        get => GetValue(HorizontalContentAlignmentProperty);
+        set => SetValue(HorizontalContentAlignmentProperty, value);
+    }
+
+    public VerticalAlignment VerticalContentAlignment
+    {
+        get => GetValue(VerticalContentAlignmentProperty);
+        set => SetValue(VerticalContentAlignmentProperty, value);
+    }
+
+    public double MaxDropDownHeight
+    {
+        get => GetValue(MaxDropDownHeightProperty);
+        set => SetValue(MaxDropDownHeightProperty, value);
+    }
+
+    public bool IsEditable
+    {
+        get => GetValue(IsEditableProperty);
+        set => SetValue(IsEditableProperty, value);
+    }
+
+    public bool IsDropDownOpen
+    {
+        get => GetValue(IsDropDownOpenProperty);
+        set => SetValue(IsDropDownOpenProperty, value);
+    }
+
+    // Per WPF:
+    // !comboBox.IsDropDownOpen && comboBox.IsKeyboardFocusWithin ||
+    // comboBox.HighlightedElement != null && highlightedElement.Content == comboBox._clonedElement
+    public bool IsSelectionBoxHighlighted
+    {
+        get => _isSelectionBoxHighlighted;
+        private set => SetAndRaise(IsSelectionBoxHighlightedProperty, ref _isSelectionBoxHighlighted, value);
+    }
+
+    public object SelectionBoxItem
+    {
+        get => _selectionBoxItem;
+        private set => SetAndRaise(SelectionBoxItemProperty, ref _selectionBoxItem, value);
+    }
+
+    public IDataTemplate SelectionBoxItemTemplate
+    {
+        get => _selectionBoxItemTemplate;
+        private set => SetAndRaise(SelectionBoxItemTemplateProperty, ref _selectionBoxItemTemplate, value);
+    }
+
+    public string PlaceholderText
+    {
+        get => GetValue(PlaceholderTextProperty);
+        set => SetValue(PlaceholderTextProperty, value);
+    }
+
+    public IDataTemplate HeaderTemplate
+    {
+        get => GetValue(HeaderTemplateProperty);
+        set => SetValue(HeaderTemplateProperty, value);
+    }
+
+    public FAComboBoxSelectionChangedTrigger SelectionChangedTrigger
+    {
+        get => GetValue(SelectionChangedTriggerProperty);
+        set => SetValue(SelectionChangedTriggerProperty, value);
+    }
+
+    public IBrush PlaceholderForeground
+    {
+        get => GetValue(PlaceholderForegroundProperty);
+        set => SetValue(PlaceholderForegroundProperty, value);
+    }
+
+    public ControlTheme TextBoxTheme
+    {
+        get => GetValue(TextBoxThemeProperty);
+        set => SetValue(TextBoxThemeProperty, value);
+    }
+
+    public string Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+
+    public event EventHandler<EventArgs> DropDownOpened;
+    public event EventHandler<EventArgs> DropDownClosed;
+    public event TypedEventHandler<FAComboBox, FAComboBoxTextSubmittedEventArgs> TextSubmitted;
+
+    private bool _isSelectionBoxHighlighted;
+    private object _selectionBoxItem;
+    private IDataTemplate _selectionBoxItemTemplate;
+}

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxAutomationPeer.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxAutomationPeer.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+
+namespace FluentAvalonia.UI.Controls;
+
+public class FAComboBoxAutomationPeer : SelectingItemsControlAutomationPeer,
+    IExpandCollapseProvider, IValueProvider
+{
+    public FAComboBoxAutomationPeer(SelectingItemsControl owner) 
+        : base(owner)
+    {
+
+    }
+
+    public new FAComboBox Owner => (FAComboBox)base.Owner;
+
+    public ExpandCollapseState ExpandCollapseState => ToState(Owner.IsDropDownOpen);
+
+    public bool ShowsMenu => true;
+
+    bool IValueProvider.IsReadOnly => true;
+
+    string IValueProvider.Value
+    {
+        get
+        {
+            var selection = GetSelection();
+            return selection.Count == 1 ? selection[0].GetName() : null;
+        }
+    }
+
+    public void Collapse() => Owner.IsDropDownOpen = false;
+
+    public void Expand() => Owner.IsDropDownOpen = true;
+
+    public void SetValue(string value) => throw new NotSupportedException();
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.ComboBox;
+
+    protected override IReadOnlyList<AutomationPeer> GetSelectionCore()
+    {
+        if (ExpandCollapseState == ExpandCollapseState.Expanded)
+            return base.GetSelectionCore();
+
+        // If the combo box is not open then we won't have an ItemsPresenter so the default
+        // GetSelectionCore implementation won't work. For this case we create a separate
+        // peer to represent the unrealized item.
+        if (Owner.SelectedItem is object selection)
+        {
+            _selection ??= new[] { new UnrealizedSelectionPeer(this) };
+            _selection[0].Item = selection;
+            return _selection;
+        }
+
+        return null;
+    }
+
+    protected override void OwnerPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        base.OwnerPropertyChanged(sender, e);
+
+        if (e.Property == FAComboBox.IsDropDownOpenProperty)
+        {
+            RaisePropertyChangedEvent(ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty,
+                ToState((bool)e.OldValue!),
+                ToState((bool)e.NewValue!));
+        }
+    }
+
+    private static ExpandCollapseState ToState(bool value)
+    {
+        return value ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
+    }
+
+    private UnrealizedSelectionPeer[] _selection;
+
+    private class UnrealizedSelectionPeer : UnrealizedElementAutomationPeer
+    {
+        public UnrealizedSelectionPeer(FAComboBoxAutomationPeer owner)
+        {
+            _owner = owner;
+        }
+
+        public object Item
+        {
+            get => _item;
+            set
+            {
+                if (_item != value)
+                {
+                    var oldValue = GetNameCore();
+                    _item = value;
+                    RaisePropertyChangedEvent(
+                        AutomationElementIdentifiers.NameProperty,
+                        oldValue,
+                        GetNameCore());
+                }
+            }
+        }
+
+        protected override string GetAcceleratorKeyCore() => null;
+        protected override string GetAccessKeyCore() => null;
+        protected override string GetAutomationIdCore() => null;
+        protected override string GetClassNameCore() => typeof(FAComboBoxItem).Name;
+        protected override AutomationPeer GetLabeledByCore() => null;
+        protected override AutomationPeer GetParentCore() => _owner;
+        protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.ListItem;
+
+        protected override string GetNameCore()
+        {
+            if (_item is Control c)
+            {
+                var result = AutomationProperties.GetName(c);
+
+                if (result is null && c is ContentControl cc && cc.Presenter?.Child is TextBlock text)
+                {
+                    result = text.Text;
+                }
+
+                if (result is null)
+                {
+                    result = c.GetValue(ContentControl.ContentProperty)?.ToString();
+                }
+
+                return result;
+            }
+
+            return _item?.ToString();
+        }
+
+        private readonly FAComboBoxAutomationPeer _owner;
+        private object _item;
+    }
+}

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxItem.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxItem.cs
@@ -4,7 +4,9 @@ using Avalonia.VisualTree;
 
 namespace FluentAvalonia.UI.Controls;
 
-
+/// <summary>
+/// Represents the container for an item in a <see cref="FAComboBox"/> control.
+/// </summary>
 public class FAComboBoxItem : ListBoxItem
 {
     static FAComboBoxItem()

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxItem.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxItem.cs
@@ -1,0 +1,28 @@
+﻿using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+
+namespace FluentAvalonia.UI.Controls;
+
+
+public class FAComboBoxItem : ListBoxItem
+{
+    static FAComboBoxItem()
+    {
+        FocusableProperty.OverrideDefaultValue<FAComboBoxItem>(true);
+    }
+
+    protected override void OnGotFocus(GotFocusEventArgs e)
+    {
+        base.OnGotFocus(e);
+        if (e.NavigationMethod == NavigationMethod.Directional || e.NavigationMethod == NavigationMethod.Tab)
+        {
+            var parent = (Parent as FAComboBox) ?? this.FindAncestorOfType<FAComboBox>();
+            if (parent != null)
+            {
+                parent.ItemFocused(this);
+            }
+        }
+
+    }
+}

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxSelectionChangedTrigger.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxSelectionChangedTrigger.cs
@@ -1,0 +1,14 @@
+﻿namespace FluentAvalonia.UI.Controls;
+
+public enum FAComboBoxSelectionChangedTrigger
+{
+    /// <summary>
+    /// A change event occurs when the user commits a selection in the ComboBox
+    /// </summary>
+    Committed,
+
+    /// <summary>
+    /// A change event occurs each time the user navigates to a new selection in the ComboBox
+    /// </summary>
+    Always
+}

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxSelectionChangedTrigger.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxSelectionChangedTrigger.cs
@@ -1,5 +1,8 @@
 ﻿namespace FluentAvalonia.UI.Controls;
 
+/// <summary>
+/// Defines constants that specify what action causes a SelectionChanged event to occur.
+/// </summary>
 public enum FAComboBoxSelectionChangedTrigger
 {
     /// <summary>

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxTextSubmittedEventArgs.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxTextSubmittedEventArgs.cs
@@ -2,6 +2,9 @@
 
 namespace FluentAvalonia.UI.Controls;
 
+/// <summary>
+/// Provides data when the user enters custom text into the ComboBox.
+/// </summary>
 public class FAComboBoxTextSubmittedEventArgs : EventArgs
 {
     internal FAComboBoxTextSubmittedEventArgs(string text)

--- a/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxTextSubmittedEventArgs.cs
+++ b/FluentAvalonia/UI/Controls/FAComboBox/FAComboBoxTextSubmittedEventArgs.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace FluentAvalonia.UI.Controls;
+
+public class FAComboBoxTextSubmittedEventArgs : EventArgs
+{
+    internal FAComboBoxTextSubmittedEventArgs(string text)
+    {
+        Text = text;
+    }
+
+    /// <summary>
+    /// Gets or sets whether the TextSubmitted event was handled or not. If **true**,
+    /// the framework will not automatically update the selected item of the ComboBox
+    /// to the new value.
+    /// </summary>
+    /// <remarks>
+    /// You should handle this event if binding to SelectedItem and entered text is not
+    /// translatable to your view model. Otherwise, the selection will be cleared
+    /// </remarks>
+    public bool Handled { get; set; }
+
+    /// <summary>
+    /// Gets the custom text value entered by the user
+    /// </summary>
+    public string Text { get; }
+}


### PR DESCRIPTION
It's back & better than ever (well, I hope). The FAComboBox is back and has been overhauled from the original attempt that's in the stable 1.x branch. The main thing this control aims is to add the `IsEditable` property and support, which has also been improved from the old version. As is typical for my controls, this API & functionality is based on the UWP/WinUI version rather than WPF.

For IsEditable=True, text search works either on the `DisplayMemberBinding` or `.ToString()` if the ComboBox is populated with viewmodels, `Content.ToString()` if its raw `FAComboBoxItem`s. The `IsTextSearchEnabled` property will control whether autocomplete is enabled. Note that if not editable, IsTextSearchEnabled will fallback to the default implementation in `SelectingItemsControl`, which only works on `.ToString()`.

The popup is centered on the SelectedItem when opened if the ComboBox is not editable (with SlideY constraint adjustment), and the displayed above or below with the proper CornerRadius adjustments if it is editable (with FlipY constraint adjustment (so its always either above or below the ComboBox). Technically I'd like to also apply ResizeY, but there appears to be a bug where that produces something like ResizeX (probably a typo in the popup code upstream).

![image](https://user-images.githubusercontent.com/40413319/217712670-79a52b9e-6d4e-4dfc-9143-8298a9e8bac8.png)

Known bugs/things to be aware of:
- FAComboBox has the same bug as normal ComboBox where the keyboard won't cycle through the items if its unopened.
- Occasionally, keyboard focus/navigation in the dropdown will go to the wrong item. I can't reliably repro this so I can't fix this yet
- Text search with IsEditable=True will likely not filter disabled items as it uses the items source, rather than materialized containers (which is what SelectingItemsControl uses for text search). This opens a big can of worms as that requires materializing items to do the search (especially if the items are view models), and right now I don't think that's worth it. (Also haven't checked what UWP does in this scenario, or even WPF)


...And yes, the title is a Star Wars pun
