### PR TITLE
Update to `AppWindow`

### DIFF
--- a/FluentAvalonia.sln
+++ b/FluentAvalonia.sln
@@ -11,8 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
-		LICENSE = LICENSE
 		Directory.Packages.props = Directory.Packages.props
+		LICENSE = LICENSE
 		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
@@ -20,8 +20,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentAvaloniaTests", "tests\FluentAvaloniaTests\FluentAvaloniaTests.csproj", "{8AE77DED-A81D-43DC-B4A2-AE03ED1C20F9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FASandbox", "samples\FASandbox\FASandbox.csproj", "{3CD8ED83-02E7-4949-9C48-531E142A2695}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentAvalonia.UI.Windowing", "src\FluentAvalonia.UI.Windowing\FluentAvalonia.UI.Windowing.csproj", "{4DEE35BC-DD05-4939-BC52-790F2D80C8F1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{7E9416E1-C672-4622-8D32-91A16802873A}"
 EndProject
@@ -49,10 +47,6 @@ Global
 		{3CD8ED83-02E7-4949-9C48-531E142A2695}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3CD8ED83-02E7-4949-9C48-531E142A2695}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3CD8ED83-02E7-4949-9C48-531E142A2695}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4DEE35BC-DD05-4939-BC52-790F2D80C8F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4DEE35BC-DD05-4939-BC52-790F2D80C8F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4DEE35BC-DD05-4939-BC52-790F2D80C8F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4DEE35BC-DD05-4939-BC52-790F2D80C8F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/FASandbox/FASandbox.csproj
+++ b/samples/FASandbox/FASandbox.csproj
@@ -13,7 +13,6 @@
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
    </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\FluentAvalonia.UI.Windowing\FluentAvalonia.UI.Windowing.csproj" />
     <ProjectReference Include="..\..\src\FluentAvalonia\FluentAvalonia.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/FluentAvaloniaSamples/App.axaml
+++ b/samples/FluentAvaloniaSamples/App.axaml
@@ -37,7 +37,6 @@
 
     <Application.Styles>
         <sty:FluentAvaloniaTheme PreferUserAccentColor="True" PreferSystemTheme="True" />
-        <StyleInclude Source="avares://FluentAvalonia.UI.Windowing/Styles/FAWindowingStyles.axaml" />
         <!--<StyleInclude Source="avares://AvaloniaEdit/AvaloniaEdit.xaml" />-->
         <StyleInclude Source="/Styles/OptionsDisplayItemStyles.axaml" />
         <StyleInclude Source="/Styles/ControlExampleStyles.axaml" />

--- a/samples/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/samples/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Avalonia.Diagnostics" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\FluentAvalonia.UI.Windowing\FluentAvalonia.UI.Windowing.csproj" />
     <ProjectReference Include="..\..\src\FluentAvalonia\FluentAvalonia.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/samples/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="Avalonia.Diagnostics" />
+    <PackageReference Include="Avalonia.Diagnostics" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FluentAvalonia\FluentAvalonia.csproj" />

--- a/samples/FluentAvaloniaSamples/Program.cs
+++ b/samples/FluentAvaloniaSamples/Program.cs
@@ -20,6 +20,5 @@ class Program
             {
                 UseWindowsUIComposition = true,
                 CompositionBackdropCornerRadius = 8f
-            })
-            .UseFAWindowing();
+            });
 }

--- a/src/FluentAvalonia/FluentAvalonia.csproj
+++ b/src/FluentAvalonia/FluentAvalonia.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 	<RepositoryUrl>https://github.com/amwx/FluentAvalonia</RepositoryUrl>
 	<PackageId>FluentAvaloniaUI</PackageId>
@@ -39,9 +40,6 @@
         <AvaloniaResource Include="Assets\*.*" />
 	    <AvaloniaResource Include="Fonts\*.*" />
     </ItemGroup>
-    <ItemGroup>
-      <None Remove="Assets\ControlStrings.json" />
-    </ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Avalonia" />
@@ -52,13 +50,9 @@
         <PackageReference Include="Avalonia.Controls.DataGrid" />
 		<PackageReference Include="MicroCom.CodeGenerator.MSBuild" />
 		<PackageReference Include="MicroCom.Runtime" />
-        <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />
+        <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />        
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
 	</ItemGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="FluentAvalonia.UI.Windowing" />
-  </ItemGroup>
 </Project>

--- a/src/FluentAvalonia/Interop/Helpers/BOOL.cs
+++ b/src/FluentAvalonia/Interop/Helpers/BOOL.cs
@@ -1,0 +1,99 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly struct BOOL : IComparable, IComparable<BOOL>, IEquatable<BOOL>, IFormattable
+{
+    public BOOL(int value)
+    {
+        Value = value;
+    }
+
+    public readonly int Value;
+
+    public static BOOL FALSE => new BOOL(0);
+
+    public static BOOL TRUE => new BOOL(1);
+
+    public static bool operator ==(BOOL left, BOOL right) => left.Value == right.Value;
+
+    public static bool operator !=(BOOL left, BOOL right) => left.Value != right.Value;
+
+    public static bool operator <(BOOL left, BOOL right) => left.Value < right.Value;
+
+    public static bool operator <=(BOOL left, BOOL right) => left.Value <= right.Value;
+
+    public static bool operator >(BOOL left, BOOL right) => left.Value > right.Value;
+
+    public static bool operator >=(BOOL left, BOOL right) => left.Value >= right.Value;
+
+    public static implicit operator bool(BOOL value) => value.Value != 0;
+
+    public static implicit operator BOOL(bool value) => new BOOL(value ? 1 : 0);
+
+    public static bool operator false(BOOL value) => value.Value == 0;
+
+    public static bool operator true(BOOL value) => value.Value != 0;
+
+    public static implicit operator BOOL(byte value) => new BOOL(value);
+
+    public static explicit operator byte(BOOL value) => (byte)(value.Value);
+
+    public static implicit operator BOOL(short value) => new BOOL(value);
+
+    public static explicit operator short(BOOL value) => (short)(value.Value);
+
+    public static implicit operator BOOL(int value) => new BOOL(value);
+
+    public static implicit operator int(BOOL value) => value.Value;
+
+    public static explicit operator BOOL(long value) => new BOOL((int)(value));
+
+    public static implicit operator long(BOOL value) => value.Value;
+
+    public static explicit operator BOOL(nint value) => new BOOL((int)(value));
+
+    public static implicit operator nint(BOOL value) => value.Value;
+
+    public static implicit operator BOOL(sbyte value) => new BOOL(value);
+
+    public static explicit operator sbyte(BOOL value) => (sbyte)(value.Value);
+
+    public static implicit operator BOOL(ushort value) => new BOOL(value);
+
+    public static explicit operator ushort(BOOL value) => (ushort)(value.Value);
+
+    public static explicit operator BOOL(uint value) => new BOOL((int)(value));
+
+    public static explicit operator uint(BOOL value) => (uint)(value.Value);
+
+    public static explicit operator BOOL(ulong value) => new BOOL((int)(value));
+
+    public static explicit operator ulong(BOOL value) => (ulong)(value.Value);
+
+    public static explicit operator BOOL(nuint value) => new BOOL((int)(value));
+
+    public static explicit operator nuint(BOOL value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is BOOL other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of BOOL.");
+    }
+
+    public int CompareTo(BOOL other) => Value.CompareTo(other.Value);
+
+    public override bool Equals(object obj) => (obj is BOOL other) && Equals(other);
+
+    public bool Equals(BOOL other) => Value.Equals(other.Value);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public override string ToString() => Value.ToString();
+
+    public string ToString(string format, IFormatProvider formatProvider) => Value.ToString(format, formatProvider);
+}

