### PR TITLE
Various fixes

### DIFF
--- a/samples/FASandbox/MainWindow.axaml
+++ b/samples/FASandbox/MainWindow.axaml
@@ -11,20 +11,20 @@
         x:Class="FASandbox.MainWindow"
         Title="FASandbox">
 
-    <StackPanel Spacing="50">
-        <ui:SettingsExpander IconSource="Globe" Header="Test Header" IsExpanded="True"
+    <StackPanel Margin="10">
+        <ui:SettingsExpander IconSource="Globe" Header="Test Header"
                                  Description="This is a description for the SettingsExpander"
-                                 ActionIconSource="Save" IsClickEnabled="False">
+                                 ActionIconSource="Save" IsClickEnabled="True">
             <ui:SettingsExpander.Footer>
                 <Button Content="FooterButton" />
             </ui:SettingsExpander.Footer>
 
-            <ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
-            <ui:SettingsExpanderItem Content="Content Here">
-                <ui:SettingsExpanderItem.Footer>
-                    <Button Content="FooterButton" />
-                </ui:SettingsExpanderItem.Footer>
-            </ui:SettingsExpanderItem>
+            <!--<ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
+                <ui:SettingsExpanderItem Content="Content Here">
+                    <ui:SettingsExpanderItem.Footer>
+                        <Button Content="FooterButton" />
+                    </ui:SettingsExpanderItem.Footer>
+                </ui:SettingsExpanderItem>-->
         </ui:SettingsExpander>
     </StackPanel>
     

--- a/samples/FluentAvaloniaSamples/Pages/FAControlPages/NavigationViewPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/FAControlPages/NavigationViewPage.axaml
@@ -5,7 +5,7 @@
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:ctrls="using:FluentAvaloniaSamples.Controls"
              xmlns:vm="using:FluentAvaloniaSamples.ViewModels"
-             mc:Ignorable="d" d:DesignWidth="1100" d:DesignHeight="720"
+             mc:Ignorable="d" d:DesignWidth="1100" d:DesignHeight="1500"
              x:Class="FluentAvaloniaSamples.Pages.NavigationViewPage"
              x:DataType="vm:NavViewPageViewModel"
              PreviewImage="/Assets/PageIcons/NavView.jpg">
@@ -155,7 +155,7 @@ Known issues:
 
         <ctrls:ControlExample Header="NavigationView API in Action"
                               XamlSource="avares://FluentAvaloniaSamples/Pages/SampleCode/NavView6.xaml.txt">
-            <ui:NavigationView x:Name="nvSample6" Height="460"
+            <ui:NavigationView x:Name="nvSample6" Height="460" Header="asdf"
                                PaneDisplayMode="{Binding ((ComboBoxItem)SelectedItem).Content, ElementName=DispModeAPIBox}">
                 <ui:NavigationView.MenuItems>
                     <ui:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" IconSource="Play" />

--- a/samples/FluentAvaloniaSamples/Views/MainWindow.axaml.cs
+++ b/samples/FluentAvaloniaSamples/Views/MainWindow.axaml.cs
@@ -13,6 +13,8 @@ using FluentAvalonia.UI.Media;
 using FluentAvalonia.UI.Windowing;
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentAvaloniaSamples.Views;
 
@@ -33,10 +35,7 @@ public class SampleAppSplashScreen : IApplicationSplashScreen
 
     int IApplicationSplashScreen.MinimumShowTime => 2000;
 
-    void IApplicationSplashScreen.RunTasks()
-    {
-
-    }
+    Task IApplicationSplashScreen.RunTasks(CancellationToken token) => null;
 }
 
 public class MainWindow : AppWindow

--- a/src/FluentAvalonia/Interop/Win32Interop.cs
+++ b/src/FluentAvalonia/Interop/Win32Interop.cs
@@ -151,9 +151,8 @@ internal static unsafe partial class Win32Interop
             unsafe
             {
                 int dark = useDark ? 1 : 0;
-                //DwmSetWindowAttribute(hwnd, DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(int));
+                DwmSetWindowAttribute(hwnd, DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(int));
             }
-
         }
         else
         {
@@ -176,9 +175,10 @@ internal static unsafe partial class Win32Interop
             if (success == 0)
                 return false;
         }
-
+        
         // Try to get the window to redraw to reflect the changes
-        //SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0, (uint)(0x0001 | 0x0002 | 0x0004 | 0x0010 | 0x0020 | 0x0200));
+        SetWindowPos((HWND)hwnd, HWND.NULL, 0, 0, 0, 0,
+            SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
 
         return true;
     }

