### PR TITLE
Turn dialog animations back on

### DIFF
--- a/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
@@ -140,7 +140,7 @@
         </Setter>
 
         <!--Handle hidden dialog-->
-        <!--<Style Selector="^:hidden /template/ Panel#LayoutRoot">
+        <Style Selector="^:hidden /template/ Panel#LayoutRoot">
             <Style.Animations>
                 <Animation Duration="00:00:00.167" FillMode="Forward">
                     <KeyFrame Cue="0%">
@@ -168,13 +168,13 @@
             </Style.Animations>
         </Style>
 
-        --><!--Handle open dialog--><!--
+        <!--Handle open dialog-->
         <Style Selector="^:open /template/ Panel#LayoutRoot">
             <Setter Property="IsVisible" Value="True"/>
             <Style.Animations>
-                --><!-- Animation applies with priority of LocalValue
+                 <!--Animation applies with priority of LocalValue
                  To overrule the IsVisible=False in :hidden, set
-                 IsVisible=True in BOTH KeyFrames here --><!--
+                 IsVisible=True in BOTH KeyFrames here--> 
                 <Animation Duration="00:00:00.250" FillMode="Forward">
                     <KeyFrame Cue="0%">
                         <Setter Property="IsVisible" Value="True"/>
@@ -200,7 +200,7 @@
                     </KeyFrame>
                 </Animation>
             </Style.Animations>
-        </Style>-->
+        </Style>
 
         <!--Handle showing smoke layer-->
         <Style Selector="^:nosmokelayer /template/ Panel#LayoutRoot">

--- a/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
+++ b/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
@@ -269,7 +269,7 @@
             </Style>
 
 
-            <!--<Style Selector="^:hidden /template/ Panel#LayoutRoot">
+            <Style Selector="^:hidden /template/ Panel#LayoutRoot">
                 <Style.Animations>
                     <Animation Duration="00:00:00.167" FillMode="Forward">
                         <KeyFrame Cue="0%">
@@ -297,13 +297,13 @@
                 </Style.Animations>
             </Style>
 
-            --><!--Handle open dialog--><!--
+            <!--Handle open dialog-->
             <Style Selector="^:open /template/ Panel#LayoutRoot">
                 <Setter Property="IsVisible" Value="True"/>
                 <Style.Animations>
-                    --><!-- Animation applies with priority of LocalValue
-                 To overrule the IsVisible=False in :hidden, set
-                 IsVisible=True in BOTH KeyFrames here --><!--
+                     <!--Animation applies with priority of LocalValue
+                         To overrule the IsVisible=False in :hidden, set
+                         IsVisible=True in BOTH KeyFrames here--> 
                     <Animation Duration="00:00:00.250" FillMode="Forward">
                         <KeyFrame Cue="0%">
                             <Setter Property="IsVisible" Value="True"/>
@@ -329,7 +329,7 @@
                         </KeyFrame>
                     </Animation>
                 </Style.Animations>
-            </Style>-->
+            </Style>
             
         </Style>
         


### PR DESCRIPTION
PR turns the open and close animations for `TaskDialog` and `ContentDialog` back on. I can't repro the original animation issues when the composition renderer was first implemented so I think they've been fixed, though not sure where/how.