--- a/src/FluentAvalonia/Interop/Helpers/COLORREF.cs
+++ b/src/FluentAvalonia/Interop/Helpers/COLORREF.cs
@@ -1,0 +1,95 @@
+﻿namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct COLORREF : IComparable, IComparable<COLORREF>, IEquatable<COLORREF>, IFormattable
+{
+	public readonly uint Value;
+
+	public COLORREF(uint value)
+	{
+		Value = value;
+	}
+
+	public static bool operator ==(COLORREF left, COLORREF right) => left.Value == right.Value;
+
+	public static bool operator !=(COLORREF left, COLORREF right) => left.Value != right.Value;
+
+	public static bool operator <(COLORREF left, COLORREF right) => left.Value < right.Value;
+
+	public static bool operator <=(COLORREF left, COLORREF right) => left.Value <= right.Value;
+
+	public static bool operator >(COLORREF left, COLORREF right) => left.Value > right.Value;
+
+	public static bool operator >=(COLORREF left, COLORREF right) => left.Value >= right.Value;
+
+	public static implicit operator COLORREF(byte value) => new COLORREF(value);
+
+	public static explicit operator byte(COLORREF value) => (byte)(value.Value);
+
+	public static explicit operator COLORREF(short value) => new COLORREF((uint)(value));
+
+	public static explicit operator short(COLORREF value) => (short)(value.Value);
+
+	public static explicit operator COLORREF(int value) => new COLORREF((uint)(value));
+
+	public static explicit operator int(COLORREF value) => (int)(value.Value);
+
+	public static explicit operator COLORREF(long value) => new COLORREF((uint)(value));
+
+	public static implicit operator long(COLORREF value) => value.Value;
+
+	public static explicit operator COLORREF(nint value) => new COLORREF((uint)(value));
+
+	public static explicit operator nint(COLORREF value) => (nint)(value.Value);
+
+	public static explicit operator COLORREF(sbyte value) => new COLORREF((uint)(value));
+
+	public static explicit operator sbyte(COLORREF value) => (sbyte)(value.Value);
+
+	public static implicit operator COLORREF(ushort value) => new COLORREF(value);
+
+	public static explicit operator ushort(COLORREF value) => (ushort)(value.Value);
+
+	public static implicit operator COLORREF(uint value) => new COLORREF(value);
+
+	public static implicit operator uint(COLORREF value) => value.Value;
+
+	public static explicit operator COLORREF(ulong value) => new COLORREF((uint)(value));
+
+	public static implicit operator ulong(COLORREF value) => value.Value;
+
+	public static explicit operator COLORREF(nuint value) => new COLORREF((uint)(value));
+
+	public static implicit operator nuint(COLORREF value) => value.Value;
+
+	public int CompareTo(object obj)
+	{
+		if (obj is COLORREF other)
+		{
+			return CompareTo(other);
+		}
+
+		return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of COLORREF.");
+	}
+
+	public int CompareTo(COLORREF other) => Value.CompareTo(other.Value);
+
+	public override bool Equals(object obj) => (obj is COLORREF other) && Equals(other);
+
+	public bool Equals(COLORREF other) => Value.Equals(other.Value);
+
+	public override int GetHashCode() => Value.GetHashCode();
+
+	public override string ToString() => Value.ToString("X8");
+
+	public string ToString(string format, IFormatProvider formatProvider) => Value.ToString(format, formatProvider);
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/FluentAvalonia/Interop/Helpers/DWMWINDOWATTRIBUTE.cs
+++ b/src/FluentAvalonia/Interop/Helpers/DWMWINDOWATTRIBUTE.cs
@@ -1,4 +1,4 @@
-﻿namespace FluentAvalonia.Interop;
+﻿namespace FluentAvalonia.Interop.Win32;
 
 internal enum DWMWINDOWATTRIBUTE
 {

--- a/src/FluentAvalonia/Interop/Helpers/HBITMAP.cs
+++ b/src/FluentAvalonia/Interop/Helpers/HBITMAP.cs
@@ -1,0 +1,99 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct HBITMAP : IComparable, IEquatable<HBITMAP>
+{
+    public readonly void* Value;
+
+    public HBITMAP(void* value)
+    {
+        Value = value;
+    }
+
+    public static HBITMAP INVALID_VALUE => new HBITMAP((void*)(-1));
+
+    public static HBITMAP NULL => new HBITMAP(null);
+
+    public static bool operator ==(HBITMAP left, HBITMAP right) => left.Value == right.Value;
+
+    public static bool operator !=(HBITMAP left, HBITMAP right) => left.Value != right.Value;
+
+    public static bool operator <(HBITMAP left, HBITMAP right) => left.Value < right.Value;
+
+    public static bool operator <=(HBITMAP left, HBITMAP right) => left.Value <= right.Value;
+
+    public static bool operator >(HBITMAP left, HBITMAP right) => left.Value > right.Value;
+
+    public static bool operator >=(HBITMAP left, HBITMAP right) => left.Value >= right.Value;
+
+    public static explicit operator HBITMAP(void* value) => new HBITMAP(value);
+
+    public static implicit operator void*(HBITMAP value) => value.Value;
+
+    public static explicit operator HBITMAP(byte value) => new HBITMAP((void*)(value));
+
+    public static explicit operator byte(HBITMAP value) => (byte)(value.Value);
+
+    public static explicit operator HBITMAP(short value) => new HBITMAP((void*)(value));
+
+    public static explicit operator short(HBITMAP value) => (short)(value.Value);
+
+    public static explicit operator HBITMAP(int value) => new HBITMAP((void*)(value));
+
+    public static explicit operator int(HBITMAP value) => (int)(value.Value);
+
+    public static explicit operator HBITMAP(long value) => new HBITMAP((void*)(value));
+
+    public static explicit operator long(HBITMAP value) => (long)(value.Value);
+
+    public static explicit operator HBITMAP(nint value) => new HBITMAP((void*)(value));
+
+    public static implicit operator nint(HBITMAP value) => (nint)(value.Value);
+
+    public static explicit operator HBITMAP(sbyte value) => new HBITMAP((void*)(value));
+
+    public static explicit operator sbyte(HBITMAP value) => (sbyte)(value.Value);
+
+    public static explicit operator HBITMAP(ushort value) => new HBITMAP((void*)(value));
+
+    public static explicit operator ushort(HBITMAP value) => (ushort)(value.Value);
+
+    public static explicit operator HBITMAP(uint value) => new HBITMAP((void*)(value));
+
+    public static explicit operator uint(HBITMAP value) => (uint)(value.Value);
+
+    public static explicit operator HBITMAP(ulong value) => new HBITMAP((void*)(value));
+
+    public static explicit operator ulong(HBITMAP value) => (ulong)(value.Value);
+
+    public static explicit operator HBITMAP(nuint value) => new HBITMAP((void*)(value));
+
+    public static implicit operator nuint(HBITMAP value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is HBITMAP other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of HBITMAP.");
+    }
+
+   // public int CompareTo(HBITMAP other) => ((nuint)(Value)).CompareTo((nuint)(other.Value));
+
+    public override bool Equals(object obj) => (obj is HBITMAP other) && Equals(other);
+
+    public bool Equals(HBITMAP other) => ((nuint)(Value)).Equals((nuint)(other.Value));
+
+    public override int GetHashCode() => ((nuint)(Value)).GetHashCode();
+
+    //public override string ToString() => ((nuint)(Value)).ToString((sizeof(nint) == 4) ? "X8" : "X16");
+
+   // public string ToString(string? format, IFormatProvider? formatProvider) => ((nuint)(Value)).ToString(format, formatProvider);
+
+   // public static explicit operator HBITMAP(HGDIOBJ value) => new HBITMAP(value.Value);
+
+    //public static implicit operator HGDIOBJ(HBITMAP value) => new HGDIOBJ(value.Value);
+}

--- a/src/FluentAvalonia/Interop/Helpers/HINSTANCE.cs
+++ b/src/FluentAvalonia/Interop/Helpers/HINSTANCE.cs
@@ -1,0 +1,93 @@
+﻿namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct HINSTANCE : IComparable, IEquatable<HINSTANCE>
+{
+    public readonly void* Value;
+
+    public HINSTANCE(void* value)
+    {
+        Value = value;
+    }
+
+    public static HINSTANCE INVALID_VALUE => new HINSTANCE((void*)(-1));
+
+    public static HINSTANCE NULL => new HINSTANCE(null);
+
+    public static bool operator ==(HINSTANCE left, HINSTANCE right) => left.Value == right.Value;
+
+    public static bool operator !=(HINSTANCE left, HINSTANCE right) => left.Value != right.Value;
+
+    public static bool operator <(HINSTANCE left, HINSTANCE right) => left.Value < right.Value;
+
+    public static bool operator <=(HINSTANCE left, HINSTANCE right) => left.Value <= right.Value;
+
+    public static bool operator >(HINSTANCE left, HINSTANCE right) => left.Value > right.Value;
+
+    public static bool operator >=(HINSTANCE left, HINSTANCE right) => left.Value >= right.Value;
+
+    public static explicit operator HINSTANCE(void* value) => new HINSTANCE(value);
+
+    public static implicit operator void*(HINSTANCE value) => value.Value;
+
+    public static explicit operator HINSTANCE(byte value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator byte(HINSTANCE value) => (byte)(value.Value);
+
+    public static explicit operator HINSTANCE(short value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator short(HINSTANCE value) => (short)(value.Value);
+
+    public static explicit operator HINSTANCE(int value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator int(HINSTANCE value) => (int)(value.Value);
+
+    public static explicit operator HINSTANCE(long value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator long(HINSTANCE value) => (long)(value.Value);
+
+    public static explicit operator HINSTANCE(nint value) => new HINSTANCE((void*)(value));
+
+    public static implicit operator nint(HINSTANCE value) => (nint)(value.Value);
+
+    public static explicit operator HINSTANCE(sbyte value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator sbyte(HINSTANCE value) => (sbyte)(value.Value);
+
+    public static explicit operator HINSTANCE(ushort value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator ushort(HINSTANCE value) => (ushort)(value.Value);
+
+    public static explicit operator HINSTANCE(uint value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator uint(HINSTANCE value) => (uint)(value.Value);
+
+    public static explicit operator HINSTANCE(ulong value) => new HINSTANCE((void*)(value));
+
+    public static explicit operator ulong(HINSTANCE value) => (ulong)(value.Value);
+
+    public static explicit operator HINSTANCE(nuint value) => new HINSTANCE((void*)(value));
+
+    public static implicit operator nuint(HINSTANCE value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is HINSTANCE other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of HINSTANCE.");
+    }
+
+    //public int CompareTo(HINSTANCE other) => ((nuint)(Value)).CompareTo((nuint)(other.Value));
+
+    public override bool Equals(object obj) => (obj is HINSTANCE other) && Equals(other);
+
+    public bool Equals(HINSTANCE other) => ((nuint)(Value)).Equals((nuint)(other.Value));
+
+    public override int GetHashCode() => ((nuint)(Value)).GetHashCode();
+
+    //public override string ToString() => ((nuint)(Value)).ToString((sizeof(nint) == 4) ? "X8" : "X16");
+
+   // public string ToString(string format, IFormatProvider formatProvider) => ((nuint)(Value)).ToString(format, formatProvider);
+}

--- a/src/FluentAvalonia/Interop/Helpers/HMENU.cs
+++ b/src/FluentAvalonia/Interop/Helpers/HMENU.cs
@@ -1,0 +1,102 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct HMENU : IComparable, IEquatable<HMENU>
+{
+    public readonly void* Value;
+
+    public HMENU(void* value)
+    {
+        Value = value;
+    }
+
+    public static HMENU INVALID_VALUE => new HMENU((void*)(-1));
+
+    public static HMENU NULL => new HMENU(null);
+
+    public static bool operator ==(HMENU left, HMENU right) => left.Value == right.Value;
+
+    public static bool operator !=(HMENU left, HMENU right) => left.Value != right.Value;
+
+    public static bool operator <(HMENU left, HMENU right) => left.Value < right.Value;
+
+    public static bool operator <=(HMENU left, HMENU right) => left.Value <= right.Value;
+
+    public static bool operator >(HMENU left, HMENU right) => left.Value > right.Value;
+
+    public static bool operator >=(HMENU left, HMENU right) => left.Value >= right.Value;
+
+    public static explicit operator HMENU(void* value) => new HMENU(value);
+
+    public static implicit operator void*(HMENU value) => value.Value;
+
+    public static explicit operator HMENU(byte value) => new HMENU((void*)(value));
+
+    public static explicit operator byte(HMENU value) => (byte)(value.Value);
+
+    public static explicit operator HMENU(short value) => new HMENU((void*)(value));
+
+    public static explicit operator short(HMENU value) => (short)(value.Value);
+
+    public static explicit operator HMENU(int value) => new HMENU((void*)(value));
+
+    public static explicit operator int(HMENU value) => (int)(value.Value);
+
+    public static explicit operator HMENU(long value) => new HMENU((void*)(value));
+
+    public static explicit operator long(HMENU value) => (long)(value.Value);
+
+    public static explicit operator HMENU(nint value) => new HMENU((void*)(value));
+
+    public static implicit operator nint(HMENU value) => (nint)(value.Value);
+
+    public static explicit operator HMENU(sbyte value) => new HMENU((void*)(value));
+
+    public static explicit operator sbyte(HMENU value) => (sbyte)(value.Value);
+
+    public static explicit operator HMENU(ushort value) => new HMENU((void*)(value));
+
+    public static explicit operator ushort(HMENU value) => (ushort)(value.Value);
+
+    public static explicit operator HMENU(uint value) => new HMENU((void*)(value));
+
+    public static explicit operator uint(HMENU value) => (uint)(value.Value);
+
+    public static explicit operator HMENU(ulong value) => new HMENU((void*)(value));
+
+    public static explicit operator ulong(HMENU value) => (ulong)(value.Value);
+
+    public static explicit operator HMENU(nuint value) => new HMENU((void*)(value));
+
+    public static implicit operator nuint(HMENU value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is HMENU other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of HMENU.");
+    }
+
+    //public int CompareTo(HMENU other) => ((nuint)(Value)).CompareTo((nuint)(other.Value));
+
+    public override bool Equals(object obj) => (obj is HMENU other) && Equals(other);
+
+    public bool Equals(HMENU other) => ((nuint)(Value)).Equals((nuint)(other.Value));
+
+    public override int GetHashCode() => ((nuint)(Value)).GetHashCode();
+
+   // public override string ToString() => ((nuint)(Value)).ToString((sizeof(nint) == 4) ? "X8" : "X16");
+
+    //public string ToString(string? format, IFormatProvider? formatProvider) => ((nuint)(Value)).ToString(format, formatProvider);
+}
+
+
+
+
+
+
+

--- a/src/FluentAvalonia/Interop/Helpers/HRESULT.cs
+++ b/src/FluentAvalonia/Interop/Helpers/HRESULT.cs
@@ -1,0 +1,96 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct HRESULT : IComparable, IComparable<HRESULT>, IEquatable<HRESULT>, IFormattable
+{
+    public readonly int Value;
+
+    public HRESULT(int value)
+    {
+        Value = value;
+    }
+
+    public bool FAILED => Value < 0;
+
+    public bool SUCCEEDED => Value >= 0;
+
+    public static bool operator ==(HRESULT left, HRESULT right) => left.Value == right.Value;
+
+    public static bool operator !=(HRESULT left, HRESULT right) => left.Value != right.Value;
+
+    public static bool operator <(HRESULT left, HRESULT right) => left.Value < right.Value;
+
+    public static bool operator <=(HRESULT left, HRESULT right) => left.Value <= right.Value;
+
+    public static bool operator >(HRESULT left, HRESULT right) => left.Value > right.Value;
+
+    public static bool operator >=(HRESULT left, HRESULT right) => left.Value >= right.Value;
+
+    public static implicit operator HRESULT(byte value) => new HRESULT(value);
+
+    public static explicit operator byte(HRESULT value) => (byte)(value.Value);
+
+    public static implicit operator HRESULT(short value) => new HRESULT(value);
+
+    public static explicit operator short(HRESULT value) => (short)(value.Value);
+
+    public static implicit operator HRESULT(int value) => new HRESULT(value);
+
+    public static implicit operator int(HRESULT value) => value.Value;
+
+    public static explicit operator HRESULT(long value) => new HRESULT((int)(value));
+
+    public static implicit operator long(HRESULT value) => value.Value;
+
+    public static explicit operator HRESULT(nint value) => new HRESULT((int)(value));
+
+    public static implicit operator nint(HRESULT value) => value.Value;
+
+    public static implicit operator HRESULT(sbyte value) => new HRESULT(value);
+
+    public static explicit operator sbyte(HRESULT value) => (sbyte)(value.Value);
+
+    public static implicit operator HRESULT(ushort value) => new HRESULT(value);
+
+    public static explicit operator ushort(HRESULT value) => (ushort)(value.Value);
+
+    public static explicit operator HRESULT(uint value) => new HRESULT((int)(value));
+
+    public static explicit operator uint(HRESULT value) => (uint)(value.Value);
+
+    public static explicit operator HRESULT(ulong value) => new HRESULT((int)(value));
+
+    public static explicit operator ulong(HRESULT value) => (ulong)(value.Value);
+
+    public static explicit operator HRESULT(nuint value) => new HRESULT((int)(value));
+
+    public static explicit operator nuint(HRESULT value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is HRESULT other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of HRESULT.");
+    }
+
+    public int CompareTo(HRESULT other) => Value.CompareTo(other.Value);
+
+    public override bool Equals(object obj) => (obj is HRESULT other) && Equals(other);
+
+    public bool Equals(HRESULT other) => Value.Equals(other.Value);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public override string ToString() => Value.ToString("X8");
+
+    public string ToString(string format, IFormatProvider formatProvider) => Value.ToString(format, formatProvider);
+}
+
+
+
+
+

--- a/src/FluentAvalonia/Interop/Helpers/HWND.cs
+++ b/src/FluentAvalonia/Interop/Helpers/HWND.cs
@@ -1,0 +1,98 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct HWND : IComparable, IEquatable<HWND>
+{
+    public readonly void* Value;
+
+    public HWND(void* value)
+    {
+        Value = value;
+    }
+
+    public static HWND INVALID_VALUE => new HWND((void*)(-1));
+
+    public static HWND NULL => new HWND(null);
+
+    public static bool operator ==(HWND left, HWND right) => left.Value == right.Value;
+
+    public static bool operator !=(HWND left, HWND right) => left.Value != right.Value;
+
+    public static bool operator <(HWND left, HWND right) => left.Value < right.Value;
+
+    public static bool operator <=(HWND left, HWND right) => left.Value <= right.Value;
+
+    public static bool operator >(HWND left, HWND right) => left.Value > right.Value;
+
+    public static bool operator >=(HWND left, HWND right) => left.Value >= right.Value;
+
+    public static explicit operator HWND(void* value) => new HWND(value);
+
+    public static implicit operator void*(HWND value) => value.Value;
+
+    public static explicit operator HWND(byte value) => new HWND((void*)(value));
+
+    public static explicit operator byte(HWND value) => (byte)(value.Value);
+
+    public static explicit operator HWND(short value) => new HWND((void*)(value));
+
+    public static explicit operator short(HWND value) => (short)(value.Value);
+
+    public static explicit operator HWND(int value) => new HWND((void*)(value));
+
+    public static explicit operator int(HWND value) => (int)(value.Value);
+
+    public static explicit operator HWND(long value) => new HWND((void*)(value));
+
+    public static explicit operator long(HWND value) => (long)(value.Value);
+
+    public static explicit operator HWND(nint value) => new HWND((void*)(value));
+
+    public static implicit operator nint(HWND value) => (nint)(value.Value);
+
+    public static explicit operator HWND(sbyte value) => new HWND((void*)(value));
+
+    public static explicit operator sbyte(HWND value) => (sbyte)(value.Value);
+
+    public static explicit operator HWND(ushort value) => new HWND((void*)(value));
+
+    public static explicit operator ushort(HWND value) => (ushort)(value.Value);
+
+    public static explicit operator HWND(uint value) => new HWND((void*)(value));
+
+    public static explicit operator uint(HWND value) => (uint)(value.Value);
+
+    public static explicit operator HWND(ulong value) => new HWND((void*)(value));
+
+    public static explicit operator ulong(HWND value) => (ulong)(value.Value);
+
+    public static explicit operator HWND(nuint value) => new HWND((void*)(value));
+
+    public static implicit operator nuint(HWND value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is HWND other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of HWND.");
+    }
+
+    //public int CompareTo(HWND other) => ((nuint)(Value)).CompareTo((nuint)(other.Value));
+
+    public override bool Equals(object obj) => (obj is HWND other) && Equals(other);
+
+    public bool Equals(HWND other) => ((nuint)(Value)).Equals((nuint)(other.Value));
+
+    public override int GetHashCode() => ((nuint)(Value)).GetHashCode();
+
+    //public override string ToString() => ((nuint)(Value)).ToString((sizeof(nint) == 4) ? "X8" : "X16");
+
+    //public string ToString(string? format, IFormatProvider? formatProvider) => ((nuint)(Value)).ToString(format, formatProvider);
+}
+
+
+

--- a/src/FluentAvalonia/Interop/Helpers/LPARAM.cs
+++ b/src/FluentAvalonia/Interop/Helpers/LPARAM.cs
@@ -1,0 +1,88 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct LPARAM : IComparable, IEquatable<LPARAM>
+{
+    public readonly nint Value;
+
+    public LPARAM(nint value)
+    {
+        Value = value;
+    }
+
+    public static bool operator ==(LPARAM left, LPARAM right) => left.Value == right.Value;
+
+    public static bool operator !=(LPARAM left, LPARAM right) => left.Value != right.Value;
+
+    public static bool operator <(LPARAM left, LPARAM right) => left.Value < right.Value;
+
+    public static bool operator <=(LPARAM left, LPARAM right) => left.Value <= right.Value;
+
+    public static bool operator >(LPARAM left, LPARAM right) => left.Value > right.Value;
+
+    public static bool operator >=(LPARAM left, LPARAM right) => left.Value >= right.Value;
+
+    public static implicit operator LPARAM(byte value) => new LPARAM(value);
+
+    public static explicit operator byte(LPARAM value) => (byte)(value.Value);
+
+    public static implicit operator LPARAM(short value) => new LPARAM(value);
+
+    public static explicit operator short(LPARAM value) => (short)(value.Value);
+
+    public static implicit operator LPARAM(int value) => new LPARAM(value);
+
+    public static explicit operator int(LPARAM value) => (int)(value.Value);
+
+    public static explicit operator LPARAM(long value) => new LPARAM((nint)(value));
+
+    public static implicit operator long(LPARAM value) => value.Value;
+
+    public static implicit operator LPARAM(nint value) => new LPARAM(value);
+
+    public static implicit operator nint(LPARAM value) => value.Value;
+
+    public static implicit operator LPARAM(sbyte value) => new LPARAM(value);
+
+    public static explicit operator sbyte(LPARAM value) => (sbyte)(value.Value);
+
+    public static implicit operator LPARAM(ushort value) => new LPARAM(value);
+
+    public static explicit operator ushort(LPARAM value) => (ushort)(value.Value);
+
+    public static explicit operator LPARAM(uint value) => new LPARAM((nint)(value));
+
+    public static explicit operator uint(LPARAM value) => (uint)(value.Value);
+
+    public static explicit operator LPARAM(ulong value) => new LPARAM((nint)(value));
+
+    public static explicit operator ulong(LPARAM value) => (ulong)(value.Value);
+
+    public static explicit operator LPARAM(nuint value) => new LPARAM((nint)(value));
+
+    public static explicit operator nuint(LPARAM value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is LPARAM other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of LPARAM.");
+    }
+
+    //public int CompareTo(LPARAM other) => Value.CompareTo(other.Value);
+
+    public override bool Equals(object obj) => (obj is LPARAM other) && Equals(other);
+
+    public bool Equals(LPARAM other) => Value.Equals(other.Value);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public override string ToString() => Value.ToString((sizeof(nint) == 4) ? "X8" : "X16");
+
+   // public string ToString(string? format, IFormatProvider? formatProvider) => Value.ToString(format, formatProvider);
+}
+

--- a/src/FluentAvalonia/Interop/Helpers/LRESULT.cs
+++ b/src/FluentAvalonia/Interop/Helpers/LRESULT.cs
@@ -1,0 +1,167 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct LRESULT : IComparable, IEquatable<LRESULT>
+{
+    public readonly nint Value;
+
+    public LRESULT(nint value)
+    {
+        Value = value;
+    }
+
+    public static bool operator ==(LRESULT left, LRESULT right) => left.Value == right.Value;
+
+    public static bool operator !=(LRESULT left, LRESULT right) => left.Value != right.Value;
+
+    public static bool operator <(LRESULT left, LRESULT right) => left.Value < right.Value;
+
+    public static bool operator <=(LRESULT left, LRESULT right) => left.Value <= right.Value;
+
+    public static bool operator >(LRESULT left, LRESULT right) => left.Value > right.Value;
+
+    public static bool operator >=(LRESULT left, LRESULT right) => left.Value >= right.Value;
+
+    public static implicit operator LRESULT(byte value) => new LRESULT(value);
+
+    public static explicit operator byte(LRESULT value) => (byte)(value.Value);
+
+    public static implicit operator LRESULT(short value) => new LRESULT(value);
+
+    public static explicit operator short(LRESULT value) => (short)(value.Value);
+
+    public static implicit operator LRESULT(int value) => new LRESULT(value);
+
+    public static explicit operator int(LRESULT value) => (int)(value.Value);
+
+    public static explicit operator LRESULT(long value) => new LRESULT((nint)(value));
+
+    public static implicit operator long(LRESULT value) => value.Value;
+
+    public static implicit operator LRESULT(nint value) => new LRESULT(value);
+
+    public static implicit operator nint(LRESULT value) => value.Value;
+
+    public static implicit operator LRESULT(sbyte value) => new LRESULT(value);
+
+    public static explicit operator sbyte(LRESULT value) => (sbyte)(value.Value);
+
+    public static implicit operator LRESULT(ushort value) => new LRESULT(value);
+
+    public static explicit operator ushort(LRESULT value) => (ushort)(value.Value);
+
+    public static explicit operator LRESULT(uint value) => new LRESULT((nint)(value));
+
+    public static explicit operator uint(LRESULT value) => (uint)(value.Value);
+
+    public static explicit operator LRESULT(ulong value) => new LRESULT((nint)(value));
+
+    public static explicit operator ulong(LRESULT value) => (ulong)(value.Value);
+
+    public static explicit operator LRESULT(nuint value) => new LRESULT((nint)(value));
+
+    public static explicit operator nuint(LRESULT value) => (nuint)(value.Value);
+
+    public int CompareTo(object obj)
+    {
+        if (obj is LRESULT other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of LRESULT.");
+    }
+
+    //public int CompareTo(LRESULT other) => Value.CompareTo(other.Value);
+
+    public override bool Equals(object obj) => (obj is LRESULT other) && Equals(other);
+
+    public bool Equals(LRESULT other) => Value.Equals(other.Value);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public override string ToString() => Value.ToString();
+
+    //public string ToString(string? format, IFormatProvider? formatProvider) => Value.ToString(format, formatProvider);
+
+    public static explicit operator LRESULT(void* value) => new LRESULT((nint)(value));
+
+    public static implicit operator void*(LRESULT value) => (void*)(value.Value);
+
+    public static explicit operator LRESULT(BOOL value) => new LRESULT(value.Value);
+
+    public static explicit operator BOOL(LRESULT value) => new BOOL((int)(value.Value));
+
+    //public static explicit operator LRESULT(HANDLE value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HANDLE(LRESULT value) => new HANDLE((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HBRUSH value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HBRUSH(LRESULT value) => new HBRUSH((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HCURSOR value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HCURSOR(LRESULT value) => new HCURSOR((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HDC value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HDC(LRESULT value) => new HDC((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HDROP value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HDROP(LRESULT value) => new HDROP((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HFONT value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HFONT(LRESULT value) => new HFONT((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HGDIOBJ value) => new LRESULT((nint)(value.Value));
+
+   // public static explicit operator HGDIOBJ(LRESULT value) => new HGDIOBJ((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HGLOBAL value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HGLOBAL(LRESULT value) => new HGLOBAL((void*)(value.Value));
+
+   // public static explicit operator LRESULT(HICON value) => new LRESULT((nint)(value.Value));
+
+   // public static explicit operator HICON(LRESULT value) => new HICON((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HINSTANCE value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HINSTANCE(LRESULT value) => new HINSTANCE((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HLOCAL value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HLOCAL(LRESULT value) => new HLOCAL((void*)(value.Value));
+
+    public static explicit operator LRESULT(HMENU value) => new LRESULT((nint)(value.Value));
+
+    public static explicit operator HMENU(LRESULT value) => new HMENU((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HMODULE value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HMODULE(LRESULT value) => new HMODULE((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HPALETTE value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HPALETTE(LRESULT value) => new HPALETTE((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HPEN value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HPEN(LRESULT value) => new HPEN((void*)(value.Value));
+
+    //public static explicit operator LRESULT(HRGN value) => new LRESULT((nint)(value.Value));
+
+    //public static explicit operator HRGN(LRESULT value) => new HRGN((void*)(value.Value));
+
+    public static explicit operator LRESULT(HWND value) => new LRESULT((nint)(value.Value));
+
+    public static explicit operator HWND(LRESULT value) => new HWND((void*)(value.Value));
+
+    public static explicit operator LRESULT(LPARAM value) => new LRESULT(value.Value);
+
+    public static explicit operator LRESULT(WPARAM value) => new LRESULT((nint)(value.Value));
+}

--- a/src/FluentAvalonia/Interop/Helpers/MARGINS.cs
+++ b/src/FluentAvalonia/Interop/Helpers/MARGINS.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace FluentAvalonia.Interop.Win32;
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MARGINS
+{
+    public int leftWidth;
+    public int rightWidth;
+    public int topHeight;
+    public int bottomHeight;
+}

--- a/src/FluentAvalonia/Interop/Helpers/MENUITEMINFO.cs
+++ b/src/FluentAvalonia/Interop/Helpers/MENUITEMINFO.cs
@@ -1,0 +1,17 @@
+﻿namespace FluentAvalonia.Interop.Win32;
+
+internal unsafe struct MENUITEMINFO
+{
+    public uint cbSize;
+    public uint fMask;
+    public uint fType;
+    public uint fState;
+    public uint wID;
+    public HMENU hSubMenu;
+    public HBITMAP hbmpChecked;
+    public HBITMAP hbmpUnchecked;
+    public nuint dwItemData;
+    public ushort* dwTypeData;
+    public uint cch;
+    public HBITMAP hbmpItem;
+}

--- a/src/FluentAvalonia/Interop/Helpers/NCCALCSIZE_PARAMS.cs
+++ b/src/FluentAvalonia/Interop/Helpers/NCCALCSIZE_PARAMS.cs
@@ -1,0 +1,39 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace FluentAvalonia.Interop.Win32;
+
+#pragma warning disable 0649
+
+internal unsafe struct NCCALCSIZE_PARAMS
+{
+    public _rgrc_e__FixedBuffer rgrc;
+     
+    public WINDOWPOS* lppos;
+
+    public struct _rgrc_e__FixedBuffer
+    {
+        public RECT e0;
+        public RECT e1;
+        public RECT e2;
+
+        public ref RECT this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => ref AsSpan()[index];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<RECT> AsSpan()
+        {
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            return MemoryMarshal.CreateSpan(ref e0, 3);
+#else
+            return new Span<RECT>(Unsafe.AsPointer(ref e0), 3);
+#endif
+        }
+    }
+}

--- a/src/FluentAvalonia/Interop/Helpers/RECT.cs
+++ b/src/FluentAvalonia/Interop/Helpers/RECT.cs
@@ -1,0 +1,28 @@
+﻿namespace FluentAvalonia.Interop.Win32;
+
+internal struct RECT
+{
+    public RECT(Avalonia.Rect rect)
+    {
+        left = (int)rect.X;
+        top = (int)rect.Y;
+        right = (int)(rect.X + rect.Width);
+        bottom = (int)(rect.Y + rect.Height);
+    }
+
+    public RECT(int l, int t, int r, int b)
+    {
+        left = l;
+        top = t;
+        right = r;
+        bottom = b;
+    }
+
+    public int left;
+    public int top;
+    public int right;
+    public int bottom;
+
+    public int Width => right - left;
+    public int Height => bottom - top;   
+}

--- a/src/FluentAvalonia/Interop/Helpers/WINDOWPOS.cs
+++ b/src/FluentAvalonia/Interop/Helpers/WINDOWPOS.cs
@@ -1,0 +1,14 @@
+﻿namespace FluentAvalonia.Interop.Win32;
+
+#pragma warning disable 0649
+
+internal struct WINDOWPOS
+{
+    public HWND hWnd;
+    public HWND hWndInsertAfter;
+    public int x;
+    public int y;
+    public int cx;
+    public int cy;
+    public uint flags;
+}

--- a/src/FluentAvalonia/Interop/Helpers/WPARAM.cs
+++ b/src/FluentAvalonia/Interop/Helpers/WPARAM.cs
@@ -1,0 +1,167 @@
+﻿// Adapted from TerraFX.Interop.Windows, MIT license
+
+namespace FluentAvalonia.Interop.Win32;
+
+internal readonly unsafe struct WPARAM : IComparable, IEquatable<WPARAM>
+{
+    public readonly nuint Value;
+
+    public WPARAM(nuint value)
+    {
+        Value = value;
+    }
+
+    public static bool operator ==(WPARAM left, WPARAM right) => left.Value == right.Value;
+
+    public static bool operator !=(WPARAM left, WPARAM right) => left.Value != right.Value;
+
+    public static bool operator <(WPARAM left, WPARAM right) => left.Value < right.Value;
+
+    public static bool operator <=(WPARAM left, WPARAM right) => left.Value <= right.Value;
+
+    public static bool operator >(WPARAM left, WPARAM right) => left.Value > right.Value;
+
+    public static bool operator >=(WPARAM left, WPARAM right) => left.Value >= right.Value;
+
+    public static implicit operator WPARAM(byte value) => new WPARAM(value);
+
+    public static explicit operator byte(WPARAM value) => (byte)(value.Value);
+
+    public static explicit operator WPARAM(short value) => new WPARAM((nuint)(value));
+
+    public static explicit operator short(WPARAM value) => (short)(value.Value);
+
+    public static explicit operator WPARAM(int value) => new WPARAM((nuint)(value));
+
+    public static explicit operator int(WPARAM value) => (int)(value.Value);
+
+    public static explicit operator WPARAM(long value) => new WPARAM((nuint)(value));
+
+    public static explicit operator long(WPARAM value) => (long)(value.Value);
+
+    public static explicit operator WPARAM(nint value) => new WPARAM((nuint)(value));
+
+    public static explicit operator nint(WPARAM value) => (nint)(value.Value);
+
+    public static explicit operator WPARAM(sbyte value) => new WPARAM((nuint)(value));
+
+    public static explicit operator sbyte(WPARAM value) => (sbyte)(value.Value);
+
+    public static implicit operator WPARAM(ushort value) => new WPARAM(value);
+
+    public static explicit operator ushort(WPARAM value) => (ushort)(value.Value);
+
+    public static implicit operator WPARAM(uint value) => new WPARAM(value);
+
+    public static explicit operator uint(WPARAM value) => (uint)(value.Value);
+
+    public static explicit operator WPARAM(ulong value) => new WPARAM((nuint)(value));
+
+    public static implicit operator ulong(WPARAM value) => value.Value;
+
+    public static implicit operator WPARAM(nuint value) => new WPARAM(value);
+
+    public static implicit operator nuint(WPARAM value) => value.Value;
+
+    public int CompareTo(object obj)
+    {
+        if (obj is WPARAM other)
+        {
+            return CompareTo(other);
+        }
+
+        return (obj is null) ? 1 : throw new ArgumentException("obj is not an instance of WPARAM.");
+    }
+
+   // public int CompareTo(WPARAM other) => Value.CompareTo(other.Value);
+
+    public override bool Equals(object obj) => (obj is WPARAM other) && Equals(other);
+
+    public bool Equals(WPARAM other) => Value.Equals(other.Value);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+   // public override string ToString() => Value.ToString((sizeof(nint) == 4) ? "X8" : "X16");
+
+   // public string ToString(string? format, IFormatProvider? formatProvider) => Value.ToString(format, formatProvider);
+
+    public static explicit operator WPARAM(void* value) => new WPARAM((nuint)(value));
+
+    public static implicit operator void*(WPARAM value) => (void*)(value.Value);
+
+    public static explicit operator WPARAM(BOOL value) => new WPARAM((nuint)(value.Value));
+
+    public static explicit operator BOOL(WPARAM value) => new BOOL((int)(value.Value));
+
+    //public static explicit operator WPARAM(HANDLE value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HANDLE(WPARAM value) => new HANDLE((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HBRUSH value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HBRUSH(WPARAM value) => new HBRUSH((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HCURSOR value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HCURSOR(WPARAM value) => new HCURSOR((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HDC value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HDC(WPARAM value) => new HDC((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HDROP value) => new WPARAM((nuint)(value.Value));
+    
+    //public static explicit operator HDROP(WPARAM value) => new HDROP((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HFONT value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HFONT(WPARAM value) => new HFONT((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HGDIOBJ value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HGDIOBJ(WPARAM value) => new HGDIOBJ((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HGLOBAL value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HGLOBAL(WPARAM value) => new HGLOBAL((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HICON value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HICON(WPARAM value) => new HICON((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HINSTANCE value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HINSTANCE(WPARAM value) => new HINSTANCE((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HLOCAL value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HLOCAL(WPARAM value) => new HLOCAL((void*)(value.Value));
+
+    public static explicit operator WPARAM(HMENU value) => new WPARAM((nuint)(value.Value));
+
+    public static explicit operator HMENU(WPARAM value) => new HMENU((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HMODULE value) => new WPARAM((nuint)(value.Value));
+    
+    //public static explicit operator HMODULE(WPARAM value) => new HMODULE((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HPALETTE value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HPALETTE(WPARAM value) => new HPALETTE((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HPEN value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HPEN(WPARAM value) => new HPEN((void*)(value.Value));
+
+    //public static explicit operator WPARAM(HRGN value) => new WPARAM((nuint)(value.Value));
+
+    //public static explicit operator HRGN(WPARAM value) => new HRGN((void*)(value.Value));
+
+    public static explicit operator WPARAM(HWND value) => new WPARAM((nuint)(value.Value));
+
+    public static explicit operator HWND(WPARAM value) => new HWND((void*)(value.Value));
+
+    public static explicit operator WPARAM(LPARAM value) => new WPARAM((nuint)(value.Value));
+
+    public static explicit operator WPARAM(LRESULT value) => new WPARAM((nuint)(value.Value));
+}

--- a/src/FluentAvalonia/Interop/Win32Interop.cs
+++ b/src/FluentAvalonia/Interop/Win32Interop.cs
@@ -1,21 +1,124 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using Avalonia;
 using System.Security;
+using Avalonia;
+using FluentAvalonia.Interop;
+using FluentAvalonia.Interop.Win32;
+using MicroCom.Runtime;
 
 namespace FluentAvalonia.Interop;
 
-internal static unsafe class Win32Interop
+internal static unsafe partial class Win32Interop
 {
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL GetWindowRect(HWND hWnd, RECT* lpRect);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL GetClientRect(HWND hWnd, RECT* lpRect);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL AdjustWindowRectEx(RECT* lpRect, uint dwStyle, BOOL bMenu, uint dwExStyle);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern int GetSystemMetrics(int smIndex);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern int GetSystemMetricsForDpi(int nIndex, uint dpi);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL SetWindowPos(HWND hWnd, HWND hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL AdjustWindowRectExForDpi(RECT* lpRect, int dwStyle, BOOL bMenu, int dwExStyle, int dpi);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern LRESULT DefWindowProcW(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern LRESULT CallWindowProcW(nint lpPrevWndProc, HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
+
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL PostMessage(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern HMENU GetSystemMenu(HWND hWnd, BOOL bRevert);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL SetMenuItemInfo(HMENU hMenu, uint item, bool fByPosition, MENUITEMINFO* lpmii);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL SetMenuDefaultItem(HMENU hMenu, uint uItem, uint fByPos);
+
+    [DllImport(s_user32, SetLastError = true)]
+    public static extern BOOL TrackPopupMenu(HMENU hMenu, uint uFlags,
+        int x, int y, int nReserved, HWND hWnd, RECT* prcRect);
+
+    [DllImport(s_user32)]
+    public static extern int GetWindowLongW(HWND hWnd, int nIndex);
+
+    [DllImport(s_user32)]
+    public static extern int SetWindowLongW(HWND hWnd, int nIndex, int dwNewLong);
+
+    // Below is adapted from TerraFX.Interop.Windows, MIT License
+    public static delegate*<HWND, int, nint> GetWindowLongPtr => &GetWindowLongPtrW;
+
+    public static nint GetWindowLongPtrW(HWND hWnd, int nIndex)
+    {
+        if (sizeof(nint) == 4)
+        {
+            return GetWindowLongW(hWnd, nIndex);
+        }
+        else
+        {
+            [DllImport(s_user32, EntryPoint = "GetWindowLongPtrW")]
+            static extern nint _GetWindowLongPtrW(HWND hWnd, int nIndex);
+
+            return _GetWindowLongPtrW(hWnd, nIndex);
+        }
+    }
+
+    public static delegate*<HWND, int, nint, nint> SetWindowLongPtr => &SetWindowLongPtrW;
+
+    public static nint SetWindowLongPtrW(HWND hWnd, int nIndex, nint dwNewLong)
+    {
+        if (sizeof(nint) == 4)
+        {
+            return SetWindowLongW(hWnd, nIndex, (int)dwNewLong);
+        }
+        else
+        {
+            [DllImport(s_user32, EntryPoint = "SetWindowLongPtrW")]
+            static extern nint _SetWindowLongPtr(HWND hWnd, int nIndex, nint dwNewLong);
+
+            return _SetWindowLongPtr(hWnd, nIndex, dwNewLong);
+        }
+    }
+
+    [DllImport(s_dwmapi, SetLastError = true)]
+    public static extern HRESULT DwmExtendFrameIntoClientArea(HWND hWnd, MARGINS* margins);
+
+    [DllImport(s_ole32, ExactSpelling = true)]
+    public static extern HRESULT CoCreateInstance(Guid* rclsid, void* pUnkOuter,
+        int dwClsContext, Guid* riid, void** ppv);
+
+    internal unsafe static T CreateInstance<T>(Guid clsid, Guid iid) where T : IUnknown
+    {
+        void* pUnk;
+        var hresult = CoCreateInstance(&clsid, null, 1, &iid, &pUnk);
+        if (hresult != 0)
+        {
+            throw new COMException("CreateInstance", hresult);
+        }
+        using var unk = MicroComRuntime.CreateProxyFor<IUnknown>(pUnk, true);
+        return MicroComRuntime.QueryInterface<T>(unk);
+    }
+
+
     [DllImport(s_dwmapi, SetLastError = true)]
     public static extern int DwmSetWindowAttribute(nint hWnd, DWMWINDOWATTRIBUTE attr, void* value, int attrSize);
 
-    // TODO: TabViewListView
-    [DllImport(s_user32)]
-    public static extern int GetSystemMetrics(int smIndex);
-    [DllImport(s_user32)]
-    public static extern int GetSystemMetricsForDpi(int nIndex, uint dpi);
-
+    
 
     [DllImport(s_user32, SetLastError = true)]
     public static unsafe extern int SetWindowCompositionAttribute(IntPtr hwnd, WINDOWCOMPOSITIONATTRIBDATA* data);
@@ -29,11 +132,6 @@ internal static unsafe class Win32Interop
     [DllImport(s_uxtheme, EntryPoint = "#135")]
     public static extern bool fnAllowDarkModeForApp(IntPtr hwnd, bool allow);
 
-
-
-    [DllImport(s_user32, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
 
     [SecurityCritical]
     [DllImport(s_ntdll, SetLastError = true, CharSet = CharSet.Unicode)]
@@ -53,9 +151,9 @@ internal static unsafe class Win32Interop
             unsafe
             {
                 int dark = useDark ? 1 : 0;
-                DwmSetWindowAttribute(hwnd, DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(int));
+                //DwmSetWindowAttribute(hwnd, DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(int));
             }
-            
+
         }
         else
         {
@@ -80,11 +178,83 @@ internal static unsafe class Win32Interop
         }
 
         // Try to get the window to redraw to reflect the changes
-        SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0, (uint)(0x0001 | 0x0002 | 0x0004 | 0x0010 | 0x0020 | 0x0200));
+        //SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0, (uint)(0x0001 | 0x0002 | 0x0004 | 0x0010 | 0x0020 | 0x0200));
 
         return true;
     }
 
+
+    public const int GWLP_WNDPROC = -4;
+
+    public const int WM_CREATE = 0x0001;
+    public const int WM_SIZE = 0x0005;
+    public const int WM_NCMOUSEMOVE = 0x00A0;
+    public const int WM_NCLBUTTONDOWN = 0x00A1;
+    public const int WM_NCLBUTTONUP = 0x00A2;
+    public const int WM_NCHITTEST = 0x0084;
+    public const int WM_NCCALCSIZE = 0x0083;
+    public const int WM_ACTIVATE = 0x0006;
+    public const int WM_NCRBUTTONDOWN = 0x00A4;
+    public const int WM_NCRBUTTONDBLCLK = 0x00A6;
+    public const int WM_NCRBUTTONUP = 0x00A5;
+    public const int WM_SYSCOMMAND = 0x0112;
+    public const int WM_RBUTTONUP = 0x0205;
+    public const int WM_SETTINGCHANGE = 0x001A; // Also WM_WININICHANGE
+    public const int WM_SYSCOLORCHANGE = 0x0015;
+
+    //SC
+    public const int SC_CLOSE = 0xF060;
+    public const int SC_KEYMENU = 0xF100;
+    public const int SC_MAXIMIZE = 0xF030;
+    public const int SC_MINIMIZE = 0xF020;
+    public const int SC_MOVE = 0xF010;
+    public const int SC_RESTORE = 0xF120;
+    public const int SC_SIZE = 0xF000;
+
+    //MIIM
+    public const int MIIM_STATE = 0x00000001;
+
+    // SWP
+    public const int SWP_NOSIZE = 0x0001;
+    public const int SWP_NOMOVE = 0x0002;
+    public const int SWP_NOZORDER = 0x0004;
+    public const int SWP_NOREDRAW = 0x0008;
+    public const int SWP_NOACTIVATE = 0x0010;
+    public const int SWP_FRAMECHANGED = 0x0020;
+    public const int SWP_SHOWWINDOW = 0x0040;
+    public const int SWP_NOOWNERZORDER = 0x0200;
+    public const int SWP_DRAWFRAME = 0x0020;
+    public const int SWP_NOREPOSITION = 0x0200;
+
+    // SM
+    public const int SM_CXPADDEDBORDER = 92;
+    public const int SM_CYSIZEFRAME = 33;
+
+    // HT
+    public const int HTCLIENT = 1;
+    public const int HTCAPTION = 2;
+    public const int HTMAXBUTTON = 9;
+    public const int HTTOP = 12;
+
+
+    // MFS
+    public const int MFS_DISABLED = 0x00000003;
+    public const int MFS_ENABLED = 0x00000000;
+
+    // TPM
+    public const int TPM_RETURNCMD = 0x0100;
+
+    public static readonly Guid ITaskBarList3CLSID = Guid.Parse("56FDF344-FD6D-11D0-958A-006097C9A090");
+    public static readonly Guid ITaskBarList3IID = Guid.Parse("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
+
+    public static PixelPoint PointFromLParam(LPARAM lParam)
+    {
+        int lP = (int)lParam;
+        return new PixelPoint((short)(lP & 0xffff), (short)(lP >> 16));
+    }
+
+
+    private const string s_ole32 = "ole32.dll";
     private const string s_dwmapi = "dwmapi";
     private const string s_user32 = "user32.dll";
     private const string s_ntdll = "ntdll.dll";

--- a/src/FluentAvalonia/Interop/WinRT/WinRT.idl
+++ b/src/FluentAvalonia/Interop/WinRT/WinRT.idl
@@ -22,8 +22,18 @@
 @clr-map WCHAR System.Char
 @clr-map Color FluentAvalonia.Interop.WinRT.WinRTColor
 @clr-map Size FluentAvalonia.Interop.WinRT.WinRTSize
-//@clr-map TypedEventHandler<TSender, TArgs> FluentAvalonia.Core.TypeEventHandler<TSender, TArgs>
-//@clr-map EventRegistrationToken FluentAvalonia.Interop.WinRT.EventRegistrationToken
+@clr-map ULONGLONG ulong
+@clr-map HIMAGELIST IntPtr
+@clr-map THUMBBUTTONFLAGS int
+@clr-map THUMBBUTTONMASK int
+@clr-map THUMBBUTTON int
+@clr-map TBPFLAG int
+@clr-map UINT uint
+@clr-map LPTHUMBBUTTON int
+@clr-map HICON void*
+@clr-map LPCWSTR ushort*
+@clr-map RECT FluentAvalonia.Interop.Win32.RECT
+
 
 enum TrustLevel
 {
@@ -145,4 +155,82 @@ interface IAccessibilitySettings : IInspectable
     [propget] HRESULT HighContrastScheme([out][retval] HSTRING* value);
     //[eventadd] HRESULT HighContrastChanged([in] Windows.Foundation.TypedEventHandler<Windows.UI.ViewManagement.AccessibilitySettings*, IInspectable*>* handler, [out][retval] EventRegistrationToken* cookie);
     //[eventremove] HRESULT HighContrastChanged([in] EventRegistrationToken cookie);
+}
+
+[uuid(56FDF342-FD6D-11d0-958A-006097C9A090)]
+interface ITaskbarList : IUnknown
+{
+    HRESULT HrInit();
+
+    HRESULT AddTab([in] HWND hwnd);
+
+    HRESULT DeleteTab([in] HWND hwnd);
+
+    HRESULT ActivateTab([in] HWND hwnd);
+
+    HRESULT SetActiveAlt([in] HWND hwnd);
+}
+
+[uuid(602D4995-B13A-429b-A66E-1935E44F4317)]
+interface ITaskbarList2 : ITaskbarList
+{
+    HRESULT MarkFullscreenWindow(
+        [in] HWND hwnd,
+        [in] BOOL fFullscreen);
+}
+
+[uuid(ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf)]
+interface ITaskbarList3 : ITaskbarList2
+{
+    HRESULT SetProgressValue(
+        [in] HWND hwnd,
+        [in] ULONGLONG ullCompleted,
+        [in] ULONGLONG ullTotal);
+
+    HRESULT SetProgressState(
+        [in] HWND hwnd,
+        [in] TBPFLAG tbpFlags);
+
+    HRESULT RegisterTab(
+        [in] HWND hwndTab,
+        [in] HWND hwndMDI);
+
+    HRESULT UnregisterTab(
+        [in] HWND hwndTab);
+
+    HRESULT SetTabOrder(
+        [in] HWND hwndTab,
+        [in] HWND hwndInsertBefore);
+
+    HRESULT SetTabActive(
+        [in] HWND hwndTab,
+        [in] HWND hwndMDI,
+        [in] DWORD dwReserved);
+
+    HRESULT ThumbBarAddButtons(
+        [in] HWND hwnd,
+        [in] UINT cButtons,
+        [in, size_is(cButtons)] LPTHUMBBUTTON pButton);
+
+    HRESULT ThumbBarUpdateButtons(
+        [in] HWND hwnd,
+        [in] UINT cButtons,
+        [in, size_is(cButtons)] LPTHUMBBUTTON pButton);
+
+    HRESULT ThumbBarSetImageList(
+        [in] HWND hwnd,
+        [in] HIMAGELIST himl);
+
+    HRESULT SetOverlayIcon(
+        [in] HWND hwnd,
+        [in] HICON hIcon,
+        [in, unique, string] LPCWSTR pszDescription);
+
+    HRESULT SetThumbnailTooltip(
+        [in] HWND hwnd,
+        [in, unique, string] LPCWSTR pszTip);
+
+    HRESULT SetThumbnailClip(
+        [in] HWND hwnd,
+        [in] RECT* prcClip);
 }

--- a/src/FluentAvalonia/Styling/ControlThemes/Controls.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/Controls.axaml
@@ -108,7 +108,8 @@
 
                 <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml" />
                 <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxItemStyles.axaml" />
-                
+
+                <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/AppWindowStyles.axaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Styles.Resources>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/AppWindowStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/AppWindowStyles.axaml
@@ -1,0 +1,244 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:wnd="clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia"
+                    xmlns:ui="using:FluentAvalonia.UI.Controls">
+    
+    <ControlTheme TargetType="Button" x:Key="FA_SystemCaptionButton">
+        <Setter Property="Background" Value="{DynamicResource FATitle_SysCaptionBackground}" />
+        <Setter Property="BorderBrush" Value="{x:Null}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Width" Value="46" />
+        <Setter Property="Foreground" Value="{DynamicResource FATitle_SysCaptionForeground}" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}">
+                    <Viewbox Width="14"
+                             Height="14">
+                        <ui:FontIcon Name="ButtonIcon"
+                                     FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                     Glyph="{TemplateBinding Content}" />
+                    </Viewbox>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:inactive">
+            <Style Selector="^ /template/ Border">
+                <Setter Property="Background" Value="{DynamicResource FATitle_SysCaptionBackgroundInactive}" />
+            </Style>
+            <Style Selector="^ /template/ ui|FontIcon">
+                <Setter Property="Foreground" Value="{DynamicResource FATitle_SysCaptionForegroundInactive}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ Border">
+                <Setter Property="Background" Value="{DynamicResource FATitle_SysCaptionBackgroundHover}" />
+            </Style>
+            <Style Selector="^ /template/ ui|FontIcon">
+                <Setter Property="Foreground" Value="{DynamicResource FATitle_SysCaptionForegroundHover}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ Border">
+                <Setter Property="Background" Value="{DynamicResource FATitle_SysCaptionBackgroundPressed}" />
+            </Style>
+            <Style Selector="^ /template/ ui|FontIcon">
+                <Setter Property="Foreground" Value="{DynamicResource FATitle_SysCaptionForegroundPressed}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^.Close">
+            <Style Selector="^:pointerover /template/ Border">
+                <Setter Property="Background" Value="#e81123" />
+            </Style>
+            <Style Selector="^:pointerover /template/ ui|FontIcon">
+                <Setter Property="Foreground" Value="White" />
+            </Style>
+            <Style Selector="^:pressed /template/ Border">
+                <Setter Property="Background" Value="#f1707a" />
+            </Style>
+            <Style Selector="^:pressed /template/ ui|FontIcon">
+                <Setter Property="Foreground" Value="White" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5" />
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme TargetType="wnd:MinMaxCloseControl" x:Key="{x:Type wnd:MinMaxCloseControl}">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <StackPanel Orientation="Horizontal">
+                    <Button Name="MinimizeButton"
+                            Theme="{StaticResource FA_SystemCaptionButton}"
+                            Content="&#xE921;"/>
+                    <Button Name="MaxRestoreButton"
+                            Theme="{StaticResource FA_SystemCaptionButton}"
+                            Content="&#xE922;" />
+                    <Button Name="CloseButton"
+                            Theme="{StaticResource FA_SystemCaptionButton}"
+                            Content="&#xE8BB;"
+                            Classes="Close"  />
+                </StackPanel>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:maximized /template/ Button#MaxRestoreButton">
+            <Setter Property="Content" Value="&#xE923;" />
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme TargetType="wnd:AppSplashScreen" x:Key="{x:Type wnd:AppSplashScreen}">
+        <Setter Property="Background" Value="{DynamicResource CoreSplashScreenBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource CoreSplashScreenForeground}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel Name="Root"
+                       Background="{TemplateBinding Background}">
+                    <TextBlock Name="AppNameText"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Center"
+                               FontSize="{DynamicResource SplashScreenTextSize}"
+                               FontWeight="{DynamicResource SplashScreenTextFontWeight}"/>
+                    <Image Name="AppImageHost"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Center"
+                           Width="{DynamicResource SplashScreenImageWidth}"
+                           Height="{DynamicResource SplashScreenImageWidth}" />
+                    <ContentPresenter Name="ContentHost"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
+                                      HorizontalContentAlignment="Stretch"
+                                      VerticalContentAlignment="Stretch" />
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+
+    <ControlTemplate x:Key="AppWindowOnWindowsTemplate" TargetType="{x:Type wnd:AppWindow}">
+        <VisualLayerManager>
+            <!-- Because we use the System Border, we don't specify anything like that here.-->
+            <Border Background="{TemplateBinding Background}"
+                    Padding="{TemplateBinding Padding}"
+                    Name="RootBorder">
+                <Panel>
+                    <Panel Name="DefaultTitleBar"
+                           Height="{Binding TemplateSettings.TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}}"
+                           Background="{DynamicResource FATitle_TitleBarBackground}"
+                           TextElement.Foreground="{DynamicResource FATitle_TitleBarForeground}"
+                           VerticalAlignment="Top">
+
+                        <Image Source="{TemplateBinding Icon}"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Left"
+                               Width="16" Height="16"
+                               IsVisible="{Binding TemplateSettings.IsTitleBarContentVisible, RelativeSource={RelativeSource TemplatedParent}}"
+                               Margin="8 0 0 0"
+                               Name="Icon"/>
+
+                        <TextBlock Name="TitleText"
+                                   Text="{TemplateBinding Title}"
+                                   Margin="12 0 0 0"
+                                   FontSize="12"
+                                   IsVisible="{Binding TemplateSettings.IsTitleBarContentVisible, RelativeSource={RelativeSource TemplatedParent}}"
+                                   VerticalAlignment="Center"
+                                   HorizontalAlignment="Left" />
+                    </Panel>
+
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      ClipToBounds="False"
+                                      Margin="{Binding TemplateSettings.ContentMargin, RelativeSource={RelativeSource TemplatedParent}}"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}" />
+
+                    <wnd:AppSplashScreen Name="SplashHost"
+                                         IsVisible="False"/>
+
+                    <!-- Add the Caption Buttons, these should ALWAYS overlay the window -->
+                    <wnd:MinMaxCloseControl HorizontalAlignment="Right"
+                                            VerticalAlignment="Top"
+                                            Name="SystemCaptionButtons"
+                                            Height="{Binding TemplateSettings.TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}}"/>
+
+                </Panel>
+            </Border>
+        </VisualLayerManager>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="AppWindowDefaultTemplate" TargetType="{x:Type wnd:AppWindow}">
+        <Panel>
+            <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+            <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+            <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+            <VisualLayerManager>
+                <VisualLayerManager.ChromeOverlayLayer>
+                    <TitleBar />
+                </VisualLayerManager.ChromeOverlayLayer>
+                <ContentPresenter Name="PART_ContentPresenter"
+                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                  Content="{TemplateBinding Content}"
+                                  Margin="{TemplateBinding Padding}"
+                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+            </VisualLayerManager>
+            <wnd:AppSplashScreen Name="SplashHost"
+                                 IsVisible="False"/>
+        </Panel>
+    </ControlTemplate>
+
+
+    <ControlTheme TargetType="wnd:AppWindow" x:Key="{x:Type wnd:AppWindow}">
+        <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource ApplicationPageBackgroundThemeBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+        <Setter Property="Background" Value="{DynamicResource ApplicationPageBackgroundThemeBrush}" />
+        <Setter Property="Template" Value="{StaticResource AppWindowDefaultTemplate}" />
+
+        <Style Selector="^:windows">
+            <Setter Property="Template" Value="{StaticResource AppWindowOnWindowsTemplate}" />
+
+            <Style Selector="^:icon">
+                <Style Selector="^ /template/ Image#Icon">
+                    <Setter Property="IsVisible" Value="True" />
+                </Style>
+                <Style Selector="^ /template/ TextBlock#TitleText">
+                    <Setter Property="Margin" Value="32 0 0 0" />
+                </Style>
+            </Style>
+
+            <Style Selector="^[WindowState=FullScreen]">
+                <Style Selector="^ /template/ Panel#DefaultTitleBar">
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+                <Style Selector="^ /template/ wnd|MinMaxCloseControl#SystemCaptionButtons">
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+            </Style>
+
+            <Style Selector="^[IsActive=False]">
+                <Style Selector="^ /template/ Panel#DefaultTitleBar">
+                    <Setter Property="Background" Value="{DynamicResource FATitle_TitleBarBackgroundInactive}" />
+                    <Setter Property="TextElement.Foreground" Value="{DynamicResource FATitle_TitleBarForegroundInactive}" />
+                </Style>
+            </Style>
+        </Style>
+
+        <Style Selector="^:splashOpen">
+            <Style Selector="^ /template/ wnd|AppSplashScreen#SplashHost">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+        </Style>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/FluentAvalonia/UI/Controls/IconElement/FAPathIcon.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/FAPathIcon.properties.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Media;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
+using Path = Avalonia.Controls.Shapes.Path;
 
 namespace FluentAvalonia.UI.Controls;
 

--- a/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -14,6 +14,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls.Primitives;
+using FluentAvalonia.UI.Windowing;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -226,12 +227,17 @@ public partial class TaskDialog : ContentControl
             PseudoClasses.Set(s_pcHidden, false);
             PseudoClasses.Set(s_pcHosted, false);
 
-            var svc = AvaloniaLocator.Current.GetService<IFAWindowProvider>();
-            if (svc == null)
-                throw new InvalidOperationException("No window host available for TaskDialog. Be sure to reference FluentAvalonia.UI.Windowing & " +
-                    "specify .UseFAWindowing in the AppBuilder");
+            var host = new AppWindow()
+            {
+                CanResize = false,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                ShowAsDialog = true,
+                Content = this,
+                MinWidth = 100,
+                MinHeight = 100
+            };
 
-            var host = svc.CreateTaskDialogHost(this);
             if (_host == null)
             {
                 host[!Window.TitleProperty] = this[!TitleProperty];

--- a/src/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.cs
+++ b/src/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Numerics;
+﻿using System.Numerics;
 using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Animation.Easings;
@@ -17,7 +16,7 @@ using Avalonia.Rendering.Composition.Animations;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
-using FluentAvalonia.UI.Controls.Internal;
+using Path = Avalonia.Controls.Shapes.Path;
 
 namespace FluentAvalonia.UI.Controls;
 

--- a/src/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
+++ b/src/FluentAvalonia/UI/Controls/TeachingTip/TeachingTip.props.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using Avalonia;
+﻿using Avalonia;
 using System.Windows.Input;
 using Avalonia.Controls;
 using FluentAvalonia.Core;
 using Avalonia.Styling;
 using FluentAvalonia.Core.Attributes;
 using Avalonia.Controls.Metadata;
-using Avalonia.Controls.Shapes;
+using Path = Avalonia.Controls.Shapes.Path;
 
 namespace FluentAvalonia.UI.Controls;
 

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
@@ -13,6 +9,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
+using FluentAvalonia.Core;
 using FluentAvalonia.Interop;
 using FluentAvalonia.UI.Controls.Primitives;
 using FluentAvalonia.UI.Media;
@@ -97,36 +94,44 @@ public partial class AppWindow : Window, IStyleable
         if (change.Property == IconProperty)
         {
             base.Icon = new WindowIcon(change.NewValue as IBitmap);
-            PseudoClasses.Set(":icon", change.NewValue != null);
+            PseudoClasses.Set(SharedPseudoclasses.s_pcIcon, change.NewValue != null);
         }
         else if (change.Property == ActualThemeVariantProperty)
         {
             SetTitleBarColors();
         }
 
-        if (IsWindows && !_hasShown)
+        if (IsWindows)
         {
-            // HACK: Because of the frame adjustments made to AppWindow, setting the window
-            // size before it is shown will result in an incorrect window size
-            // To determine this, we check if WM_SIZE has been sent, if it hasn't, this is a
-            // user requested size and we store it and apply it in Opened
-            // Changing the size while the window is active works correctly
-            if (change.Property == WidthProperty)
+            if (change.Property == WindowStateProperty)
             {
-                var newV = change.GetNewValue<double>();
-                if (double.IsInfinity(_win32Manager.LastWMSizeSize.Width))
-                {
-                    _win32Manager.LastUserWidth = newV;
-                }
+                HandleFullScreenTransition(change.GetNewValue<WindowState>());
             }
-            else if (change.Property == HeightProperty)
+
+            if (!_hasShown)
             {
-                var newV = change.GetNewValue<double>();
-                if (double.IsInfinity(_win32Manager.LastWMSizeSize.Height))
+                // HACK: Because of the frame adjustments made to AppWindow, setting the window
+                // size before it is shown will result in an incorrect window size
+                // To determine this, we check if WM_SIZE has been sent, if it hasn't, this is a
+                // user requested size and we store it and apply it in Opened
+                // Changing the size while the window is active works correctly
+                if (change.Property == WidthProperty)
                 {
-                    _win32Manager.LastUserHeight = newV;
+                    var newV = change.GetNewValue<double>();
+                    if (double.IsInfinity(_win32Manager.LastWMSizeSize.Width))
+                    {
+                        _win32Manager.LastUserWidth = newV;
+                    }
                 }
-            }
+                else if (change.Property == HeightProperty)
+                {
+                    var newV = change.GetNewValue<double>();
+                    if (double.IsInfinity(_win32Manager.LastWMSizeSize.Height))
+                    {
+                        _win32Manager.LastUserHeight = newV;
+                    }
+                }
+            }            
         }
     }
 

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
@@ -1,0 +1,569 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using FluentAvalonia.Interop;
+using FluentAvalonia.UI.Controls.Primitives;
+using FluentAvalonia.UI.Media;
+
+namespace FluentAvalonia.UI.Windowing;
+
+public partial class AppWindow : Window, IStyleable
+{
+    public AppWindow()
+    {
+        TemplateSettings = new AppWindowTemplateSettings();
+        _titleBar = new AppWindowTitleBar(this);
+
+        if (OSVersionHelper.IsWindows() && !Design.IsDesignMode)
+        {
+            InitializeAppWindow();
+        }
+    }
+
+    static AppWindow()
+    {
+        AllowInteractionInTitleBarProperty.Changed.AddClassHandler<Control>(OnAllowInteractionInTitleBarChanged);
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var sz = base.MeasureOverride(availableSize);
+
+        // UGLY HACK: Seems with CanResize=False, the window shrinks exactly the amount
+        // we modify the window in WM_NCCALCSIZE so we need to fix that here
+        // But the content measures to the normal size - so in constrained environments
+        // like the TaskDialog, stuff gets cut off
+        if (IsWindows)
+        {
+            // TODO: This doesn't appear necessary for TaskDialog anymore, but just in case, I'll
+            //       keep this here as a reminder
+            //if (!CanResize)
+            //{
+                //var wid = (16 * PlatformImpl.RenderScaling);
+                //var hgt = (8 * PlatformImpl.RenderScaling);
+                //sz = new Size(sz.Width + wid, sz.Height + hgt);
+            //}
+
+            if (SystemCaptionControl != null)
+                _titleBar.SetInset(SystemCaptionControl.DesiredSize.Width, FlowDirection);
+        }        
+
+        return sz;
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);      
+
+        if (IsWindows && !Design.IsDesignMode)
+        {
+            _templateRoot = e.NameScope.Find<Border>("RootBorder");
+                        
+            _captionButtons = e.NameScope.Find<MinMaxCloseControl>("SystemCaptionButtons");
+            _defaultTitleBar = e.NameScope.Find<Panel>("DefaultTitleBar");
+
+            // This will set all our TemplateSettings properties
+            OnTitleBarHeightChanged(_titleBar.Height);
+
+            SetTitleBarColors();
+        }
+
+        if (SplashScreen != null)
+        {
+            var host = e.NameScope.Find<AppSplashScreen>("SplashHost");
+            if (host != null)
+            {
+                _splashContext.Host = host;
+            }
+        }
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == IconProperty)
+        {
+            base.Icon = new WindowIcon(change.NewValue as IBitmap);
+            PseudoClasses.Set(":icon", change.NewValue != null);
+        }
+        else if (change.Property == ActualThemeVariantProperty)
+        {
+            SetTitleBarColors();
+        }
+
+        if (IsWindows && !_hasShown)
+        {
+            // HACK: Because of the frame adjustments made to AppWindow, setting the window
+            // size before it is shown will result in an incorrect window size
+            // To determine this, we check if WM_SIZE has been sent, if it hasn't, this is a
+            // user requested size and we store it and apply it in Opened
+            // Changing the size while the window is active works correctly
+            if (change.Property == WidthProperty)
+            {
+                var newV = change.GetNewValue<double>();
+                if (double.IsInfinity(_win32Manager.LastWMSizeSize.Width))
+                {
+                    _win32Manager.LastUserWidth = newV;
+                }
+            }
+            else if (change.Property == HeightProperty)
+            {
+                var newV = change.GetNewValue<double>();
+                if (double.IsInfinity(_win32Manager.LastWMSizeSize.Height))
+                {
+                    _win32Manager.LastUserHeight = newV;
+                }
+            }
+        }
+    }
+
+    protected override async void OnOpened(EventArgs e)
+    {
+        if (IsWindows)
+        {
+            _hasShown = true;
+
+            if (!double.IsNaN(_win32Manager.LastUserHeight))
+            {
+                Height = _win32Manager.LastUserHeight;
+            }
+
+            if (!double.IsNaN(_win32Manager.LastUserWidth))
+            {
+                Width = _win32Manager.LastUserWidth;
+            }
+        }
+        
+
+        if (_splashContext != null && !_splashContext.HasShownSplashScreen && !Design.IsDesignMode)
+        {
+            PseudoClasses.Set(":splashOpen", true);
+            var time = DateTime.Now;
+
+            // n00b async/await mistake - need to await here, thansk to GH taj-ny for finding and fixing this
+            await _splashContext.RunJobs();
+
+            var delta = DateTime.Now - time;
+            if (delta.TotalMilliseconds < _splashContext.SplashScreen.MinimumShowTime)
+            {
+                await Task.Delay(Math.Max(1, _splashContext.SplashScreen.MinimumShowTime - (int)delta.TotalMilliseconds));
+            }
+
+            LoadApp();
+        }
+
+        base.OnOpened(e);
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _splashContext?.TryCancel();
+
+        base.OnClosed(e);     
+    }
+
+    internal void OnExtendsContentIntoTitleBarChanged(bool isExtended)
+    {
+        if (isExtended)
+        {
+            TemplateSettings.IsTitleBarContentVisible = false;
+            TemplateSettings.ContentMargin = new Thickness();
+        }
+        else
+        {
+            TemplateSettings.IsTitleBarContentVisible = true;
+            
+            if (WindowState != WindowState.FullScreen)
+                TemplateSettings.ContentMargin = new Thickness(0, _titleBar.Height, 0, 0);
+        }
+    }
+
+    internal void OnTitleBarHeightChanged(double height)
+    {
+        TemplateSettings.TitleBarHeight = height;
+        OnExtendsContentIntoTitleBarChanged(_titleBar.ExtendsContentIntoTitleBar);
+    }
+
+    internal void TitleBarColorsChanged()
+    {
+        SetTitleBarColors();
+    }
+
+    internal bool HitTestTitleBar(Point p)
+    {
+        if (_defaultTitleBar == null)
+            return false;
+
+        // Check the specified drag rectangles first - these override the default titlebar behavior
+        // If that returns null, no drag rects were specified and we use the default logic
+        var result = _titleBar.HitTestDragRects(p);
+
+        if (result.HasValue)
+        {
+            if (result.Value)
+                result = CheckExclusionList(p);
+
+            return result.Value;
+        }
+        else
+        {
+            // DEFAULT LOGIC
+
+            // We do a simple bounds check here first for the default title bar
+            // which is always present, even w/ content extended into titlebar
+
+            // What we know is that the default title bar will always be [0,0,WindowWidth,TitleBar.Height]
+            // Therefore, we only need to do check the Y coordinate
+            var hgt = _titleBar.Height * PlatformImpl.RenderScaling;
+            if (p.Y < hgt)
+            {
+                if (TitleBar.TitleBarHitTestType == TitleBarHitTestType.Complex &&
+                    !ComplexHitTest(p))
+                {
+                    return false;
+                }
+                // Now we know we're in the top part of the window designated as the titlebar
+                // We need to see if we can actually drag
+                // We need to check our exclusion list to see if we we should let the pointer event pass into
+                // the client area or say we've grabbed the title bar
+
+                return CheckExclusionList(p);
+            }
+
+            return false;
+        }
+
+
+        bool CheckExclusionList(Point p)
+        {
+            if (_excludeHitTestList != null && _excludeHitTestList.Count > 0)
+            {
+                // We don't have to read the AttachedProperty value here because we only add them to the list
+                // IF the value is true, and remove them if it's set to false later - saving us that overhead
+
+                // We iterate backwards as this is where we'll purge the list if any controls 
+                // have been GC'd and the WeakReference no longer exists
+                for (int i = _excludeHitTestList.Count - 1; i >= 0; i--)
+                {
+                    if (_excludeHitTestList[i].TryGetTarget(out var target))
+                    {
+                        // Skip invisible or disconnected controls
+                        if (!target.IsVisible || !target.IsAttachedToVisualTree())
+                            continue;
+
+                        // If control was reparented into new window, matrix may be null, catch that case
+                        var mat = target.TransformToVisual(this);
+                        if (mat.HasValue)
+                        {
+                            if (new Rect(target.Bounds.Size).TransformToAABB(mat.Value).Contains(p))
+                            {
+                                // We've hit a control that's asked to be in the titlebar but allow interaction
+                                // return false so NCHITTEST returns HTCLIENT
+                                return false;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        _excludeHitTestList.RemoveAt(i);
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+
+    internal bool ComplexHitTest(Point p)
+    {
+        var result = this.InputHitTest(p) as InputElement;
+
+        // Special case for TabViewListView during drag operations where blank space 
+        // is inserted and causes HitTest to fail (since nothing focusable is there)
+        if (result is Visual v && v.TemplatedParent is TabViewListView)
+            return false;
+
+        if (result == _defaultTitleBar)
+            return true;
+
+        while (result != null)
+        {
+            if (result.IsHitTestVisible && result.Focusable)
+                return false;
+
+            result = result.GetVisualParent() as InputElement;
+        }
+
+        return true;
+    }
+
+    internal void UpdateContentPosition(Thickness t)
+    {        
+        if (_templateRoot != null)
+            _templateRoot.Margin = t;
+    }
+
+    internal void UpdateFullScreenState(bool isFullScreen)
+    {
+        if (isFullScreen)
+        {
+            TemplateSettings.ContentMargin = new Thickness();
+        }
+        else
+        {
+            OnExtendsContentIntoTitleBarChanged(_titleBar.ExtendsContentIntoTitleBar);
+        }
+    }
+
+    internal void OnWin32WindowStateChanged(WindowState state)
+    {
+        if (state == WindowState.FullScreen)
+        {
+            TemplateSettings.ContentMargin = new Thickness();
+        }
+        else
+        {
+            OnExtendsContentIntoTitleBarChanged(_titleBar.ExtendsContentIntoTitleBar);
+        }
+    }
+
+    private void SetTitleBarColors()
+    {
+        if (_templateRoot == null)
+            return;
+
+        bool foundAccent = _templateRoot.TryFindResource(s_SystemAccentColor, out var sysColor);
+        Color? accentVariant = null;
+        var themeVar = ActualThemeVariant;
+
+        if (themeVar == ThemeVariant.Light)
+        {
+            if (_templateRoot.TryFindResource(s_SystemAccentColorDark1, out var v))
+            {
+                accentVariant = Unsafe.Unbox<Color>(v);
+            }
+        }
+        else
+        {
+            if (_templateRoot.TryFindResource(s_SystemAccentColorLight1, out var v))
+            {
+                accentVariant = Unsafe.Unbox<Color>(v);
+            }
+        }
+
+        Color textColor;
+        if (_templateRoot.TryFindResource(s_TextFillColorPrimary, themeVar, out var value))
+        {
+            textColor = Unsafe.Unbox<Color>(value);
+        }
+        else
+        {
+            if (ActualThemeVariant == ThemeVariant.Dark)
+            {
+                textColor = Colors.White;
+            }
+            else
+            {
+                textColor = Colors.Black;
+            }
+        }
+
+        SetResource(s_TitleBarBackground, _titleBar.BackgroundColor ?? Colors.Transparent);
+        SetResource(s_TitleBarForeground, _titleBar.ForegroundColor ?? textColor);
+
+        SetResource(s_TitleBarInactiveBackground, _titleBar.InactiveBackgroundColor ?? Colors.Transparent);
+        SetResource(s_TitleBarInactiveForeground, _titleBar.InactiveForegroundColor ?? Colors.Gray);
+
+        SetResource(s_SysCaptionBackground, _titleBar.ButtonBackgroundColor ?? Colors.Transparent);
+        SetResource(s_SysCaptionForeground, _titleBar.ButtonForegroundColor ?? textColor);
+
+        SetResource(s_SysCaptionBackgroundHover, _titleBar.ButtonHoverBackgroundColor ??
+            (foundAccent ? Unsafe.Unbox<Color>(sysColor) : Color.FromArgb(23, 0, 0, 0)));
+        SetResource(s_SysCaptionForegroundHover, _titleBar.ButtonHoverForegroundColor ?? textColor);
+
+        SetResource(s_SysCaptionBackgroundPressed, _titleBar.ButtonPressedBackgroundColor ??
+            (foundAccent ? Unsafe.Unbox<Color>(sysColor) : Color.FromArgb(52, 0, 0, 0)));
+        SetResource(s_SysCaptionForegroundPressed, _titleBar.ButtonPressedForegroundColor ?? GetPressedColor(textColor));
+
+        SetResource(s_SysCaptionBackgroundInactive, _titleBar.ButtonInactiveBackgroundColor ?? Colors.Transparent);
+        SetResource(s_SysCaptionForegroundInactive, _titleBar.ButtonInactiveForegroundColor ??
+            (accentVariant ?? Colors.Gray));
+
+
+        void SetResource(string name, Color color)
+        {
+            _templateRoot.Resources[name] = color;
+        }
+
+        Color GetPressedColor(Color c)
+        {
+            Color2 c2 = (Color2)c;
+            c2.GetHSLf(out _, out _, out var l, out _);
+
+            if (l < 0.5f)
+            {
+                return c2.LightenPercent(0.15f);
+            }
+            else
+            {
+                return c2.LightenPercent(-0.15f);
+            }
+        }
+    }
+
+    private static void OnAllowInteractionInTitleBarChanged(Control control, AvaloniaPropertyChangedEventArgs propChangeArgs)
+    {
+        if (control is TopLevel tl || control is Popup)
+            return; //throw new InvalidOperationException("AllowTitleBarHitTest cannot be set on TopLevels or Popups");
+
+        
+        if (propChangeArgs.GetNewValue<bool>())
+        {
+            // Control likely isn't attached to the visual tree yet so we have no way of attaching this to the 
+            // AppWindow hosting it, defer now, but we'll check first just in case
+            if (control.GetVisualRoot() is AppWindow aw)
+            {
+                aw.AddExcludeHitTestItem(control);
+            }
+            else if (!Design.IsDesignMode) // Don't attach in Design mode
+            {
+                // Defer until attached to visual tree
+                control.AttachedToVisualTree += AwaitControlAttachedToVisualTree;
+            }
+        }
+        else
+        {
+            // If we change the value to false while still connected, we'll remove it from the list
+            // Otherwise, we'll have to wait for the ref to be GC'd then we'll remove it later
+            if (control.GetVisualRoot() is AppWindow aw)
+            {
+                aw.RemoveExcludeHitTestItem(control);
+            }
+        }
+        
+        void AwaitControlAttachedToVisualTree(object sender, VisualTreeAttachmentEventArgs args)
+        {
+            var control = sender as Control;
+            control.AttachedToVisualTree -= AwaitControlAttachedToVisualTree;
+
+            if (control.GetVisualRoot() is AppWindow aw)
+            {
+                aw.AddExcludeHitTestItem(control);
+            }
+        }
+    }
+
+    private void AddExcludeHitTestItem(Control c)
+    {
+        if (_excludeHitTestList == null)
+            _excludeHitTestList = new List<WeakReference<Control>>();
+
+        for (int i = 0; i < _excludeHitTestList.Count; i++)
+        {
+            // Control was already added - can happen if removed and re-added to the visual tree and
+            // the control ref was never GC'd (like page navigation w/ cache)
+            if (_excludeHitTestList[i].TryGetTarget(out var target) && target == c)
+                return;
+        }
+
+        _excludeHitTestList.Add(new WeakReference<Control>(c));
+    }
+
+    private void RemoveExcludeHitTestItem(Control c)
+    {
+        if (_excludeHitTestList == null)
+            return;
+            
+        for (int i = _excludeHitTestList.Count - 1; i >= 0; i--)
+        {
+            if (_excludeHitTestList[i].TryGetTarget(out var target) && target == c)
+            {
+                _excludeHitTestList.RemoveAt(i);
+                return;
+            }
+        }
+    }
+
+    
+
+    private async void LoadApp()
+    {
+        if (Presenter is not ContentPresenter cp)
+            return;
+
+        cp.IsVisible = true;
+
+        using var disp = cp.SetValue(OpacityProperty, 0d, Avalonia.Data.BindingPriority.Animation);
+
+        var aniSplash = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(250),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0d),
+                    Setters =
+                    {
+                        new Setter(OpacityProperty, 1d)
+                    }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1d),
+                    Setters =
+                    {
+                        new Setter(OpacityProperty, 0d),
+                    },
+                    KeySpline = new KeySpline(0,0,0,1)
+                }
+            }
+        };
+
+        var aniCP = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(167),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0d),
+                    Setters =
+                    {
+                        new Setter(OpacityProperty, 0d)
+                    }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1d),
+                    Setters =
+                    {
+                        new Setter(OpacityProperty, 1d),
+                    },
+                    KeySpline = new KeySpline(0,0,0,1)
+                }
+            }
+        };
+
+        await Task.WhenAll(aniSplash.RunAsync(_splashContext.Host, null),
+            aniCP.RunAsync((Animatable)Presenter, null));
+
+        PseudoClasses.Set(":splashOpen", false);
+        _splashContext.HasShownSplashScreen = true;
+    }
+
+    private bool _hasShown;
+}

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
@@ -106,6 +106,7 @@ public partial class AppWindow : Window, IStyleable
             if (change.Property == WindowStateProperty)
             {
                 HandleFullScreenTransition(change.GetNewValue<WindowState>());
+                OnExtendsContentIntoTitleBarChanged(TitleBar.ExtendsContentIntoTitleBar);
             }
 
             if (!_hasShown)

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.props.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.props.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+
+namespace FluentAvalonia.UI.Windowing;
+
+public partial class AppWindow : Window, IStyleable
+{
+    /// <summary>
+    /// Defines the <see cref="TemplateSettings"/> property
+    /// </summary>
+    public static readonly StyledProperty<AppWindowTemplateSettings> TemplateSettingsProperty =
+        AvaloniaProperty.Register<AppWindow, AppWindowTemplateSettings>(nameof(TemplateSettings));
+
+    /// <summary>
+    /// Defines the <see cref="Icon"/> property
+    /// </summary>
+    public static readonly new StyledProperty<IImage> IconProperty =
+        AvaloniaProperty.Register<AppWindow, IImage>(nameof(Icon));
+
+    /// <summary>
+    /// Defines the AllowInteractionInTitleBar attached property
+    /// </summary>
+    public static readonly AttachedProperty<bool> AllowInteractionInTitleBarProperty =
+        AvaloniaProperty.RegisterAttached<AppWindow, Control, bool>("AllowInteractionInTitleBar");
+
+    /// <summary>
+    /// Gets the value of the <see cref="AllowInteractionInTitleBarProperty"/> attached property for the given control
+    /// </summary>
+    public static bool GetAllowInteractionInTitleBar(Control c) => c.GetValue(AllowInteractionInTitleBarProperty);
+
+    /// <summary>
+    /// Sets the value of the <see cref="AllowInteractionInTitleBarProperty"/> attached property for the given control
+    /// </summary>
+    /// <param name="c"></param>
+    /// <param name="b"></param>
+    public static void SetAllowInteractionInTitleBar(Control c, bool b) => c.SetValue(AllowInteractionInTitleBarProperty, b);
+
+    /// <summary>
+    /// Provides calculated data for items within the Template of AppWindow
+    /// </summary>
+    public AppWindowTemplateSettings TemplateSettings
+    {
+        get => GetValue(TemplateSettingsProperty);
+        private set => SetValue(TemplateSettingsProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the icon for the window
+    /// </summary>
+    /// <remarks>
+    /// Note that this type is <see cref="IImage"/> and not <see cref="WindowIcon"/>, like on Window
+    /// This is done to allow using a window icon in managed titlebar. Provided the
+    /// image is an <see cref="IBitmap"/>, it should convert to a WindowIcon without 
+    /// issue and you'll still get the icon in the taskbar, on other OS's, etc.
+    /// </remarks>
+    public new IImage Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value whether the AppWindow should hide its minimize/maximize buttons like 
+    /// a dialog window. This property is only respected on Windows.
+    /// </summary>
+    public bool ShowAsDialog
+    {
+        get => _hideSizeButtons;
+        set
+        {
+            _hideSizeButtons = value;
+            PseudoClasses.Set(":dialog", value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the splash screen that should show when the window first loads
+    /// </summary>
+    public IApplicationSplashScreen SplashScreen
+    {
+        get => _splashContext?.SplashScreen;
+        set
+        {
+            if (value == null)
+            {
+                if (_splashContext != null)
+                {
+                    _splashContext.Host.SplashScreen = null;
+                }
+
+                _splashContext = null;
+                PseudoClasses.Set(":splashScreen", false);
+            }
+            else
+            {
+                _splashContext = new SplashScreenContext(value);
+                PseudoClasses.Set(":splashScreen", true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the Titlebar description information for the AppWindow
+    /// </summary>
+    /// <remarks>
+    /// Use this property to customize the colors, height, and whether the window contents should
+    /// display in the titlebar area
+    /// </remarks>
+    public AppWindowTitleBar TitleBar => _titleBar;
+
+    /// <summary>
+    /// Gets the interface for custom platform-specific features through the AppWindow class
+    /// NOTE: Only implemented on Windows right now
+    /// </summary>
+    public IAppWindowPlatformFeatures PlatformFeatures { get; private set; }
+
+    protected internal bool IsWindows11 { get; internal set; }
+
+    protected internal bool IsWindows { get; internal set; }
+
+    Type IStyleable.StyleKey => typeof(AppWindow);
+
+    internal MinMaxCloseControl SystemCaptionControl => _captionButtons;
+
+
+    private SplashScreenContext _splashContext;
+    private Border _templateRoot;
+    private MinMaxCloseControl _captionButtons;
+    private Panel _defaultTitleBar;
+    private AppWindowTitleBar _titleBar;
+    private List<WeakReference<Control>> _excludeHitTestList;
+    private bool _hideSizeButtons;
+
+    // Resource names used in SetTitleBarColors
+    private static readonly string s_SystemAccentColor = "SystemAccentColor";
+    private static readonly string s_SystemAccentColorLight1 = "SystemAccentColorLight1";
+    private static readonly string s_SystemAccentColorDark1 = "SystemAccentColorDark1";
+    private static readonly string s_TextFillColorPrimary = "TextFillColorPrimary";
+
+    private static readonly string s_TitleBarBackground = "FATitle_TitleBarBackground";
+    private static readonly string s_TitleBarForeground = "FATitle_TitleBarForeground";
+    private static readonly string s_TitleBarInactiveBackground = "FATitle_TitleBarBackgroundInactive";
+    private static readonly string s_TitleBarInactiveForeground = "FATitle_TitleBarForegroundInactive";
+    private static readonly string s_SysCaptionBackground = "FATitle_SysCaptionBackground";
+    private static readonly string s_SysCaptionForeground = "FATitle_SysCaptionForeground";
+    private static readonly string s_SysCaptionBackgroundHover = "FATitle_SysCaptionBackgroundHover";
+    private static readonly string s_SysCaptionForegroundHover = "FATitle_SysCaptionForegroundHover";
+    private static readonly string s_SysCaptionBackgroundPressed = "FATitle_SysCaptionBackgroundPressed";
+    private static readonly string s_SysCaptionForegroundPressed = "FATitle_SysCaptionForegroundPressed";
+    private static readonly string s_SysCaptionBackgroundInactive = "FATitle_SysCaptionBackgroundInactive";
+    private static readonly string s_SysCaptionForegroundInactive = "FATitle_SysCaptionForegroundInactive";
+}

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindowTemplateSettings.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindowTemplateSettings.cs
@@ -1,0 +1,74 @@
+﻿using Avalonia;
+using Avalonia.Media;
+
+namespace FluentAvalonia.UI.Windowing;
+
+/// <summary>
+/// Defines settings used in the template of an <see cref="AppWindow"/> (Windows Only)
+/// </summary>
+public class AppWindowTemplateSettings : AvaloniaObject
+{
+    /// <summary>
+    /// Defines the <see cref="TitleBarHeight"/> property
+    /// </summary>
+    public static readonly StyledProperty<double> TitleBarHeightProperty =
+        AvaloniaProperty.Register<AppWindowTemplateSettings, double>(nameof(TitleBarHeight), 32d);
+
+    /// <summary>
+    /// Defines the <see cref="ContentMargin"/> property
+    /// </summary>
+    public static readonly StyledProperty<Thickness> ContentMarginProperty =
+        AvaloniaProperty.Register<AppWindowTemplateSettings, Thickness>(nameof(ContentMargin));
+
+    /// <summary>
+    /// Defines the <see cref="IsTitleBarContentVisible"/> property
+    /// </summary>
+    public static readonly StyledProperty<bool> IsTitleBarContentVisibleProperty =
+        AvaloniaProperty.Register<AppWindowTemplateSettings, bool>(nameof(IsTitleBarContentVisible));
+
+    /// <summary>
+    /// Defines the <see cref="WindowIcon"/> property
+    /// </summary>
+    public static readonly StyledProperty<IImage> WindowIconProperty =
+        AvaloniaProperty.Register<AppWindowTemplateSettings, IImage>(nameof(WindowIcon));
+
+    /// <summary>
+    /// Gets or sets the height of the managed titlebar for AppWindow
+    /// </summary>
+    public double TitleBarHeight
+    {
+        get => GetValue(TitleBarHeightProperty);
+        set => SetValue(TitleBarHeightProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the window content margin for AppWindow
+    /// </summary>
+    /// <remarks>
+    /// This value is calculated based on WindowState, title bar height and whether
+    /// the content is extended into the titlebar area
+    /// </remarks>
+    public Thickness ContentMargin
+    {
+        get => GetValue(ContentMarginProperty);
+        set => SetValue(ContentMarginProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the titlebar content is visible (Icon and App name text)
+    /// </summary>
+    public bool IsTitleBarContentVisible
+    {
+        get => GetValue(IsTitleBarContentVisibleProperty);
+        set => SetValue(IsTitleBarContentVisibleProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the icon used in the managed titlebar of AppWindow
+    /// </summary>
+    public IImage WindowIcon
+    {
+        get => GetValue(WindowIconProperty);
+        set => SetValue(WindowIconProperty, value);
+    }
+}

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindowTitleBar.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindowTitleBar.cs
@@ -1,0 +1,354 @@
+﻿using Avalonia;
+using Avalonia.Media;
+using Avalonia.Utilities;
+
+namespace FluentAvalonia.UI.Windowing;
+
+/// <summary>
+/// Values describing the complexity the title bar hit test logic should use
+/// </summary>
+public enum TitleBarHitTestType
+{
+    /// <summary>
+    /// Hit testing is done with a simple bounds check
+    /// </summary>
+    Simple,
+
+    /// <summary>
+    /// Hit testing is done with bounds checks first, then
+    /// uses the current Renderer to hit test visuals to check
+    /// for interactive content
+    /// </summary>
+    /// <remarks>
+    /// Use this if you're using something like a TabView or NavigationView
+    /// where managing the drag rectangles manually may be too cumbersome
+    /// </remarks>
+    Complex
+}
+
+
+public class AppWindowTitleBar
+{
+    internal AppWindowTitleBar(AppWindow parent)
+    {
+        _parent = parent;
+    }
+
+    /// <summary>
+    /// Gets or sets the background color of the title bar when the window is active
+    /// </summary>
+    public Color? BackgroundColor
+    {
+        get => _backgroundColor;
+        set
+        {
+            if (_backgroundColor != value)
+            {
+                _backgroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color of the title bar when the window is active
+    /// </summary>
+    public Color? ForegroundColor
+    {
+        get => _foregroundColor;
+        set
+        {
+            if (_foregroundColor != value)
+            {
+                _foregroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the background color of the title bar when the window is inactive
+    /// </summary>
+    public Color? InactiveBackgroundColor
+    {
+        get => _inactiveBackgroundColor;
+        set
+        {
+            if (_inactiveBackgroundColor != value)
+            {
+                _inactiveBackgroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color of the title bar when the window is inactive
+    /// </summary>
+    public Color? InactiveForegroundColor
+    {
+        get => _inactiveForegroundColor; 
+        set
+        {
+            if (_inactiveForegroundColor != value)
+            {
+                _inactiveForegroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the background color of the caption buttons when the window is active
+    /// </summary>
+    public Color? ButtonBackgroundColor
+    {
+        get => _buttonBackgroundColor; 
+        set
+        {
+            if (_buttonBackgroundColor != value)
+            {
+                _buttonBackgroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color of the caption buttons when the window is active
+    /// </summary>
+    public Color? ButtonForegroundColor
+    {
+        get => _buttonForegroundColor; 
+        set
+        {
+            if (_buttonForegroundColor != value)
+            {
+                _buttonForegroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the background color of the caption buttons when the window is active
+    /// and the pointer is over the minimize or maximize button
+    /// </summary>
+    public Color? ButtonHoverBackgroundColor
+    {
+        get => _buttonHoverBackgroundColor;
+        set
+        {
+            if (_buttonHoverBackgroundColor != value)
+            {
+                _buttonHoverBackgroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color of the caption buttons when the window is active
+    /// and the pointer is over the minimize or maximize button
+    /// </summary>
+    public Color? ButtonHoverForegroundColor
+    {
+        get => _buttonHoverForegroundColor; 
+        set
+        {
+            if (_buttonHoverForegroundColor != value)
+            {
+                _buttonHoverForegroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the background color of the caption buttons when the window is active
+    /// and the pointer is pressed on the minimize or maximize button
+    /// </summary>
+    public Color? ButtonPressedBackgroundColor
+    {
+        get => _buttonPressedBackgroundColor;
+        set
+        {
+            if (_buttonPressedBackgroundColor != value)
+            {
+                _buttonPressedBackgroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color of the caption buttons when the window is active
+    /// and the pointer is pressed on the minimize or maximize button
+    /// </summary>
+    public Color? ButtonPressedForegroundColor
+    {
+        get => _buttonPressedForegroundColor; 
+        set
+        {
+            if (_buttonPressedForegroundColor != value)
+            {
+                _buttonPressedForegroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the background color of the caption buttons when the window is inactive
+    /// </summary>
+    public Color? ButtonInactiveBackgroundColor
+    {
+        get => _buttonInactiveBackgroundColor; 
+        set
+        {
+            if (_buttonInactiveBackgroundColor != value)
+            {
+                _buttonInactiveBackgroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color of the caption buttons when the window is inactive
+    /// </summary>
+    public Color? ButtonInactiveForegroundColor
+    {
+        get => _buttonInactiveForegroundColor; 
+        set
+        {
+            if (_buttonInactiveForegroundColor != value)
+            {
+                _buttonInactiveForegroundColor = value;
+                _parent.TitleBarColorsChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether the window content should display in the title bar area of the window
+    /// </summary>
+    public bool ExtendsContentIntoTitleBar
+    {
+        get => _extendsContentIntoTitleBar;
+        set
+        {
+            if (_extendsContentIntoTitleBar != value)
+            {
+                _extendsContentIntoTitleBar = value;
+                _parent.OnExtendsContentIntoTitleBarChanged(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets how the hit test logic should handle hit testing controls that are placed
+    /// in the title bar drag rect region
+    /// </summary>
+    public TitleBarHitTestType TitleBarHitTestType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the default title bar
+    /// </summary>
+    /// <remarks>
+    /// If <see cref="ExtendsContentIntoTitleBar" /> is true, this value describes the height of the
+    /// default drag rect and caption buttons only. If custom drag rects are set, only the caption
+    /// buttons are affected by this
+    /// </remarks>
+    public double Height
+    {
+        get => _height;
+        set
+        {
+            if (!MathUtilities.AreClose(_height, value))
+            {
+                _height = value;
+                _parent.OnTitleBarHeightChanged(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the system reserved region for caption buttons
+    /// </summary>
+    /// <remarks>
+    /// This value is always zero in LTR mode. In RTL mode, this value is constant unless
+    /// render scaling changes on the window
+    /// </remarks>
+    public double LeftInset => _leftInset;
+
+    /// <summary>
+    /// Gets or sets the system reserved region for caption buttons
+    /// </summary>
+    /// <remarks>
+    /// This value is always zero in RTL mode. In LTR mode, this value is constant unless
+    /// render scaling changes on the window
+    /// </remarks>
+    public double RightInset => _rightInset;
+
+    /// <summary>
+    /// Sets custom specified drag regions for the window. Setting this value overrides the 
+    /// default drag rect. Pass null to restore to the default.
+    /// </summary>
+    public void SetDragRectangles(Rect[] value)
+    {
+        _dragRects = value;
+    }
+
+    internal bool? HitTestDragRects(Point p)
+    {
+        if (_dragRects == null)
+            return null;
+
+        for (int i = 0; i < _dragRects.Length; i++)
+        {
+            if (_dragRects[i].Contains(p))
+            {
+                if (TitleBarHitTestType == TitleBarHitTestType.Simple)
+                    return true;
+
+                return _parent.ComplexHitTest(p);
+            }
+        }
+
+        return false;
+    }
+
+    internal void SetInset(double inset, FlowDirection dir)
+    {
+        if (dir == FlowDirection.LeftToRight)
+        {
+            _leftInset = inset;
+            _rightInset = 0;
+        }
+        else
+        {
+            _rightInset = inset;
+            _leftInset = 0;
+        }
+    }
+
+    private AppWindow _parent;
+    private Color? _backgroundColor;
+    private Color? _buttonBackgroundColor;
+    private Color? _buttonForegroundColor;
+    private Color? _buttonHoverBackgroundColor;
+    private Color? _buttonHoverForegroundColor;
+    private Color? _buttonInactiveBackgroundColor;
+    private Color? _buttonInactiveForegroundColor;
+    private Color? _buttonPressedBackgroundColor;
+    private Color? _buttonPressedForegroundColor;
+    private bool _extendsContentIntoTitleBar;
+    private Color? _foregroundColor;
+    private double _height = 32;
+    private Color? _inactiveBackgroundColor;
+    private Color? _inactiveForegroundColor;
+    private Rect[] _dragRects;
+    private double _leftInset;
+    private double _rightInset;
+}

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/IAppWindowPlatformFeatures.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/IAppWindowPlatformFeatures.cs
@@ -1,0 +1,34 @@
+﻿using Avalonia.Media;
+
+namespace FluentAvalonia.UI.Windowing;
+
+public enum TaskBarProgressBarState
+{
+    None = 0x00000000,
+    Normal = 0x00000002,
+    Paused = 0x00000008,
+    Error = 0x00000004,
+    Indeterminate = 0x00000001
+}
+
+/// <summary>
+/// Provides a set of function that enable platform-specific functionality through AppWindow
+/// These function are only available on Windows at the current time
+/// </summary>
+public interface IAppWindowPlatformFeatures
+{
+    /// <summary>
+    /// Windows11 only, sets the border color of the current window to the specified color
+    /// </summary>
+    void SetWindowBorderColor(Color color);
+
+    /// <summary>
+    /// Activate the taskbar progressbar indicator with the given state
+    /// </summary>
+    void SetTaskBarProgressBarState(TaskBarProgressBarState state);
+
+    /// <summary>
+    /// Activate the taskbar progressbar indicator with the given values
+    /// </summary>
+    void SetTaskBarProgressBarValue(ulong currentValue, ulong totalValue);
+}

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/IApplicationSplashScreen.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/IApplicationSplashScreen.cs
@@ -1,0 +1,44 @@
+﻿using Avalonia.Media;
+
+namespace FluentAvalonia.UI.Windowing;
+
+/// <summary>
+/// Defines a user specified UWP-like SplashScreen for CoreWindow
+/// </summary>
+public interface IApplicationSplashScreen
+{
+    /// <summary>
+    /// Specifies the name of the Application to display during the SplashScreen
+    /// </summary>
+    string AppName { get; }
+
+    /// <summary>
+    /// Specifies the desired image to be shown during the SplashScreen
+    /// </summary>
+    IImage AppIcon { get; }
+
+    /// <summary>
+    /// Specifies custom content to be shown during the SplashScreen
+    /// </summary>
+    object SplashScreenContent { get; }
+
+    /// <summary>
+    /// Called by CoreWindow to run necessary background tasks during the splashscreen
+    /// </summary>
+    /// <remarks>
+    /// This method is called in a background thread (i.e., you don't need to include your own Task). 
+    /// Remember that UI thread related tasks must be posted to the dispatcher from this method
+    /// </remarks>
+    void RunTasks();
+
+    /// <summary>
+    /// Specifies the minimum show time (in milliseconds) for the SplashScreen.
+    /// </summary>
+    /// <remarks>
+    /// For quick background loading jobs, you may get undesirable visual effects from the window opening,
+    /// and immediately switching from Splash to main content. If the background tasks (i.e., RunTasks()) 
+    /// finishes before this time, the background thread will hold until the desired time elapses, before
+    /// returning to let CoreWindow finish opening.
+    /// </remarks>
+    int MinimumShowTime { get; }
+}

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/MinMaxCloseControl.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/MinMaxCloseControl.cs
@@ -1,0 +1,181 @@
+﻿using Avalonia.Controls;
+using Avalonia;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Input;
+using System.Reactive.Disposables;
+using System;
+
+namespace FluentAvalonia.UI.Windowing;
+
+public class MinMaxCloseControl : TemplatedControl
+{
+    public MinMaxCloseControl()
+    {
+        KeyboardNavigation.SetIsTabStop(this, false);
+    }
+
+    internal Button MinimizeButton => _minimizeButton;
+
+    internal Button MaximizeButton => _maximizeButton;
+
+    internal Button CloseButton => _closeButton;
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        if (_minimizeButton != null)
+            _minimizeButton.Click -= OnButtonClick;
+
+        if (_maximizeButton != null)
+            _maximizeButton.Click -= OnButtonClick;
+
+        if (_closeButton != null)
+            _closeButton.Click -= OnButtonClick;
+
+        base.OnApplyTemplate(e);
+
+        // Changed to.Get<>(), template shouldn't be messed with to extent these items aren't found
+        // anymore, so throw if we have an invalid template
+        _minimizeButton = e.NameScope.Get<Button>("MinimizeButton");
+        _minimizeButton.Click += OnButtonClick;
+
+        _maximizeButton = e.NameScope.Get<Button>("MaxRestoreButton");
+        _maximizeButton.Click += OnButtonClick;
+
+        _closeButton = e.NameScope.Get<Button>("CloseButton");
+        _closeButton.Click += OnButtonClick;
+
+        // MinMaxCloseControl should only be used in Template of AppWindow - so TemplatedParent
+        // here should A) never be null, and B) Always be AppWindow
+        _owner = TemplatedParent as AppWindow;
+        _owner.Opened += OwnerWindowOpened;
+
+        if (_owner.ShowAsDialog)
+        {
+            _minimizeButton.IsVisible = false;
+            _maximizeButton.IsVisible = false;
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+
+        _windowStateObservable?.Dispose();
+        _windowStateObservable = null;
+    }
+
+    private void OwnerWindowOpened(object sender, EventArgs args)
+    {
+        _windowStateObservable = new CompositeDisposable(
+            _owner.GetObservable(Window.WindowStateProperty).Subscribe(OnWindowStateChanged),
+            _owner.GetObservable(WindowBase.IsActiveProperty).Subscribe(OnWindowActiveChanged));
+    }
+
+    private void OnButtonClick(object sender, RoutedEventArgs e)
+    {
+        if (_owner == null)
+            return;
+
+        if (sender == _minimizeButton)
+        {
+            _owner.WindowState = WindowState.Minimized;
+        }
+        else if (sender == _maximizeButton)
+        {
+            if (_owner.WindowState == WindowState.Maximized)
+            {
+                _owner.WindowState = WindowState.Normal;
+            }
+            else if (_owner.WindowState == WindowState.Normal)
+            {
+                _owner.WindowState = WindowState.Maximized;
+            }
+        }
+        else if (sender == _closeButton)
+        {
+            _owner.Close();
+        }
+    }
+
+    private void OnWindowStateChanged(WindowState state)
+    {
+        PseudoClasses.Set(":maximized", state == WindowState.Maximized);
+        PseudoClasses.Set(":fullscreen", state == WindowState.FullScreen);
+    }
+
+    private void OnWindowActiveChanged(bool active)
+    {
+        ((IPseudoClasses)MinimizeButton.Classes).Set(":inactive", !active);
+        ((IPseudoClasses)MaximizeButton.Classes).Set(":inactive", !active);
+        ((IPseudoClasses)CloseButton.Classes).Set(":inactive", !active);
+    }
+
+    internal bool HitTest(Point p, out bool isMaximize)
+    {
+        isMaximize = false;
+        if (_maximizeButton == null)
+            return false;
+
+        var mat = this.TransformToVisual(_owner).Value;
+        var bnds = new Rect(Bounds.Size).TransformToAABB(mat);
+
+        if (bnds.Contains(p))
+        {
+            mat = _maximizeButton.TransformToVisual(_owner).Value;
+            bnds = new Rect(_maximizeButton.Bounds.Size).TransformToAABB(mat);
+
+            isMaximize = bnds.Contains(p);
+            return true;
+        }
+
+        return false;
+    }
+
+    internal bool HitTestMaxButton(Point pos)
+    {
+        if (_maximizeButton == null)
+            return false;
+
+        var mat = _maximizeButton.TransformToVisual(_owner).Value;
+        var bnds = new Rect(_maximizeButton.Bounds.Size).TransformToAABB(mat);
+
+        return bnds.Contains(pos);
+    }
+
+    internal void ClearMaximizedState()
+    {
+        FakeMaximizePressed(false);
+        FakeMaximizeHover(false);
+    }
+
+    internal void FakeMaximizeHover(bool hover)
+    {
+        if (_maximizeButton != null)
+        {
+            // We can't set the IsPointerOver property b/c it's readonly and that make things angry
+            // so we'll just force set the Pseudoclass
+            ((IPseudoClasses)_maximizeButton.Classes).Set(":pointerover", hover);
+            //_maximizeButton.SetValue(InputElement.IsPointerOverProperty, hover);
+        }
+    }
+
+    internal void FakeMaximizePressed(bool pressed)
+    {
+        if (_maximizeButton != null)
+        {
+            _maximizeButton.SetValue(Button.IsPressedProperty, pressed);
+        }
+    }
+
+    internal void FakeMaximizeClick()
+    {
+        OnButtonClick(_maximizeButton, null);
+    }
+
+    private IDisposable _windowStateObservable;
+    private AppWindow _owner;
+    private Button _minimizeButton;
+    private Button _maximizeButton;
+    private Button _closeButton;
+}

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/SplashScreenContext.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/SplashScreenContext.cs
@@ -1,0 +1,80 @@
+﻿using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace FluentAvalonia.UI.Windowing;
+
+internal class SplashScreenContext
+{
+    public SplashScreenContext(IApplicationSplashScreen splash)
+    {
+        SplashScreen = splash;
+    }
+
+    public IApplicationSplashScreen SplashScreen { get; }
+
+    public bool HasShownSplashScreen { get; set; }
+
+    public AppSplashScreen Host
+    {
+        get => _splashHost;
+        set
+        {
+            _splashHost = value;
+            _splashHost.SplashScreen = SplashScreen;
+        }
+    }
+
+    public async Task RunJobs()
+    {
+        _splashCTS = new CancellationTokenSource();
+        await Task.Run(() =>
+        {
+            SplashScreen.RunTasks();
+        });
+        _splashCTS.Dispose();
+        _splashCTS = null;
+    }
+
+    public void TryCancel()
+    {
+        _splashCTS?.Cancel();
+        _splashCTS?.Dispose();
+        _splashCTS = null;
+    }
+
+    private AppSplashScreen _splashHost;
+    private CancellationTokenSource _splashCTS;
+}
+
+public class AppSplashScreen : TemplatedControl
+{
+    public IApplicationSplashScreen SplashScreen { get; set; }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+
+        if (SplashScreen != null)
+        {
+            // User set content has priority
+            if (SplashScreen.SplashScreenContent != null)
+            {
+                var cp = e.NameScope.Find<ContentPresenter>("ContentHost");
+                cp.Content = SplashScreen.SplashScreenContent;
+            }
+            else if (SplashScreen.AppIcon != null) // Followed by the icon
+            {
+                var img = e.NameScope.Find<Image>("AppImageHost");
+                img.Source = SplashScreen.AppIcon;
+            }
+            else if (!string.IsNullOrEmpty(SplashScreen.AppName)) // Followed by just the app name
+            {
+                var tb = e.NameScope.Find<TextBlock>("AppNameText");
+                tb.Text = SplashScreen.AppName;
+            }
+        }
+    }
+}

--- a/src/FluentAvalonia/UI/Windowing/Win32/AppWindow.win32.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/AppWindow.win32.cs
@@ -1,0 +1,28 @@
+﻿using System.Runtime.CompilerServices;
+using FluentAvalonia.Interop;
+
+namespace FluentAvalonia.UI.Windowing;
+
+public partial class AppWindow
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void InitializeAppWindow()
+    {
+        IsWindows = true;
+        IsWindows11 = OSVersionHelper.IsWindows11();
+
+        _win32Manager = new Win32WindowManager(this);
+
+        // NOTE FOR FUTURE: 
+        // Do NOT enable these properties, doing so causes a clash of logic between here and
+        // the actual window logic within avalonia leading to the window shrinking when restoring
+        // from maximized or minimized state. 
+        //ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.NoChrome;
+        //ExtendClientAreaToDecorationsHint = true;
+        PseudoClasses.Add(":windows");
+
+        PlatformFeatures = new Win32AppWindowFeatures(this);
+    }
+
+    private Win32WindowManager _win32Manager;
+}

--- a/src/FluentAvalonia/UI/Windowing/Win32/AppWindow.win32.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/AppWindow.win32.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using Avalonia.Controls;
 using FluentAvalonia.Interop;
 
 namespace FluentAvalonia.UI.Windowing;
@@ -22,6 +23,19 @@ public partial class AppWindow
         PseudoClasses.Add(":windows");
 
         PlatformFeatures = new Win32AppWindowFeatures(this);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void HandleFullScreenTransition(WindowState state)
+    {
+        if (state == WindowState.FullScreen && !_win32Manager.IsFullscreen)
+        {
+            _win32Manager.GoToFullScreen();
+        }
+        else if (_win32Manager.IsFullscreen)
+        {
+            _win32Manager.RestoreFromFullScreen();
+        }
     }
 
     private Win32WindowManager _win32Manager;

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32AppWindowFeatures.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32AppWindowFeatures.cs
@@ -1,0 +1,79 @@
+﻿using Avalonia.Logging;
+using Avalonia.Media;
+using FluentAvalonia.Interop;
+
+namespace FluentAvalonia.UI.Windowing;
+
+internal class Win32AppWindowFeatures : IAppWindowPlatformFeatures
+{
+    public Win32AppWindowFeatures(AppWindow owner)
+    {
+        _owner = owner;
+    }
+
+    public void SetTaskBarProgressBarState(TaskBarProgressBarState state)
+    {
+        //if (_taskBarList == null)
+        //{
+        //    CreateTaskBarList();
+
+        //    // If creation fails, return 
+        //    if (_taskBarList == null)
+        //        return;
+        //}
+
+        //// Enum values are mapped to TMPF_ from Win32
+        //_taskBarList.SetProgressState(_owner.PlatformImpl.Handle.Handle, (int)state);
+    }
+
+    public void SetTaskBarProgressBarValue(ulong currentValue, ulong totalValue)
+    {
+        //if (_taskBarList == null)
+        //{
+        //    CreateTaskBarList();
+
+        //    // If creation fails, return 
+        //    if (_taskBarList == null)
+        //        return;
+        //}
+
+        //_taskBarList.SetProgressValue(_owner.PlatformImpl.Handle.Handle, currentValue, totalValue);
+    }
+
+    public unsafe void SetWindowBorderColor(Color color)
+    {
+        //// This is only available on Windows 11 right now, but don't bring the whole app down
+        //// if called on Win 10
+        //if (OSVersionHelper.IsWindows11())
+        //{
+        //    // DON'T USE .ToUint32, COLORREF has B & R components switched
+        //    // and expects alpha to be 0 (it will return hr = Parameter not correct)
+        //    COLORREF cr = ((uint)0 << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | (uint)color.R;
+        //    var hr = (HRESULT)DwmSetWindowAttribute(_owner.PlatformImpl.Handle.Handle, DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR,
+        //        &cr, sizeof(COLORREF));
+        //    if (!hr.SUCCEEDED)
+        //    {
+        //        Logger.TryGet(LogEventLevel.Debug, "AppWindow")?
+        //            .Log("SetWindowBorderColor", "Failed to set the border color of the window with hr: {hr}", hr);
+        //    }
+        //}
+    }
+
+    private unsafe void CreateTaskBarList()
+    {
+        //try
+        //{
+        //    _taskBarList = Win32.Win32Interop.CreateInstance<ITaskbarList3>(
+        //        Win32.Win32Interop.ITaskBarList3CLSID,
+        //        Win32.Win32Interop.ITaskBarList3IID);
+        //}
+        //catch (Exception ex)
+        //{
+        //    Logger.TryGet(LogEventLevel.Debug, "AppWindow")?
+        //            .Log("SetWindowBorderColor", "Unable to create instance of ITaskbarList3", ex);
+        //}
+    }
+
+    private AppWindow _owner;
+   // private ITaskbarList3 _taskBarList;
+}

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
@@ -1,0 +1,433 @@
+﻿using static FluentAvalonia.Interop.Win32Interop;
+using Avalonia.Controls;
+using FluentAvalonia.Interop.Win32;
+using Avalonia;
+using Avalonia.Logging;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace FluentAvalonia.UI.Windowing;
+
+internal unsafe class Win32WindowManager
+{
+    public Win32WindowManager(AppWindow window)
+    {
+        _window = window;
+
+        Hwnd = (HWND)_window.PlatformImpl.Handle.Handle;
+        
+
+        _oldWndProc = GetWindowLongPtrW(Hwnd, GWLP_WNDPROC);
+
+#if NET5_0_OR_GREATER
+        _appWindowRegistry.Add(Hwnd, this);
+        _wndProc = (nint)(delegate* unmanaged<HWND, uint, WPARAM, LPARAM, LRESULT>)&WndProcStatic;
+#else
+        _wndProc = Marshal.GetFunctionPointerForDelegate(WndProc);
+#endif
+
+        SetWindowLongPtrW(Hwnd, GWLP_WNDPROC, _wndProc);
+    }
+
+    public HWND Hwnd { get; }
+
+    public Size LastWMSizeSize { get; set; } = Size.Infinity;
+
+    public double LastUserWidth { get; set; } = double.NaN;
+
+    public double LastUserHeight { get; set; } = double.NaN;
+
+    private LRESULT WndProc(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam)
+    {
+        switch (msg)
+        {
+            case WM_ACTIVATE:
+                EnsureExtended();
+                break;
+
+            case WM_NCCALCSIZE:
+                if ((WPARAM)wParam != 0)
+                {
+                    return HandleNCCALCSIZE((WPARAM)wParam, (LPARAM)lParam);
+                }
+
+                return 0;
+
+            case WM_NCHITTEST:
+                return HandleNCHITTEST(lParam);
+
+            case WM_SIZE:
+                var pt = PointFromLParam(lParam);
+                LastWMSizeSize = new Size(pt.X, pt.Y);
+
+                if (_fakingMaximizeButton)
+                {
+                    _wasFakeMaximizeDown = false;
+                    _window.SystemCaptionControl.ClearMaximizedState();
+                }
+
+                EnsureExtended();
+                return CallWindowProcW(_oldWndProc, hWnd, msg, wParam, lParam);
+
+            case WM_NCLBUTTONDOWN:
+                if (_fakingMaximizeButton)
+                {
+                    var point = _window.PointToClient(PointFromLParam(lParam));
+                    _window.SystemCaptionControl.FakeMaximizePressed(_window.SystemCaptionControl.HitTestMaxButton(point));
+                    _wasFakeMaximizeDown = true;
+
+                    // This is important. If we don't tell the System we've handled this, we'll get that
+                    // classic Win32 button showing when we mouse press, and that's not good
+                    return 0;
+                }
+                break;
+
+            case WM_NCLBUTTONUP:
+                if (_fakingMaximizeButton && _wasFakeMaximizeDown)
+                {
+                    _window.SystemCaptionControl.FakeMaximizePressed(false);
+                    _wasFakeMaximizeDown = false;
+                    _window.SystemCaptionControl.FakeMaximizeClick();
+
+                    return 0;
+                }
+                break;
+
+            case WM_RBUTTONUP:
+                HandleRBUTTONUP(lParam);
+                break;
+
+            case WM_SYSCOMMAND:
+                // Enables ALT+SPACE to open the system menu
+                if ((WPARAM)wParam == SC_KEYMENU)
+                {
+                    return DefWindowProcW((HWND)hWnd, msg, (WPARAM)wParam, lParam);
+                }
+                break;
+
+            case WM_SETTINGCHANGE:
+                {
+                    HandleSETTINGCHANGED((WPARAM)wParam, lParam);
+                }
+                break;
+        }
+
+
+        return CallWindowProcW(_oldWndProc, hWnd, msg, wParam, lParam);
+    }
+
+    private int GetResizeHandleHeight() =>
+        GetSystemMetricsForDpi(SM_CXPADDEDBORDER, (uint)(96 * _window.PlatformImpl.RenderScaling)) +
+        GetSystemMetricsForDpi(SM_CYSIZEFRAME, (uint)(96 * _window.PlatformImpl.RenderScaling));
+
+    private int GetTopBorderHeight()
+    {
+        if (_window.WindowState == WindowState.Maximized || _window.WindowState == WindowState.FullScreen)
+        {
+            return 0;
+        }
+
+        // This is always 1 regardless of DPI
+        return 1;
+    }
+
+    private void EnsureExtended()
+    {
+        var marg = new MARGINS();
+
+        var style = (int)GetWindowLongPtr((HWND)Hwnd, -16);
+        var exStyle = (int)GetWindowLongPtr((HWND)Hwnd, -20);
+
+        RECT frame;
+        AdjustWindowRectExForDpi(&frame, style, false, exStyle, (int)(_window.PlatformImpl.RenderScaling * 96));
+
+        marg.topHeight = -frame.top;
+
+        var hr = DwmExtendFrameIntoClientArea((HWND)Hwnd, &marg);
+        
+        if (!hr.SUCCEEDED)
+        {
+            Logger.TryGet(LogEventLevel.Error, "AppWindow")?.Log("AppWindow.EnsureExtended", "DwmExtendFrameIntoClientArea failed with HR {hr}", hr);
+        }
+
+        SetWindowPos((HWND)Hwnd, HWND.NULL, 0, 0, 0, 0,
+            SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOREPOSITION | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+    }
+
+    private LRESULT HandleNCCALCSIZE(WPARAM wParam, LPARAM lParam)
+    {
+        var ncParams = Unsafe.Read<NCCALCSIZE_PARAMS>((void*)lParam.Value);
+
+        var originalTop = ncParams.rgrc[0].top;
+        var ret = DefWindowProcW((HWND)Hwnd, WM_NCCALCSIZE, wParam, lParam);
+        if (ret != 0)
+            return ret;
+
+        UpdateContentPosition();
+
+        var newSize = ncParams.rgrc[0];
+        newSize.top = originalTop;
+        var windowState = _window.WindowState;
+
+        if (windowState == WindowState.Maximized)
+        {
+            newSize.top += GetResizeHandleHeight();
+        }
+
+        // Fullscreen is handled for us upstream in Win32 WindowImpl - all we need to do here
+        // is remove the normal frame adjustments we do
+        // This will prevent that weird effect some apps have where the top/left is offset when the 
+        // window enters full screen 
+
+        if (windowState != WindowState.FullScreen)
+        {
+            // Use AdjustWindowRectExForDpi here to get the frame adjustments on the remaining sides
+            // Using 8 fails in high DPI scenarios, this tells us the exact difference of the NC frame
+            // and we can get accurate values that work regardless of DPI without "hacking" it
+            var style = (int)GetWindowLongPtr((HWND)Hwnd, -16);
+            var exStyle = (int)GetWindowLongPtr((HWND)Hwnd, -20);
+
+            RECT frame;
+            AdjustWindowRectExForDpi(&frame, style, false, exStyle, (int)(_window.PlatformImpl.RenderScaling * 96));
+
+            newSize.left -= frame.left; // left frame is negative, subtract to add it back
+            newSize.right -= frame.right; // right frame is positive, subtract to pull it back
+            newSize.bottom -= frame.bottom; // bottom frame is positive, subtract to pull it back
+        }
+
+        ncParams.rgrc[0] = newSize;
+
+        Unsafe.Write((void*)lParam.Value, ncParams);
+
+        return 0;
+    }
+
+    private LRESULT HandleNCHITTEST(LPARAM lParam)
+    {
+        // Because we still have the System Border (which technically extends beyond the actual window
+        // into where the Drop shadows are), we can use DefWindowProc here to handle resizing, except
+        // on the top. We'll handle that below
+        var originalRet = DefWindowProcW((HWND)Hwnd, WM_NCHITTEST, 0, lParam);
+        if (originalRet != HTCLIENT)
+            return originalRet;
+
+        // At this point, we know that the cursor is inside the client area so it
+        // has to be either the little border at the top of our custom title bar,
+        // the drag bar or something else in the XAML island. But the XAML Island
+        // handles WM_NCHITTEST on its own so actually it cannot be the XAML
+        // Island. Then it must be the drag bar or the little border at the top
+        // which the user can use to move or resize the window.
+        var point = _window.PointToClient(PointFromLParam(lParam));
+        RECT rcWindow;
+        GetWindowRect((HWND)Hwnd, &rcWindow);
+
+        // On the Top border, the resize handle overlaps with the Titlebar area, which matches
+        // a typical Win32 window or modern app window
+        var resizeBorderHeight = GetResizeHandleHeight();
+        var isOnResizeBorder = point.Y < resizeBorderHeight && !_isFullScreen;
+
+        // Make sure the caption buttons still get precedence
+        // This is where things get tricky too. On Win11, we still want to support the snap
+        // layout feature when hovering over the Maximize button. Unfortunately no API exists
+        // yet to call that manually if using a custom titlebar. But, if we return HT_MAXBUTTON
+        // here, the pointer events no longer enter the window
+        // See https://github.com/dotnet/wpf/issues/4825 for more on this...
+        // To hack our way into making this work, we'll return HT_MAXBUTTON here, but manually
+        // manage the state and handle stuff through the WM_NCLBUTTON... events
+        // This only applies on Windows 11, Windows 10 will work normally b/c no snap layout thing
+
+        if (_window.SystemCaptionControl?.HitTest(point, out var isMaximize) == true)
+        {
+            if (true && isMaximize)//_isWindows11
+            {
+                _fakingMaximizeButton = true;
+                _window.SystemCaptionControl.FakeMaximizeHover(true);
+                return HTMAXBUTTON;
+            }
+        }
+        else
+        {
+            if (_fakingMaximizeButton)
+            {
+                _fakingMaximizeButton = false;
+                _window.SystemCaptionControl?.ClearMaximizedState();
+            }
+
+            if (isOnResizeBorder)
+            {
+                if (_window.WindowState == WindowState.Maximized)
+                {
+                    return HTCAPTION;
+                }
+                else
+                {
+                    return HTTOP;
+                }
+            }
+
+            // Hit Test titlebar region, except in full screen mode
+            if (!_isFullScreen && _window.HitTestTitleBar(point))
+            {
+                return HTCAPTION;
+            }
+        }
+
+        if (_fakingMaximizeButton)
+        {
+            _fakingMaximizeButton = false;
+            _window.SystemCaptionControl?.ClearMaximizedState();
+        }
+
+        return HTCLIENT;
+    }
+
+    private unsafe void HandleRBUTTONUP(LPARAM lParam)
+    {
+        var pt = PointFromLParam(lParam);
+        if (_window.HitTestTitleBar(pt.ToPoint(_window.PlatformImpl.RenderScaling)))
+        {
+            var sysMenu = GetSystemMenu((HWND)Hwnd, false);
+            bool isMax = _window.WindowState == WindowState.Maximized;
+
+            var mii = new MENUITEMINFO
+            {
+                cbSize = (uint)sizeof(MENUITEMINFO),
+                fMask = MIIM_STATE,
+                fState = MFS_ENABLED
+            };
+            // Always enabled
+            SetMenuItemInfo(sysMenu, (uint)SC_MINIMIZE, false, &mii);
+            SetMenuItemInfo(sysMenu, (uint)SC_CLOSE, false, &mii);
+
+            // Restore only enabled if maximized
+            mii.fState = (uint)(isMax ? MFS_ENABLED : MFS_DISABLED);
+            SetMenuItemInfo(sysMenu, (uint)SC_RESTORE, false, &mii);
+
+            // Only available if normal state
+            mii.fState = (uint)(isMax ? MFS_DISABLED : MFS_ENABLED);
+            SetMenuItemInfo(sysMenu, (uint)SC_MOVE, false, &mii);
+            SetMenuItemInfo(sysMenu, (uint)SC_SIZE, false, &mii);
+            SetMenuItemInfo(sysMenu, (uint)SC_MAXIMIZE, false, &mii);
+
+            SetMenuDefaultItem(sysMenu, uint.MaxValue, 0);
+
+            var scPt = _window.PointToScreen(pt.ToPoint(_window.PlatformImpl.RenderScaling));
+
+            var ret = TrackPopupMenu(sysMenu, TPM_RETURNCMD, scPt.X, scPt.Y, 0, (HWND)Hwnd, null);
+            if (ret)
+            {
+                PostMessage((HWND)Hwnd, WM_SYSCOMMAND, (WPARAM)ret, 0);
+            }
+        }
+    }
+
+    private unsafe void HandleSETTINGCHANGED(WPARAM wParam, LPARAM lParam)
+    {
+        if (_window == null)
+            return;
+
+        //// In my testing, this message is sent 4 times for every system change...YIKES
+        //try
+        //{
+        //    var str = new string((char*)(nint)lParam);
+        //    if (str.Equals("ImmersiveColorSet", StringComparison.OrdinalIgnoreCase))
+        //    {
+        //        // Theme change was done - this is anything in the Windows Setting area,
+        //        // So it could be Light/Dark mode, or Accent Color
+        //        // Tell FATheme to requery the system theme
+        //        var faTheme = AvaloniaLocator.Current.GetRequiredService<FluentAvaloniaTheme>();
+        //        faTheme.ForceWin32WindowToTheme(_window);
+        //        faTheme.InvalidateThemingFromSystemThemeChanged();
+        //    }
+        //    else if (str.Equals("WindowsThemeElement"))
+        //    {
+        //        // When a constrast theme is activated, we get an ImmersiveColorSet message
+        //        // one with wParam = 67, one with wParam = 4131, and one with lParam
+        //        // set to "WindowsThemeElement" (the last one)
+        //        // So we'll use this to trigger an invalidation of the HighContrast theme
+        //        var faTheme = AvaloniaLocator.Current.GetRequiredService<FluentAvaloniaTheme>();
+        //        faTheme.ForceWin32WindowToTheme(_owner);
+        //        faTheme.InvalidateThemingFromSystemThemeChanged();
+        //    }
+        //}
+        //catch { }
+
+    }
+
+    private void UpdateContentPosition()
+    {
+        var topHeight = GetTopBorderHeight() / _window.PlatformImpl.RenderScaling;
+
+        // Why do we do this? We remove the entire top part of the frame between
+        // DwmExtendFrameIntoClientArea and WM_NCCALCSIZE so we need to offset the 
+        // window content by 1px to return the top frame border. Because we're doing
+        // this in the xaml part of the window, we divide by scaling to undo it so we
+        // get correct results - since scaling is automatically done for us
+        // We also need to make the top border 0 when maximized otherwise the top pixel row
+        // won't allow interactions
+        _window?.UpdateContentPosition(new Thickness(0, (topHeight == 0 && !_isFullScreen) ? (-1 / _window.PlatformImpl.RenderScaling) : topHeight, 0, 0));
+    }
+
+    private void HandleWindowStateChanged(bool isFullScreen)
+    {
+        // Avalonia's logic doesn't expect our window style to be the way it is, so when the saved window information
+        // they use is restored, it causes the window y-coor to decrease and height to grow so we need to save that
+        // information ourselves to override what they do upstream. It'll cause multiple window moves/sizes but
+        // its better than nothing and properly allows handling full screen
+        if (isFullScreen)
+        {
+            // if isFullScreen is true, this method is called before passing the WindowState upstream to Avalonia
+            // We need to store the window state ourselves to we have the required information to restore it later
+
+            _isFullScreen = true;
+
+            // To make this work we only need to store the WindowRect (including NC frame) and restore it later
+            // it automatically works this way
+            RECT rw;
+            GetWindowRect((HWND)Hwnd, &rw);
+
+            _beforeFullScreenBounds = rw;
+        }
+        else
+        {
+            // If isFullScreen is passed as false, this method is called AFTER the WindowState is handled upstream
+            // We now need to correct the window top and height using our stored information
+
+            SetWindowPos((HWND)Hwnd, HWND.NULL, _beforeFullScreenBounds.left,
+               _beforeFullScreenBounds.top,
+               _beforeFullScreenBounds.Width, _beforeFullScreenBounds.Height,
+               SWP_NOACTIVATE | SWP_NOZORDER | SWP_FRAMECHANGED);
+
+            _isFullScreen = false;
+        }
+    }
+
+
+
+#if NET5_0_OR_GREATER
+    [UnmanagedCallersOnly]
+    private static LRESULT WndProcStatic(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
+    {
+        if (_appWindowRegistry.TryGetValue(hwnd, out var wnd))
+        {
+            return wnd.WndProc(hwnd, msg, wParam, lParam);
+        }
+
+        return 0;
+    }
+
+    private static Dictionary<HWND, Win32WindowManager> _appWindowRegistry =
+        new Dictionary<HWND, Win32WindowManager>();
+#endif
+
+    private AppWindow _window;
+    private bool _fakingMaximizeButton;
+    private bool _wasFakeMaximizeDown;
+    private bool _isFullScreen;
+    private RECT _beforeFullScreenBounds;
+    private bool _hasShown;
+
+    private nint _oldWndProc;
+    private nint _wndProc;
+    
+}


### PR DESCRIPTION
As described in #303, this PR updates AppWindow to remove the dependency on Avalonia.Win32.WindowImpl, which is now internal upstream. Instead we use a WndProc hook to do what is needed. I still need to test this on Windows 10 and linux to make sure (Win 10) it functions the same, and (linux) doesn't break on other OSs (it shouldn't, but just to be safe, since this is still just win32 part).

I did manage to solve the issues I described in #303, so everything should continue working just as you expect. The only known thing is if you restore the window after full screen there is a slight stutter to the window, as Avalonia restores the window incorrectly (because it doesn't know about our frame adjustments) and then I reapply the correct position/size. It's not super obvious or distracting IMO as the window is already changing size/position so I think we'll be ok in this regard

<h2>Breaking Changes</h2>

- With the PR, `AppWindow` and all the related stuff (titlebar/splashscreen) is back in the main library. It is still under the namespace `FluentAvalonia.UI.Windowing` though.
- The `FluentAvalonia.UI.Windowing` package will be deprecated, you only need the main FluentAvaloniaUI package now
- The only changes you should have to make now (once this releases) is to:
  - Remove the windowing package reference, 
  - Remove the StyleInclude with the windowing styles (as they're now in the main styles set), 
  - and if you added `.UseFAWindowing()` for TaskDialog, take that out.
  - Xaml should be fine as the namespace hasn't changed, unless you specified the assembly (i.e., `clr-namespace:FluentAvalonia.UI.Windowing;assembly=FluentAvalonia.UI.Windowing`), which should just be changed back to FluentAvalonia

The reliance on `Avalonia.Desktop` package has been dropped, which is why AppWindow was originally placed in a separate package. Inclusion of AppWindow shouldn't mess with WASM (or other platforms where desktop isn't compatible).

One big plus to this is that AppWindow is now a type in the main assembly, which means if your app is split up into different projects for different platforms, its much easier to incorporate it. 