--- a/src/FluentAvalonia/Interop/Win32Interop.cs
+++ b/src/FluentAvalonia/Interop/Win32Interop.cs
@@ -185,6 +185,9 @@ internal static unsafe partial class Win32Interop
 
 
     public const int GWLP_WNDPROC = -4;
+    public const int GWL_STYLE = -16;
+
+    public const uint WS_MAXIMIZE = 0x01000000;
 
     public const int WM_CREATE = 0x0001;
     public const int WM_SIZE = 0x0005;

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
@@ -184,7 +184,6 @@
                                     Background="{DynamicResource ComboBoxDropDownBackground}"
                                     BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
                                     BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
-                                    Margin="0,-1,0,-1"
                                     Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
                                     HorizontalAlignment="Stretch"
                                     CornerRadius="{DynamicResource OverlayCornerRadius}">

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
@@ -145,7 +145,7 @@
                                                Grid.Column="4"
                                                Content="More"
                                                Margin="{DynamicResource TopNavigationViewOverflowButtonMargin}"
-                                               Classes="NavigationViewOverflowButtonStyleWhenPaneOnTop"
+                                               Theme="{StaticResource NavigationViewOverflowButtonStyleWhenPaneOnTop}"
                                                IsVisible="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.OverflowButtonVisibility}">
                                         <Button.Styles>
                                             <Style Selector="FlyoutPresenter">
@@ -370,7 +370,7 @@
 														ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=HeaderTemplate}"
 														VerticalContentAlignment="Stretch"
 														HorizontalContentAlignment="Stretch"
-														Classes="NavigationViewTitleHeaderContentControlTextStyle" />
+														Theme="{StaticResource NavigationViewTitleHeaderContentControlTextStyle}" />
 
                                         <ContentPresenter Grid.Row="2"
 														  Grid.ColumnSpan="2"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderStyles.axaml
@@ -3,19 +3,19 @@
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>
         <Border Padding="20" Width="700" Height="250">
-            <ui:SettingsExpander IconSource="Globe" Header="Test Header" IsExpanded="True"
+            <ui:SettingsExpander IconSource="Globe" Header="Test Header"
                                  Description="This is a description for the SettingsExpander"
-                                 ActionIconSource="Save" IsClickEnabled="False">
+                                 ActionIconSource="Save" IsClickEnabled="True">
                 <ui:SettingsExpander.Footer>
                     <Button Content="FooterButton" />
                 </ui:SettingsExpander.Footer>
                 
-                <ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
+                <!--<ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
                 <ui:SettingsExpanderItem Content="Content Here">
                     <ui:SettingsExpanderItem.Footer>
                         <Button Content="FooterButton" />
                     </ui:SettingsExpanderItem.Footer>
-                </ui:SettingsExpanderItem>
+                </ui:SettingsExpanderItem>-->
             </ui:SettingsExpander>
         </Border>
     </Design.PreviewWith>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TeachingTipStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TeachingTipStyles.axaml
@@ -4,7 +4,7 @@
                     xmlns:core="using:FluentAvalonia.Core">
 
     <Design.PreviewWith>
-        <Border Padding="50" Width="300" Height="300">
+        <Border Padding="50" Width="300" Height="300"> 
             <ui:TeachingTip Title="Change themes without hassle"
                             Subtitle="It's easier than ever to see control samples in both light and dark themes!"
                             IconSource="Refresh" IsLightDismissEnabled="False"
@@ -542,7 +542,7 @@
 
         <!-- SubTitleBlockStates -->
 
-        <Style Selector="^:showSubtitle /template/ TextBlock#SubtitleTextBlock">
+        <Style Selector="^:showSubTitle /template/ TextBlock#SubtitleTextBlock">
             <Setter Property="IsVisible" Value="True" />
         </Style>
         

--- a/src/FluentAvalonia/UI/Controls/FABorder/FABorder.cs
+++ b/src/FluentAvalonia/UI/Controls/FABorder/FABorder.cs
@@ -1,19 +1,98 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia;
+using Avalonia.Layout;
+using Avalonia.Utilities;
 
 namespace FluentAvalonia.UI.Controls;
 
 // See /Internal/BorderRenderHelper.cs for a note on some changes made compared to upstream
 // Border and BorderRenderHelper
 
