### PR TITLE
Fix Frame animation flickering

### DIFF
--- a/FluentAvalonia/UI/Media/DrillInNavigationTransitionInfo.cs
+++ b/FluentAvalonia/UI/Media/DrillInNavigationTransitionInfo.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using System;
+using System.Threading;
 
 namespace FluentAvalonia.UI.Media.Animation;
 
@@ -20,7 +21,7 @@ public class DrillInNavigationTransitionInfo : NavigationTransitionInfo
     public bool IsReversed { get; set; } = false; //Zoom out if true
 
     //Zoom & Fade
-    public async override void RunAnimation(Animatable ctrl)
+    public async override void RunAnimation(Animatable ctrl, CancellationToken cancellationToken)
     {
         var animation = new Avalonia.Animation.Animation
         {
@@ -52,7 +53,7 @@ public class DrillInNavigationTransitionInfo : NavigationTransitionInfo
             FillMode = FillMode.Forward
         };
 
-        await animation.RunAsync(ctrl, null);
+        await animation.RunAsync(ctrl, null, cancellationToken);
 
         (ctrl as Visual).Opacity = 1;
     }

--- a/FluentAvalonia/UI/Media/EntranceNavigationTransitionInfo.cs
+++ b/FluentAvalonia/UI/Media/EntranceNavigationTransitionInfo.cs
@@ -3,7 +3,6 @@ using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Media;
 using Avalonia.Styling;
-using Avalonia.VisualTree;
 using System;
 using System.Threading;
 
@@ -22,7 +21,7 @@ public class EntranceNavigationTransitionInfo : NavigationTransitionInfo
     /// <summary>
     /// Gets or sets the Vertical Offset used when animating
     /// </summary>
-    public double FromVerticalOffset { get; set; } = 28;
+    public double FromVerticalOffset { get; set; } = 100;
 
     //SlideUp and FadeIn
     public async override void RunAnimation(Animatable ctrl, CancellationToken cancellationToken)
@@ -53,7 +52,7 @@ public class EntranceNavigationTransitionInfo : NavigationTransitionInfo
                     Cue = new Cue(1d)
                 }
             },
-            Duration = TimeSpan.FromSeconds(0.67),
+            Duration = TimeSpan.FromSeconds(0.5),
             FillMode = FillMode.Forward
         };
 

--- a/FluentAvalonia/UI/Media/EntranceNavigationTransitionInfo.cs
+++ b/FluentAvalonia/UI/Media/EntranceNavigationTransitionInfo.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using System;
+using System.Threading;
 
 namespace FluentAvalonia.UI.Media.Animation;
 
@@ -24,7 +25,7 @@ public class EntranceNavigationTransitionInfo : NavigationTransitionInfo
     public double FromVerticalOffset { get; set; } = 28;
 
     //SlideUp and FadeIn
-    public async override void RunAnimation(Animatable ctrl)
+    public async override void RunAnimation(Animatable ctrl, CancellationToken cancellationToken)
     {
         var animation = new Avalonia.Animation.Animation
         {
@@ -56,7 +57,7 @@ public class EntranceNavigationTransitionInfo : NavigationTransitionInfo
             FillMode = FillMode.Forward
         };
 
-        await animation.RunAsync(ctrl, null);
+        await animation.RunAsync(ctrl, null, cancellationToken);
 
         (ctrl as Visual).Opacity = 1;
     }

--- a/FluentAvalonia/UI/Media/NavigationTransitionInfo.cs
+++ b/FluentAvalonia/UI/Media/NavigationTransitionInfo.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System.Threading;
+using Avalonia;
 using Avalonia.Animation;
 
 namespace FluentAvalonia.UI.Media.Animation;
@@ -15,5 +16,5 @@ public abstract class NavigationTransitionInfo : AvaloniaObject
     /// Executes a predefined animation on the desired object
     /// </summary>
     /// <param name="ctrl">The object to animate</param>
-    public abstract void RunAnimation(Animatable ctrl);
+    public abstract void RunAnimation(Animatable ctrl, CancellationToken cancellationToken);
 }

--- a/FluentAvalonia/UI/Media/SlideNavigationTransitionInfo.cs
+++ b/FluentAvalonia/UI/Media/SlideNavigationTransitionInfo.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using System;
+using System.Threading;
 
 namespace FluentAvalonia.UI.Media.Animation;
 
@@ -28,7 +29,7 @@ public class SlideNavigationTransitionInfo : NavigationTransitionInfo
     /// </summary>
     public double FromVerticalOffset { get; set; } = 56;
 
-    public async override void RunAnimation(Animatable ctrl)
+    public async override void RunAnimation(Animatable ctrl, CancellationToken cancellationToken)
     {
         double length = 0;
         bool isVertical = false;
@@ -86,7 +87,7 @@ public class SlideNavigationTransitionInfo : NavigationTransitionInfo
             FillMode = FillMode.Forward
         };
 
-        await animation.RunAsync(ctrl, null);
+        await animation.RunAsync(ctrl, null, cancellationToken);
 
         (ctrl as Visual).Opacity = 1;
     }

--- a/FluentAvalonia/UI/Media/SuppressNavigationTransitionInfo.cs
+++ b/FluentAvalonia/UI/Media/SuppressNavigationTransitionInfo.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System.Threading;
+using Avalonia;
 using Avalonia.Animation;
 using Avalonia.VisualTree;
 
@@ -9,7 +10,7 @@ namespace FluentAvalonia.UI.Media.Animation;
 /// </summary>
 public class SuppressNavigationTransitionInfo : NavigationTransitionInfo
 {
-    public override void RunAnimation(Animatable ctrl)
+    public override void RunAnimation(Animatable ctrl, CancellationToken cancellationToken)
     {
         //Do nothing
         (ctrl as Visual).Opacity = 1;


### PR DESCRIPTION
Fixes an issue where navigating too quickly using a Frame causes the page animation to "flicker" or "stutter". This is happening because the animation was queued but never cancelled if another animation happens before that page finishes loading.

Added a `CancellationToken` to `Frame` and all the NavigationTransitionInfo classes `RunAnimation` method that allows the animation to be cancelled if a new navigation is requested

Fixes #293