### PR TITLE
Fixes for CommandBar & Menus

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
@@ -122,7 +122,7 @@
                     </Border>
                     <Popup Name="PART_Popup"
                            WindowManagerAddShadowHint="False"
-                           PlacementMode="Right"
+                           PlacementMode="RightEdgeAlignedTop"
                            HorizontalOffset="{DynamicResource MenuFlyoutSubItemPopupHorizontalOffset}"
                            IsLightDismissEnabled="False"
                            IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuStyles.axaml
@@ -14,6 +14,12 @@
                     <MenuItem Header="New"
                               InputGesture="Ctrl+N">
                         <MenuItem Header="XML" />
+                        <MenuItem Header="XML" />
+                        <MenuItem Header="XML">
+                            <MenuItem Header="XML" />
+                            <MenuItem Header="XML" />
+                            <MenuItem Header="XML" />
+                        </MenuItem>
                     </MenuItem>
                     <MenuItem Header="Open">
                         <MenuItem.Icon>
@@ -78,6 +84,7 @@
                             </ContentPresenter.DataTemplates>
                         </ContentPresenter>
                         <Popup Name="PART_Popup"
+                               Placement="BottomEdgeAlignedLeft"
                                WindowManagerAddShadowHint="False"
                                MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
                                IsLightDismissEnabled="True"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarButtonStyles.axaml
@@ -1,12 +1,17 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:core="using:FluentAvalonia.Core"
                     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                     x:CompileBindings="True">
     <Design.PreviewWith>
         <Border Width="400" Padding="50" Height="400">
             <StackPanel Spacing="5">
                 <Border Background="SteelBlue">
-                    <ui:CommandBarButton Label="Button1" IconSource="Save" HotKey="Ctrl+S" IsCompact="True">
+                    <ui:CommandBarButton Label="Button1" 
+                                         IconSource="Save" 
+                                         HotKey="Ctrl+S" 
+                                         IsCompact="True"
+                                         core:VisualStateHelper.ForcedClassesProperty=":labelRight">
                         <ui:CommandBarButton.Flyout>
                             <Flyout />
                         </ui:CommandBarButton.Flyout>
@@ -369,6 +374,9 @@
             </Style>
             <Style Selector="^ /template/ ui|SymbolIcon#SubItemChevron">
                 <Setter Property="Margin" Value="-7,20,12,0" />
+            </Style>
+            <Style Selector="^:flyout /template/ ui|FontIcon#SubItemChevron">
+                <Setter Property="Margin" Value="{StaticResource AppBarButtonSubItemChevronLabelOnRightMargin}" />
             </Style>
         </Style>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarStyles.axaml
@@ -5,13 +5,13 @@
     <Design.PreviewWith>
         <Border Padding="50" Width="400">
             <StackPanel>
-                <ui:CommandBar ClosedDisplayMode="Compact"
+                <ui:CommandBar ClosedDisplayMode="Compact" ItemsAlignment="Left"
 							   DefaultLabelPosition="Right">
                     <ui:CommandBar.PrimaryCommands>
-                        <ui:CommandBarButton Label="Test" Icon="Save" IsCompact="False"  />
+                        <ui:CommandBarButton Label="Test" IconSource="Save" IsCompact="False"  />
                     </ui:CommandBar.PrimaryCommands>
                     <ui:CommandBar.SecondaryCommands>
-                        <ui:CommandBarButton Label="Test" Icon="Save" IsCompact="False"  />
+                        <ui:CommandBarButton Label="Test" IconSource="Save" IsCompact="False"  />
                     </ui:CommandBar.SecondaryCommands>
                 </ui:CommandBar>
             </StackPanel>
@@ -259,6 +259,10 @@
         
         <Style Selector="^:open /template/ Button#MoreButton">
             <Setter Property="VerticalAlignment" Value="Stretch" />
+        </Style>
+
+        <Style Selector="^:itemsRight /template/ ItemsControl#PrimaryItemsControl">
+            <Setter Property="HorizontalAlignment" Value="Right" />
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
+++ b/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
@@ -1196,6 +1196,7 @@
             <!-- Fontsize increased from 12 - 14 since Fluent UI icons are smaller than Segoe Fluent -->
             <x:Double x:Key="AppBarButtonSecondarySubItemChevronFontSize">14</x:Double>
             <Thickness x:Key="AppBarButtonSubItemChevronMargin">-23,20,12,0</Thickness>
+            <Thickness x:Key="AppBarButtonSubItemChevronLabelOnRightMargin">-7,20,12,0</Thickness>
             <Thickness x:Key="AppBarButtonSecondarySubItemChevronMargin">0,0,16,0</Thickness>
 
 
@@ -3145,6 +3146,7 @@
             <!-- Fontsize increased from 12 - 14 since Fluent UI icons are smaller than Segoe Fluent -->
             <x:Double x:Key="AppBarButtonSecondarySubItemChevronFontSize">14</x:Double>
             <Thickness x:Key="AppBarButtonSubItemChevronMargin">-23,20,12,0</Thickness>
+            <Thickness x:Key="AppBarButtonSubItemChevronLabelOnRightMargin">-7,20,12,0</Thickness>
             <Thickness x:Key="AppBarButtonSecondarySubItemChevronMargin">0,0,16,0</Thickness>
 
 
@@ -5145,6 +5147,7 @@
             <!-- Fontsize increased from 12 - 14 since Fluent UI icons are smaller than Segoe Fluent -->
             <x:Double x:Key="AppBarButtonSecondarySubItemChevronFontSize">14</x:Double>
             <Thickness x:Key="AppBarButtonSubItemChevronMargin">-23,20,12,0</Thickness>