-public class FABorder : Border
+public class FABorder : Decorator
 {
+    /// <summary>
+    /// Defines the <see cref="Background"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IBrush> BackgroundProperty =
+        AvaloniaProperty.Register<Border, IBrush>(nameof(Background));
+
+    /// <summary>
+    /// Defines the <see cref="BorderBrush"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IBrush> BorderBrushProperty =
+        AvaloniaProperty.Register<Border, IBrush>(nameof(BorderBrush));
+
+    /// <summary>
+    /// Defines the <see cref="BorderThickness"/> property.
+    /// </summary>
+    public static readonly StyledProperty<Thickness> BorderThicknessProperty =
+        AvaloniaProperty.Register<Border, Thickness>(nameof(BorderThickness));
+
+    /// <summary>
+    /// Defines the <see cref="CornerRadius"/> property.
+    /// </summary>
+    public static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
+        AvaloniaProperty.Register<Border, CornerRadius>(nameof(CornerRadius));
+
+    /// <summary>
+    /// Defines the <see cref="BoxShadow"/> property.
+    /// </summary>
+    public static readonly StyledProperty<BoxShadows> BoxShadowProperty =
+        AvaloniaProperty.Register<Border, BoxShadows>(nameof(BoxShadow));
+
+
+
     /// <summary>
     /// Defines the <see cref="BackgroundSizing" property
     /// </summary>
     public static readonly StyledProperty<BackgroundSizing> BackgroundSizingProperty =
         AvaloniaProperty.Register<FABorder, BackgroundSizing>(nameof(BackgroundSizing));
+
+    /// <summary>
+    /// Gets or sets a brush with which to paint the background.
+    /// </summary>
+    public IBrush Background
+    {
+        get => GetValue(BackgroundProperty);
+    set => SetValue(BackgroundProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a brush with which to paint the border.
+    /// </summary>
+    public IBrush BorderBrush
+    {
+        get => GetValue(BorderBrushProperty);
+        set => SetValue(BorderBrushProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the thickness of the border.
+    /// </summary>
+    public Thickness BorderThickness
+    {
+        get => GetValue(BorderThicknessProperty); 
+        set => SetValue(BorderThicknessProperty, value); 
+    }
+
+    /// <summary>
+    /// Gets or sets the radius of the border rounded corners.
+    /// </summary>
+    public CornerRadius CornerRadius
+    {
+        get => GetValue(CornerRadiusProperty);
+        set => SetValue(CornerRadiusProperty, value); 
+    }
+
+    /// <summary>
+    /// Gets or sets the box shadow effect parameters
+    /// </summary>
+    public BoxShadows BoxShadow
+    {
+        get => GetValue(BoxShadowProperty);
+        set => SetValue(BoxShadowProperty, value);
+    }
 
     /// <summary>
     /// Gets or sets a value that indicates how far the background extends in relation to this element's border.
@@ -22,6 +101,36 @@ public class FABorder : Border
     {
         get => GetValue(BackgroundSizingProperty);
         set => SetValue(BackgroundSizingProperty, value);
+    }
+    
+    private Thickness LayoutThickness
+    {
+        get
+        {
+            VerifyScale();
+
+            if (_layoutThickness == null)
+            {
+                var borderThickness = BorderThickness;
+
+                if (UseLayoutRounding)
+                    borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, _scale, _scale);
+
+                _layoutThickness = borderThickness;
+            }
+
+            return _layoutThickness.Value;
+        }
+    }
+
+    private void VerifyScale()
+    {
+        var currentScale = LayoutHelper.GetLayoutScale(this);
+        if (MathUtilities.AreClose(currentScale, _scale))
+            return;
+
+        _scale = currentScale;
+        _layoutThickness = null;
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -33,36 +142,55 @@ public class FABorder : Border
             if (change.Property == BackgroundProperty)
             {
                 _helper.Background = change.GetNewValue<IBrush>();
+                InvalidateVisual();
             }
             else if (change.Property == BorderBrushProperty)
             {
                 _helper.BorderBrush = change.GetNewValue<IBrush>();
+                InvalidateVisual();
             }
             else if (change.Property == BorderThicknessProperty)
             {
                 _helper.BorderThickness = change.GetNewValue<Thickness>();
+                InvalidateMeasure();
             }
             else if (change.Property == CornerRadiusProperty)
             {
                 _helper.CornerRadius = change.GetNewValue<CornerRadius>();
+                InvalidateVisual();
             }
             else if (change.Property == BoxShadowProperty)
             {
                 _helper.BoxShadow = change.GetNewValue<BoxShadows>();
+                InvalidateVisual();
             }
             else if (change.Property == BackgroundSizingProperty)
             {
                 _helper.BackgroundSizing = change.GetNewValue<BackgroundSizing>();
+                InvalidateVisual();
             }
         }
     }
 
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        return LayoutHelper.MeasureChild(Child, availableSize, Padding, BorderThickness);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        return LayoutHelper.ArrangeChild(Child, finalSize, Padding, BorderThickness);
+    }
+
     public override void Render(DrawingContext context)
     {
-        _helper ??= new BorderRenderHelper(Background, BorderBrush, BorderThickness, CornerRadius, BoxShadow, BackgroundSizing);
+        _helper ??= new BorderRenderHelper(Background, BorderBrush, BorderThickness, 
+            CornerRadius, BoxShadow, BackgroundSizing);
 
         _helper.Render(context, Bounds.Size);
     }
 
-    private BorderRenderHelper _helper;    
+    private BorderRenderHelper _helper;
+    private Thickness? _layoutThickness;
+    private double _scale;
 }

--- a/src/FluentAvalonia/UI/Controls/Frame/Frame.cs
+++ b/src/FluentAvalonia/UI/Controls/Frame/Frame.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Logging;
 using Avalonia.Threading;
 using FluentAvalonia.UI.Media.Animation;
@@ -537,21 +538,23 @@ public partial class Frame : ContentControl
 
     private void OnForwardStackChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
-        // 11.0 changed the API surface an outside implementations can no longer call RaisePropertyChanged and will need to 
-        // "Set" the property to do so. CanGoBack and CanGoForward derive their value by checking the list counts and don't
-        // use a backing boolean field so prior to 11.0 I just used RaisePropertyChanged. Now, I've made the CLR properties
-        // private set, and we use SetAndRaise but just throw away the ref param
-        CanGoForward = _forwardStack.Count > 0;
+        int oldCount = (_forwardStack.Count - (e.NewItems?.Count ?? 0) + (e.OldItems?.Count ?? 0));
+
+        bool oldForward = oldCount > 0;
+        bool newForward = _forwardStack.Count > 0;
+        RaisePropertyChanged(CanGoForwardProperty, oldForward, newForward,
+            BindingPriority.LocalValue);
     }
 
     private void OnBackStackChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
-        // 11.0 changed the API surface an outside implementations can no longer call RaisePropertyChanged and will need to 
-        // "Set" the property to do so. CanGoBack and CanGoForward derive their value by checking the list counts and don't
-        // use a backing boolean field so prior to 11.0 I just used RaisePropertyChanged. Now, I've made the CLR properties
-        // private set, and we use SetAndRaise but just throw away the ref param
-        CanGoForward = _forwardStack.Count > 0;
-        CanGoBack = _backStack.Count > 0;
+        int oldCount = (_backStack.Count - (e.NewItems?.Count ?? 0) + (e.OldItems?.Count ?? 0));
+
+        bool oldBack = oldCount > 0;
+        bool newBack = _backStack.Count > 0;
+        RaisePropertyChanged(CanGoBackProperty, oldBack, newBack, BindingPriority.LocalValue);
+        RaisePropertyChanged(BackStackDepthProperty, oldCount, _backStack.Count, 
+            BindingPriority.LocalValue);
     }
 
     private Control CreatePageAndCacheIfNecessary(Type srcPageType)

--- a/src/FluentAvalonia/UI/Controls/Frame/Frame.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/Frame/Frame.properties.cs
@@ -108,30 +108,12 @@ public partial class Frame : ContentControl
     /// <summary>
     /// Gets a value that indicates whether there is at least one entry in back navigation history.
     /// </summary>
-    public bool CanGoBack
-    {
-        get => _backStack.Count > 0;
-        private set
-        {
-            // 11.0 changed API surface for this, see OnForwardStackChanged or OnBackStackChanged for more
-            bool throwAway = (_backStack.Count - 1) > 0;
-            SetAndRaise(CanGoBackProperty, ref throwAway, value);
-        }
-    }
+    public bool CanGoBack => _backStack.Count > 0;
 
     /// <summary>
     /// Gets a value that indicates whether there is at least one entry in forward navigation history.
     /// </summary>
-    public bool CanGoForward
-    {
-        get => _forwardStack.Count > 0;
-        private set
-        {
-            // 11.0 changed API surface for this, see OnForwardStackChanged or OnBackStackChanged for more
-            bool throwAway = (_forwardStack.Count - 1) > 0;
-            SetAndRaise(CanGoForwardProperty, ref throwAway, value);
-        }
-    }
+    public bool CanGoForward=> _forwardStack.Count > 0;
 
     /// <summary>
     /// Gets a type reference for the content that is currently displayed.