+            <Thickness x:Key="AppBarButtonSubItemChevronLabelOnRightMargin">-7,20,12,0</Thickness>
             <Thickness x:Key="AppBarButtonSecondarySubItemChevronMargin">0,0,16,0</Thickness>
 
 

--- a/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.properties.cs
@@ -29,9 +29,8 @@ public partial class CommandBar
     /// <summary>
     /// Define the <see cref="IsOpen"/> property
     /// </summary>
-    public static readonly DirectProperty<CommandBar, bool> IsOpenProperty =
-        AvaloniaProperty.RegisterDirect<CommandBar, bool>(nameof(IsOpen),
-            x => x.IsOpen, (x, v) => x.IsOpen = v);
+    public static readonly StyledProperty<bool> IsOpenProperty =
+        AvaloniaProperty.Register<CommandBar, bool>(nameof(IsOpen));
 
     /// <summary>
     /// Defines the <see cref="ClosedDisplayMode"/> property
@@ -63,13 +62,15 @@ public partial class CommandBar
     /// Defines the <see cref="IsDynamicOverflowEnabled"/>
     /// </summary>
     public static readonly StyledProperty<bool> IsDynamicOverflowEnabledProperty =
-        AvaloniaProperty.Register<CommandBar, bool>(nameof(SecondaryCommands));
+        AvaloniaProperty.Register<CommandBar, bool>(nameof(IsDynamicOverflowEnabled),
+            defaultValue: true);
 
     /// <summary>
     /// Defines the <see cref="ItemsAlignment"/> property
     /// </summary>
-    public static readonly StyledProperty<HorizontalAlignment> ItemsAlignmentProperty =
-        AvaloniaProperty.Register<CommandBar, HorizontalAlignment>(nameof(ItemsAlignment), HorizontalAlignment.Left);
+    public static readonly StyledProperty<CommandBarItemsAlignment> ItemsAlignmentProperty =
+        AvaloniaProperty.Register<CommandBar, CommandBarItemsAlignment>(nameof(ItemsAlignment),
+            CommandBarItemsAlignment.Left);
 
     /// <summary>
     /// Defines the <see cref="DefaultLabelPosition"/> property
@@ -91,33 +92,8 @@ public partial class CommandBar
     /// </summary>
     public bool IsOpen
     {
-        get => _isOpen;
-        set
-        {
-            if (value)
-            {
-                OnOpening();
-            }
-            else
-            {
-                OnClosing();
-            }
-
-            if (SetAndRaise(IsOpenProperty, ref _isOpen, value))
-            {
-                PseudoClasses.Set(":open", value);
-                SetElementVisualStateForOpen(value);
-
-                if (value)
-                {
-                    OnOpened();
-                }
-                else
-                {
-                    OnClosed();
-                }
-            }
-        }
+        get => GetValue(IsOpenProperty);
+        set => SetValue(IsOpenProperty, value);
     }
 
     /// <summary>
@@ -174,7 +150,7 @@ public partial class CommandBar
     /// This property doesn't exist in WinUI, where PrimaryCommands are always right aligned.
     /// This property gives you more flexibility to control this behavior.
     /// </remarks>
-    public HorizontalAlignment ItemsAlignment
+    public CommandBarItemsAlignment ItemsAlignment
     {
         get => GetValue(ItemsAlignmentProperty);
         set => SetValue(ItemsAlignmentProperty, value);
@@ -213,10 +189,8 @@ public partial class CommandBar
     // TODO:
     //public event TypedEventHandler<CommandBar, DynamicOverflowItemsChangingEventArgs> DynamicOverflowItemsChanging;
 
-    private bool _isOpen;
     private IAvaloniaList<ICommandBarElement> _primaryCommands;
     private IAvaloniaList<ICommandBarElement> _secondaryCommands;
-    private bool _isDynamicOverflowEnabled = true;
 
     private const string s_tpPrimaryItemsControl = "PrimaryItemsControl";
     private const string s_tpContentControl = "ContentControl";

--- a/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.properties.cs
@@ -1,9 +1,7 @@
 ﻿using Avalonia.Collections;
 using Avalonia.Controls;
-using Avalonia.Layout;
 using Avalonia;
 using FluentAvalonia.Core;
-using System;
 using Avalonia.Controls.Metadata;
 
 namespace FluentAvalonia.UI.Controls;

--- a/src/FluentAvalonia/UI/Controls/CommandBar/CommandBarItemsAlignment.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBar/CommandBarItemsAlignment.cs
@@ -1,0 +1,18 @@
+﻿namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Defines constants that determine where the primary commands are shown
+/// in a <see cref="CommandBar"/>
+/// </summary>
+public enum CommandBarItemsAlignment
+{
+    /// <summary>
+    /// The items are left-aligned on the CommandBar
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// The items are right-aligned on the CommandBar
+    /// </summary>
+    Right
+}


### PR DESCRIPTION
- Fixes an issue where CommandBar will crash the app since preview6
  - This was caused when I switched `IsDynamicOverflowEnabled` to a StyledProperty but left the old field in the code, so it was always set to true, but wasn't fully initialized and led to a null ref
- Moves `CommandBar.IsOpen` to a StyledProperty
- Changed `ItemsAlignment` type from `HorizontalAlignment` to `CommandBarItemsAlignment`, with only values `Left` and `Right`. This property now actually does what its supposed to do (it wasn't respected before)
- Fixes and issue where adding a flyout to a CommandBarButton would show the chevron overlapped with the label in `LabelOnRight` mode (fixes #313)


- Fixes Avalonia menus to use the correct popup placement (fixes #322)