--- a/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.cs
+++ b/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.cs
@@ -30,6 +30,7 @@ public partial class SettingsExpander : HeaderedItemsControl, ICommandSource
         // The Expander's template hasn't been loaded yet, so defer until later when it has
         // so we can load the ToggleButton within the template
         _expander.Loaded += ExpanderLoaded;
+        _expander.Expanding += ExpanderExpanding;
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -165,6 +166,15 @@ public partial class SettingsExpander : HeaderedItemsControl, ICommandSource
         // ControlThemes don't let is drill into sub-templates so we have to do this manually here
         // Set a style on the ToggleButton to indicate we want to hide the expand/collapse chevron
         ((IPseudoClasses)_expanderToggleButton.Classes).Set(s_pcEmpty, IsClickEnabled || ItemCount == 0);
+    }
+    
+    private void ExpanderExpanding(object sender, CancelRoutedEventArgs e)
+    {
+        if (ItemCount == 0 && IsClickEnabled)
+        {
+            e.Cancel = true;
+            e.Handled = true;
+        }
     }
 
     private void ExpanderToggleButtonClick(object sender, RoutedEventArgs e)

--- a/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -104,6 +104,7 @@ public partial class TaskDialog : ContentControl
 
         SetButtons();
         SetCommands();
+        TrySetInitialFocus();
     }
 
     private void OnKeyDownPreview(object sender, KeyEventArgs e)
@@ -209,8 +210,6 @@ public partial class TaskDialog : ContentControl
             (overlayLayer.GetVisualRoot() as ILayoutRoot).LayoutManager.ExecuteInitialLayoutPass();
 
             OnOpened();
-
-            TrySetInitialFocus();
 
             PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, true);
             PseudoClasses.Set(s_pcHidden, false);

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/IApplicationSplashScreen.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/IApplicationSplashScreen.cs
@@ -23,13 +23,9 @@ public interface IApplicationSplashScreen
     object SplashScreenContent { get; }
 
     /// <summary>
-    /// Called by CoreWindow to run necessary background tasks during the splashscreen
+    /// Called by AppWindow to run necessary background tasks during the splashscreen
     /// </summary>
-    /// <remarks>
-    /// This method is called in a background thread (i.e., you don't need to include your own Task). 
-    /// Remember that UI thread related tasks must be posted to the dispatcher from this method
-    /// </remarks>
-    void RunTasks();
+    Task RunTasks(CancellationToken cancellationToken);
 
     /// <summary>
     /// Specifies the minimum show time (in milliseconds) for the SplashScreen.
@@ -38,7 +34,7 @@ public interface IApplicationSplashScreen
     /// For quick background loading jobs, you may get undesirable visual effects from the window opening,
     /// and immediately switching from Splash to main content. If the background tasks (i.e., RunTasks()) 
     /// finishes before this time, the background thread will hold until the desired time elapses, before
-    /// returning to let CoreWindow finish opening.
+    /// returning to let AppWindow finish opening.
     /// </remarks>
     int MinimumShowTime { get; }
 }

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/SplashScreenContext.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/SplashScreenContext.cs
@@ -1,8 +1,6 @@
 ﻿using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace FluentAvalonia.UI.Windowing;
 
@@ -30,10 +28,7 @@ internal class SplashScreenContext
     public async Task RunJobs()
     {
         _splashCTS = new CancellationTokenSource();
-        await Task.Run(() =>
-        {
-            SplashScreen.RunTasks();
-        });
+        await SplashScreen.RunTasks(_splashCTS.Token);
         _splashCTS.Dispose();
         _splashCTS = null;
     }

--- a/src/FluentAvalonia/UI/Windowing/Win32/AppWindow.win32.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/AppWindow.win32.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using FluentAvalonia.Interop;
+using FluentAvalonia.Interop.Win32;
 
 namespace FluentAvalonia.UI.Windowing;
 
@@ -13,6 +14,9 @@ public partial class AppWindow
         IsWindows11 = OSVersionHelper.IsWindows11();
 
         _win32Manager = new Win32WindowManager(this);
+
+        // Force AppWindow into darkmode at the system level
+        Win32Interop.ApplyTheme(_win32Manager.Hwnd, true);
 
         // NOTE FOR FUTURE: 
         // Do NOT enable these properties, doing so causes a clash of logic between here and

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32AppWindowFeatures.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32AppWindowFeatures.cs
@@ -1,6 +1,9 @@
 ﻿using Avalonia.Logging;
 using Avalonia.Media;
 using FluentAvalonia.Interop;
+using FluentAvalonia.Interop.Win32;
+using FluentAvalonia.Interop.WinRT;
+using static FluentAvalonia.Interop.Win32Interop;
 
 namespace FluentAvalonia.UI.Windowing;
 
@@ -13,67 +16,66 @@ internal class Win32AppWindowFeatures : IAppWindowPlatformFeatures
 
     public void SetTaskBarProgressBarState(TaskBarProgressBarState state)
     {
-        //if (_taskBarList == null)
-        //{
-        //    CreateTaskBarList();
+        if (_taskBarList == null)
+        {
+            CreateTaskBarList();
 
-        //    // If creation fails, return 
-        //    if (_taskBarList == null)
-        //        return;
-        //}
+            // If creation fails, return 
+            if (_taskBarList == null)
+                return;
+        }
 
-        //// Enum values are mapped to TMPF_ from Win32
-        //_taskBarList.SetProgressState(_owner.PlatformImpl.Handle.Handle, (int)state);
+        // Enum values are mapped to TMPF_ from Win32
+        _taskBarList.SetProgressState(_owner.PlatformImpl.Handle.Handle, (int)state);
     }
 
     public void SetTaskBarProgressBarValue(ulong currentValue, ulong totalValue)
     {
-        //if (_taskBarList == null)
-        //{
-        //    CreateTaskBarList();
+        if (_taskBarList == null)
+        {
+            CreateTaskBarList();
 
-        //    // If creation fails, return 
-        //    if (_taskBarList == null)
-        //        return;
-        //}
+            // If creation fails, return 
+            if (_taskBarList == null)
+                return;
+        }
 
-        //_taskBarList.SetProgressValue(_owner.PlatformImpl.Handle.Handle, currentValue, totalValue);
+        _taskBarList.SetProgressValue(_owner.PlatformImpl.Handle.Handle, currentValue, totalValue);
     }
 
     public unsafe void SetWindowBorderColor(Color color)
     {
-        //// This is only available on Windows 11 right now, but don't bring the whole app down
-        //// if called on Win 10
-        //if (OSVersionHelper.IsWindows11())
-        //{
-        //    // DON'T USE .ToUint32, COLORREF has B & R components switched
-        //    // and expects alpha to be 0 (it will return hr = Parameter not correct)
-        //    COLORREF cr = ((uint)0 << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | (uint)color.R;
-        //    var hr = (HRESULT)DwmSetWindowAttribute(_owner.PlatformImpl.Handle.Handle, DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR,
-        //        &cr, sizeof(COLORREF));
-        //    if (!hr.SUCCEEDED)
-        //    {
-        //        Logger.TryGet(LogEventLevel.Debug, "AppWindow")?
-        //            .Log("SetWindowBorderColor", "Failed to set the border color of the window with hr: {hr}", hr);
-        //    }
-        //}
+        // This is only available on Windows 11 right now, but don't bring the whole app down
+        // if called on Win 10
+        if (OSVersionHelper.IsWindows11())
+        {
+            // DON'T USE .ToUint32, COLORREF has B & R components switched
+            // and expects alpha to be 0 (it will return hr = Parameter not correct)
+            COLORREF cr = ((uint)0 << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | (uint)color.R;
+            var hr = (HRESULT)DwmSetWindowAttribute(_owner.PlatformImpl.Handle.Handle, DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR,
+                &cr, sizeof(COLORREF));
+            if (!hr.SUCCEEDED)
+            {
+                Logger.TryGet(LogEventLevel.Debug, "AppWindow")?
+                    .Log("SetWindowBorderColor", "Failed to set the border color of the window with hr: {hr}", hr);
+            }
+        }
     }
 
     private unsafe void CreateTaskBarList()
     {
-        //try
-        //{
-        //    _taskBarList = Win32.Win32Interop.CreateInstance<ITaskbarList3>(
-        //        Win32.Win32Interop.ITaskBarList3CLSID,
-        //        Win32.Win32Interop.ITaskBarList3IID);
-        //}
-        //catch (Exception ex)
-        //{
-        //    Logger.TryGet(LogEventLevel.Debug, "AppWindow")?
-        //            .Log("SetWindowBorderColor", "Unable to create instance of ITaskbarList3", ex);
-        //}
+        try
+        {
+            _taskBarList = CreateInstance<ITaskbarList3>(
+                ITaskBarList3CLSID, ITaskBarList3IID);
+        }
+        catch (Exception ex)
+        {
+            Logger.TryGet(LogEventLevel.Debug, "AppWindow")?
+                    .Log("SetWindowBorderColor", "Unable to create instance of ITaskbarList3", ex);
+        }
     }
 
     private AppWindow _owner;
-   // private ITaskbarList3 _taskBarList;
+    private ITaskbarList3 _taskBarList;
 }

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
@@ -149,7 +149,7 @@ internal unsafe class Win32WindowManager
 
     private int GetTopBorderHeight()
     {
-        if (_window.WindowState == WindowState.Maximized || _window.WindowState == WindowState.FullScreen)
+        if (_isMaximized || _window.WindowState == WindowState.FullScreen)
         {
             return 0;
         }
@@ -196,7 +196,9 @@ internal unsafe class Win32WindowManager
         newSize.top = originalTop;
         var windowState = _window.WindowState;
 
-        if (windowState == WindowState.Maximized)
+        UpdateMaximizeState();
+                
+        if (_isMaximized)
         {
             newSize.top += GetResizeHandleHeight();
         }
@@ -370,7 +372,14 @@ internal unsafe class Win32WindowManager
         Win32Interop.ApplyTheme(Hwnd, true);
     }
 
-
+    private void UpdateMaximizeState()
+    {
+        // Using the WindowState property is unreliable - seems to fail if titlebar
+        // is double clicked, but works with the maximize button - this will work
+        // in all cases
+        var sty = GetWindowLongPtrW(Hwnd, GWL_STYLE);
+        _isMaximized = (sty & WS_MAXIMIZE) == WS_MAXIMIZE;
+    }
 
 #if NET5_0_OR_GREATER
     [UnmanagedCallersOnly]
@@ -392,8 +401,7 @@ internal unsafe class Win32WindowManager
     private bool _fakingMaximizeButton;
     private bool _wasFakeMaximizeDown;
     private bool _isFullScreen;
-    private RECT _beforeFullScreenBounds;
-    private bool _hasShown;
+    private bool _isMaximized;
 
     private nint _oldWndProc;
     private nint _wndProc;

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
@@ -6,6 +6,8 @@ using Avalonia.Logging;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Avalonia.Threading;
+using Avalonia.Platform;
+using FluentAvalonia.Interop;
 
 namespace FluentAvalonia.UI.Windowing;
 
@@ -28,6 +30,12 @@ internal unsafe class Win32WindowManager
 #endif
 
         SetWindowLongPtrW(Hwnd, GWLP_WNDPROC, _wndProc);
+
+        var ps = AvaloniaLocator.Current.GetService<IPlatformSettings>();
+        ps.ColorValuesChanged += OnPlatformColorValuesChanged;
+
+        // Force AppWindow into darkmode at the system level
+        ApplyTheme(Hwnd, true);
     }
 
     public HWND Hwnd { get; }
@@ -130,12 +138,6 @@ internal unsafe class Win32WindowManager
                 if ((WPARAM)wParam == SC_KEYMENU)
                 {
                     return DefWindowProcW((HWND)hWnd, msg, (WPARAM)wParam, lParam);
-                }
-                break;
-
-            case WM_SETTINGCHANGE:
-                {
-                    HandleSETTINGCHANGED((WPARAM)wParam, lParam);
                 }
                 break;
         }
@@ -349,39 +351,6 @@ internal unsafe class Win32WindowManager
         }
     }
 
-    private unsafe void HandleSETTINGCHANGED(WPARAM wParam, LPARAM lParam)
-    {
-        if (_window == null)
-            return;
-
-        //// In my testing, this message is sent 4 times for every system change...YIKES
-        //try
-        //{
-        //    var str = new string((char*)(nint)lParam);
-        //    if (str.Equals("ImmersiveColorSet", StringComparison.OrdinalIgnoreCase))
-        //    {
-        //        // Theme change was done - this is anything in the Windows Setting area,
-        //        // So it could be Light/Dark mode, or Accent Color
-        //        // Tell FATheme to requery the system theme
-        //        var faTheme = AvaloniaLocator.Current.GetRequiredService<FluentAvaloniaTheme>();
-        //        faTheme.ForceWin32WindowToTheme(_window);
-        //        faTheme.InvalidateThemingFromSystemThemeChanged();
-        //    }
-        //    else if (str.Equals("WindowsThemeElement"))
-        //    {
-        //        // When a constrast theme is activated, we get an ImmersiveColorSet message
-        //        // one with wParam = 67, one with wParam = 4131, and one with lParam
-        //        // set to "WindowsThemeElement" (the last one)
-        //        // So we'll use this to trigger an invalidation of the HighContrast theme
-        //        var faTheme = AvaloniaLocator.Current.GetRequiredService<FluentAvaloniaTheme>();
-        //        faTheme.ForceWin32WindowToTheme(_owner);
-        //        faTheme.InvalidateThemingFromSystemThemeChanged();
-        //    }
-        //}
-        //catch { }
-
-    }
-
     private void UpdateContentPosition()
     {
         var topHeight = GetTopBorderHeight() / _window.PlatformImpl.RenderScaling;
@@ -396,38 +365,12 @@ internal unsafe class Win32WindowManager
         _window?.UpdateContentPosition(new Thickness(0, (topHeight == 0 && !_isFullScreen) ? (-1 / _window.PlatformImpl.RenderScaling) : topHeight, 0, 0));
     }
 
-    private void HandleWindowStateChanged(bool isFullScreen)
+    private void OnPlatformColorValuesChanged(object sender, PlatformColorValues e)
     {
-        // Avalonia's logic doesn't expect our window style to be the way it is, so when the saved window information
-        // they use is restored, it causes the window y-coor to decrease and height to grow so we need to save that
-        // information ourselves to override what they do upstream. It'll cause multiple window moves/sizes but
-        // its better than nothing and properly allows handling full screen
-        if (isFullScreen)
-        {
-            // if isFullScreen is true, this method is called before passing the WindowState upstream to Avalonia
-            // We need to store the window state ourselves to we have the required information to restore it later
-
-            _isFullScreen = true;
-
-            // To make this work we only need to store the WindowRect (including NC frame) and restore it later
-            // it automatically works this way
-            RECT rw;
-            GetWindowRect((HWND)Hwnd, &rw);
-
-            _beforeFullScreenBounds = rw;
-        }
-        else
-        {
-            // If isFullScreen is passed as false, this method is called AFTER the WindowState is handled upstream
-            // We now need to correct the window top and height using our stored information
-
-            SetWindowPos((HWND)Hwnd, HWND.NULL, _beforeFullScreenBounds.left,
-               _beforeFullScreenBounds.top,
-               _beforeFullScreenBounds.Width, _beforeFullScreenBounds.Height,
-               SWP_NOACTIVATE | SWP_NOZORDER | SWP_FRAMECHANGED);
-
-            _isFullScreen = false;
-        }
+        // We need to override Avalonia's default setting of this to always keep AppWindow
+        // in dark mode, which matches what windows do on Win 10/11, regardless of the actual
+        // app or system theme.
+        Win32Interop.ApplyTheme(Hwnd, true);
     }
 
 

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
@@ -33,9 +33,6 @@ internal unsafe class Win32WindowManager
 
         var ps = AvaloniaLocator.Current.GetService<IPlatformSettings>();
         ps.ColorValuesChanged += OnPlatformColorValuesChanged;
-
-        // Force AppWindow into darkmode at the system level
-        ApplyTheme(Hwnd, true);
     }
 
     public HWND Hwnd { get; }


### PR DESCRIPTION
Quite a few minor fixes and one breaking change

[Breaking Change]
- For users of `IApplicationSplashScreen`, the RunTasks method has been changed:
```diff
public interface IApplicationSplashScreen
{
- void RunTasks()
+ Task RunTasks(CancellationToken token)
}
```
RunTasks is no longer called on a background thread, instead it is a normal Task returning method that is awaited by AppWindow. This fixes an issue where the window would continue to load as normal if longer running tasks took place. A `CancellationToken` is also provided to notify if the window is closed while the task is running.

[Other changes]
- Removed the commented lines in the Win32PlatformFeatures for AppWindow that was inadvertently left in in the rework
- AppWindow no longer listens for WM_SETTINGCHANGE. FATheme should take care of that with the new APIs and theme dictionaries
- Added logic to override Avalonia trying to put the window into light mode - which return that dreaded bug about "white border on my window" (still need to verify this works)
- Fixed the `Subtitle` of `TeachingTip` not showing
- Reverted to the old logic in Frame for the BackStack/ForwardStack properties that used RaisePropertyChange now that that is no longer internal
- Fixed the `Header` and top navigation "more button" in the NavigationView - these were just missed in the Classes -> ControlTheme updates
- Removed the margin on the ComboBox's popup that was cutting off the border
- Fixed an issue where the Expander in SettingsExpander would still try to expand when `IsClickEnabled == true` resulting in unrounded bottom corners
- Made `FABorder` inherit from Decorator and reimplement the Border properties - this had to be done since they decided to seal off the Render method. Should still work as normal - and this hopefully is only a temporary control anyway until we can get `BackgroundSizing` implemented upstream
- Fixed an issue where the top of AppWindow would get cutoff when maximized by double clicking the titlebar to maximize
- Fixed an issue where TaskDialog wouldn't accept Enter or Escape if launched in "overlay" mode (#305)