### PR TITLE
Improved ICollectionView implementation

### DIFF
--- a/src/FluentAvalonia/UI/Data/CollectionView/CollectionViewGroup.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/CollectionViewGroup.cs
@@ -1,48 +1,485 @@
 ﻿using Avalonia.Collections;
+using Avalonia.Data;
 using FluentAvalonia.Core;
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace FluentAvalonia.UI.Data;
 
 internal class CollectionViewGroup : ICollectionViewGroup
 {
-    public CollectionViewGroup(GroupedDataCollectionView owner, object item, PropertyPath resolver)
+    public CollectionViewGroup(GroupedDataCollectionView owner, object item, bool hasItemsBinding)
     {
         _owner = owner;
-
         Group = item;
+        _hasItemsBinding = hasItemsBinding;
 
-        if (resolver == null)
+        Init();
+    }
+
+    public object Group { get; private set; }
+
+    public IList<object> GroupItems { get; protected set; }
+
+    internal virtual void UpdateGroup(object group)
+    {
+        Group = group;
+
+        if (!_hasItemsBinding)
         {
-            GroupItems = new CollectionWrapper(item as IEnumerable);
+            GroupItems = new CollectionWrapper(group as IEnumerable);
         }
         else
         {
-            var items = resolver.ResolvePath(item);
-            if (!(items is IEnumerable))
-                throw new InvalidOperationException($"Property Path {resolver.Path} does not resolve an IEnumerable");
-
-            GroupItems = new CollectionWrapper(items as IEnumerable);
+            GroupItems = new CollectionWrapper(_owner.GetItemsFromGroup(group));
         }
-
-        GroupItems.CollectionChanged += OnGroupItemsCollectionChanged;
     }
 
-    public object Group { get; }
-    public IAvaloniaList<object> GroupItems { get; }
+    protected virtual void Init()
+    {
+        if (!_hasItemsBinding)
+        {
+            GroupItems = new CollectionWrapper(Group as IEnumerable);
+        }
+        else
+        {
+            GroupItems = new CollectionWrapper(_owner.GetItemsFromGroup(Group));
+        }
 
-    private void OnGroupItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+        (GroupItems as INotifyCollectionChanged).CollectionChanged += OnGroupItemsCollectionChanged;
+    }
+
+    protected virtual void OnGroupItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
     {
         _owner.GroupItemsChanged(this, args);
     }
 
-    private GroupedDataCollectionView _owner;
+    protected GroupedDataCollectionView _owner;
+    protected bool _hasItemsBinding;
+}
+
+internal class SpecializedCollectionViewGroup : CollectionViewGroup, IComparer<object>
+{
+    public SpecializedCollectionViewGroup(GroupedDataCollectionView owner, object item, bool hasItemsBinding)
+        : base(owner, item, hasItemsBinding)
+    {
+
+    }
+
+    internal int HandleFilterChanged(Predicate<object> filter)
+    {
+        if (filter != null)
+        {
+            for (int i = 0; i < _view.Count; i++)
+            {
+                var item = _view.ElementAt(i);
+                if (filter(item))
+                    continue;
+
+                RemoveFromView(i, item);
+                i--;
+            }
+
+            var viewHash = new HashSet<object>(_view);
+            var viewIndex = 0;
+            for (int i = 0; i < _actualItems.Count(); i++)
+            {
+                var item = _actualItems.ElementAt(i);
+                if (viewHash.Contains(item))
+                {
+                    viewIndex++;
+                    continue;
+                }
+
+                if (HandleItemAdded(i, item, viewIndex))
+                {
+                    viewIndex++;
+                }
+            }
+        }
+
+        return _view.Count;
+    }
+
+    internal void HandleSortChanged()
+    {
+        _view.Sort(this);
+        // Don't raise event here, this is part of a bulk action
+    }
+
+    internal int Refresh()
+    {
+        _view.Clear();
+        var filter = _owner.Filter;
+        var sortDesc = _owner.GetSortDescriptions();
+
+        foreach (var item in _actualItems)
+        {
+            if (filter != null && !filter(item))
+                continue;
+
+            if (sortDesc != null && sortDesc.Count > 0)
+            {
+                var targetIndex = _view.BinarySearch(item, this);
+                if (targetIndex < 0)
+                    targetIndex = ~targetIndex;
+
+                _view.Insert(targetIndex, item);
+            }
+            else
+            {
+                _view.Add(item);
+            }
+        }
+
+        // Don't raise event here, this is part of a bulk action
+        return _view.Count;
+    }
+
+    protected override void Init()
+    {
+        // With sorting/grouping, we want to maintain the list of actual group items so we don't
+        // have to constantly evaluate the itemsbinding (if present)
+        // So, we load the actual items into _actualItems, and _view will be mapped to GroupItems
+        // which are the filtered/sorted items that are displayed
+        if (!_hasItemsBinding)
+        {
+            _actualItems = new CollectionWrapper(Group as IEnumerable);
+        }
+        else
+        {
+            _actualItems = new CollectionWrapper(_owner.GetItemsFromGroup(Group));
+        }
+
+        (_actualItems as INotifyCollectionChanged).CollectionChanged += OnGroupItemsCollectionChanged;
+
+        AttachPropertyChangedHandler(_actualItems);
+        _view = new List<object>(_actualItems.Count());
+        GroupItems = _view;
+        SourceChanged();
+    }
+
+    internal override void UpdateGroup(object group)
+    {
+        DetachPropertyChangedHandler(_actualItems);
+
+        // We're already in the middle of a collection change notification from this group
+        // as this is called when a Reset action takes place. Don't notify the CollectionView
+        // again or bad things may happen
+        _ignoreNotify = true;
+        Init();
+        _ignoreNotify = false;
+    }
+
+    protected override void OnGroupItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+    {
+        switch (args.Action)
+        {
+            case NotifyCollectionChangedAction.Add:
+                {
+                    AttachPropertyChangedHandler(args.NewItems);
+                    if (_owner.DeferCounter <= 0)
+                    {
+                        if (args.NewItems.Count == 1)
+                        {
+                            HandleItemAdded(args.NewStartingIndex, args.NewItems[0]);
+                        }
+                        else
+                        {
+                            SourceChanged();
+                        }
+                    }
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Remove:
+                {
+                    DetachPropertyChangedHandler(args.OldItems);
+                    if (_owner.DeferCounter <= 0)
+                    {
+                        if (args.OldItems.Count == 1)
+                        {
+                            HandleItemRemoved(args.OldStartingIndex, args.OldItems[0]);
+                        }
+                        else
+                        {
+                            SourceChanged();
+                        }
+                    }
+                }
+                break;
+
+            default:
+                SourceChanged();
+                break;
+        }
+    }
+
+    private void AttachPropertyChangedHandler(IEnumerable items)
+    {
+        if (!_owner.IsLiveShapingEnabled || items == null)
+            return;
+
+        foreach (var item in items.OfType<INotifyPropertyChanged>())
+        {
+            item.PropertyChanged += ItemOnPropertyChanged;
+        }
+    }
+
+    private void DetachPropertyChangedHandler(IEnumerable items)
+    {
+        if (!_owner.IsLiveShapingEnabled || items == null)
+            return;
+
+        foreach (var item in items.OfType<INotifyPropertyChanged>())
+        {
+            item.PropertyChanged -= ItemOnPropertyChanged;
+        }
+    }
+
+    private void ItemOnPropertyChanged(object item, PropertyChangedEventArgs args)
+    {
+        if (!_owner.IsLiveShapingEnabled)
+            return;
+
+        var filter = _owner.Filter;
+        var filterProps = _owner.GetFilterProperties();
+        var sortDesc = _owner.GetSortDescriptions();
+
+        var filterResult = filter?.Invoke(item);
+
+        if (filterResult.HasValue && filterProps.Contains(args.PropertyName))
+        {
+            var viewIndex = _view.IndexOf(item);
+            if (viewIndex != -1 && !filterResult.Value)
+            {
+                RemoveFromView(viewIndex, item);
+            }
+            else if (viewIndex == -1 && filterResult.Value)
+            {
+                var index = _actualItems.IndexOf(item);
+                HandleItemAdded(index, item);
+            }
+        }
+
+        if ((filterResult ?? true) && sortDesc?.Any(sd => sd.PropertyName == args.PropertyName) == true)
+        {
+            var oldIndex = _view.IndexOf(item);
+
+            // Check if item is in view:
+            if (oldIndex < 0)
+            {
+                return;
+            }
+
+            _view.RemoveAt(oldIndex);
+            var targetIndex = _view.BinarySearch(item, this);
+            if (targetIndex < 0)
+            {
+                targetIndex = ~targetIndex;
+            }
+
+            // Only trigger expensive UI updates if the index really changed:
+            if (targetIndex != oldIndex)
+            {
+                OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, oldIndex));
+
+                _view.Insert(targetIndex, item);
+
+                OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, targetIndex));
+            }
+            else
+            {
+                _view.Insert(targetIndex, item);
+            }
+        }
+        else if (string.IsNullOrEmpty(args.PropertyName))
+        {
+            SourceChanged();
+        }
+    }
+
+    private void SourceChanged()
+    {
+        _view.Clear();
+
+        var filter = _owner.Filter;
+        var sortDesc = _owner.GetSortDescriptions();
+
+        foreach (var item in _actualItems)
+        {
+            if (filter != null && !filter(item))
+                continue;
+
+            if (sortDesc != null && sortDesc.Count > 0)
+            {
+                var targetIndex = _view.BinarySearch(item, this);
+                if (targetIndex < 0)
+                    targetIndex = ~targetIndex;
+
+                _view.Insert(targetIndex, item);
+            }
+            else
+            {
+                _view.Add(item);
+            }
+        }
+
+        OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    private void OnVectorChanged(NotifyCollectionChangedEventArgs args)
+    {
+        if (_ignoreNotify)
+            return;
+
+        // if (_owner.DeferCounter > 0)
+        //     return;
+
+        _owner.GroupItemsChanged(this, args);
+    }
+
+    private bool HandleItemAdded(int newStartingIndex, object newItem, int? viewIndex = null)
+    {
+        var filter = _owner.Filter;
+        var sortDesc = _owner.GetSortDescriptions();
+        if (filter != null && !filter(newItem))
+            return false;
+
+        var newViewIndex = _view.Count;
+
+        if (sortDesc != null && sortDesc.Count > 0)
+        {
+            //_sortProperties.Clear();
+            newViewIndex = _view.BinarySearch(newItem, this);
+            if (newViewIndex < 0)
+                newViewIndex = ~newViewIndex;
+        }
+        else if (filter != null)
+        {
+            if (_actualItems == null)
+            {
+                SourceChanged();
+                return false;
+            }
+
+            if (newStartingIndex == 0 || _view.Count == 0)
+            {
+                newViewIndex = 0;
+            }
+            else if (newStartingIndex == _actualItems.Count() - 1)
+            {
+                newViewIndex = _view.Count - 1;
+            }
+            else if (viewIndex.HasValue)
+            {
+                newViewIndex = viewIndex.Value;
+            }
+            else
+            {
+                for (int i = 0, j = 0; i < _actualItems.Count(); i++)
+                {
+                    if (i == newStartingIndex)
+                    {
+                        newViewIndex = j;
+                        break;
+                    }
+
+                    if (_view[j] == _actualItems.ElementAt(i))
+                    {
+                        j++;
+                    }
+                }
+            }
+        }
+
+        _view.Insert(newViewIndex, newItem);
+        //if (newViewIndex <= CurrentPosition)
+        //{
+        //    CurrentPosition++;
+        //}
+
+        var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add,
+            newItem, newViewIndex);
+        OnVectorChanged(args);
+
+        return true;
+    }
+
+    private void HandleItemRemoved(int index, object item)
+    {
+        var filter = _owner.Filter;
+        if (filter != null && !filter(item))
+        {
+            return;
+        }
+
+        if (index < 0 || index >= _view.Count || !Equals(_view[index], item))
+        {
+            index = _view.IndexOf(item);
+        }
+
+        if (index < 0)
+        {
+            return;
+        }
+
+        RemoveFromView(index, item);
+    }
+
+    private void RemoveFromView(int index, object item)
+    {
+        _view.RemoveAt(index);
+
+        //if (index <= CurrentPosition)
+        //    CurrentPosition--;
+
+        var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index);
+        OnVectorChanged(args);
+    }
+
+    int IComparer<object>.Compare(object x, object y)
+    {
+        var sortDesc = _owner.GetSortDescriptions();
+        if (sortDesc != null)
+        {
+            for (int i = 0; i < sortDesc.Count; i++)
+            {
+                var desc = sortDesc[i];
+                object cx, cy;
+
+                if (desc.Property == null)
+                {
+                    cx = x;
+                    cy = y;
+                }
+                else
+                {
+                    cx = EvaluateBinding(desc.Property, x);
+                    cy = EvaluateBinding(desc.Property, y);
+                }
+
+                var cmp = desc.Comparer.Compare(cx, cy);
+                if (cmp != 0)
+                    return desc.Direction == SortDirection.Ascending ? cmp : -cmp;
+            }
+        }
+
+        return 0;
+    }
+
+    private static object EvaluateBinding(IBinding binding, object item)
+    {
+        _bindingHelper ??= new GroupedDataCollectionView.BindingHelper();
+
+        return _bindingHelper.Evaluate(binding, item);
+    }
+
+    private List<object> _view;
+    private IEnumerable _actualItems;
+    private static GroupedDataCollectionView.BindingHelper _bindingHelper;
+    private bool _ignoreNotify;
 }
 
 internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INCC compatibility
@@ -66,40 +503,20 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
             {
                 list[index] = value;
             }
-            else if (_collection is IList<object> genList)
-            {
-                genList[index] = value;
-            }
         }
     }
-
-    object IReadOnlyList<object>.this[int index] => this[index];
 
     public int Count => _collection.Count();
 
     public bool IsReadOnly => _collection is ICollection<object> col && col.IsReadOnly;
 
-    bool IList.IsFixedSize => false;
-    bool IList.IsReadOnly => IsReadOnly;
-    int ICollection.Count => Count;
-    bool ICollection.IsSynchronized => false;
-    object ICollection.SyncRoot => false;
-
-    object IList.this[int index]
-    {
-        get => this[index];
-        set => this[index] = value;
-    }
-
     public event NotifyCollectionChangedEventHandler CollectionChanged;
-#pragma warning disable CS0067
-    // TODO: When I finally get around to actually supporting this, actually implement this
     public event PropertyChangedEventHandler PropertyChanged;
-#pragma warning restore CS0067
 
     private void OnBackingCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
-        CollectionChanged?.Invoke(sender, e);
+        CollectionChanged?.Invoke(this, e);
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
     }
 
     public void Add(object item)
@@ -109,14 +526,6 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
         if (_collection is IList l)
         {
             l.Add(item);
-        }
-        else if (_collection is IList<object> genL)
-        {
-            genL.Add(item);
-        }
-        else if (_collection is ICollection<object> col)
-        {
-            col.Add(item);
         }
     }
 
@@ -129,16 +538,6 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
             foreach (var item in items)
                 l.Add(item);
         }
-        else if (_collection is IList<object> genL)
-        {
-            foreach (var item in genL)
-                genL.Add(item);
-        }
-        else if (_collection is ICollection<object> col)
-        {
-            foreach (var item in items)
-                col.Add(item);
-        }
     }
 
     public void Clear()
@@ -147,8 +546,6 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
 
         if (_collection is IList l)
             l.Clear();
-        else if (_collection is ICollection<object> col) // Also covers IList<T>
-            col.Clear();
     }
 
     public bool Contains(object item) =>
@@ -183,11 +580,9 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
         ThrowIfNotMutable();
 
         if (_collection is IList list)
+        {
             list.Insert(index, item);
-        else if (_collection is IList<object> genList)
-            genList.Insert(index, item);
-        else if (_collection is ICollection<object> col)
-            ThrowForMutableActionNotSupported();
+        }
     }
 
     public void InsertRange(int index, IEnumerable<object> items)
@@ -200,14 +595,6 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
             foreach (var item in items)
                 list.Insert(idx++, item);
         }
-        else if (_collection is IList<object> genList)
-        {
-            int idx = index;
-            foreach (var item in items)
-                genList.Insert(idx++, item);
-        }
-        else if (_collection is ICollection<object> col)
-            ThrowForMutableActionNotSupported();
     }
 
     public void Move(int oldIndex, int newIndex)
@@ -222,12 +609,11 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
 
     public bool Remove(object item)
     {
+        ThrowIfNotMutable();
+
         if (_collection is IList l)
             l.Remove(item);
-        else if (_collection is ICollection<object> col) // Also covers IList<T>
-            col.Remove(item);
 
-        ThrowIfNotMutable();
         return false;
     }
 
@@ -241,11 +627,9 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
         ThrowIfNotMutable();
 
         if (_collection is IList l)
+        {
             l.RemoveAt(index);
-        else if (_collection is IList<object> genList)
-            genList.RemoveAt(index);
-        else if (_collection is ICollection<object> col)
-            ThrowForMutableActionNotSupported();
+        }
     }
 
     public void RemoveRange(int index, int count)
@@ -258,15 +642,30 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
 
     private void ThrowIfNotMutable()
     {
-        if (IsReadOnly || _collection is IList || _collection is IList<object> || _collection is ICollection<object>)
+        // We can't modify the CollectionViewGroup items if it's not able to notify,
+        // even if the underlying type is something like a List
+        if (!IsReadOnly || _collection is INotifyCollectionChanged)
             return;
 
-        throw new NotSupportedException("Collection is not mutable");
+        throw new NotSupportedException("Collection is not mutable. Collection groups must implement INotifyCollectionChanged");
     }
 
-    private void ThrowForMutableActionNotSupported([CallerMemberName] string caller = null)
+    object IReadOnlyList<object>.this[int index] => this[index];
+
+    bool IList.IsFixedSize => false;
+
+    bool IList.IsReadOnly => IsReadOnly;
+
+    int ICollection.Count => Count;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => false;
+
+    object IList.this[int index]
     {
-        throw new NotSupportedException($"Collection of type {_collection.GetType()} does not support the {caller} action");
+        get => this[index];
+        set => this[index] = value;
     }
 
     int IList.Add(object value)
@@ -297,7 +696,7 @@ internal class CollectionWrapper : IAvaloniaList<object>, IList // IList for INC
 
     void ICollection.CopyTo(Array array, int index)
     {
-        throw new NotImplementedException();
+        CopyTo((object[])array, index);
     }
 
     private IEnumerable _collection;

--- a/src/FluentAvalonia/UI/Data/CollectionView/CollectionViewSource.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/CollectionViewSource.cs
@@ -1,12 +1,17 @@
 ﻿using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Data;
+using Avalonia.Metadata;
 using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace FluentAvalonia.UI.Data;
 
 /// <summary>
 /// Provides a data source that adds grouping and current-item support to collection classes.
 /// </summary>
-public class CollectionViewSource : AvaloniaObject
+public class CollectionViewSource : AvaloniaObject, ISupportInitialize
 {
     /// <summary>
     /// Defines the <see cref="IsSourceGrouped"/> property
@@ -18,9 +23,9 @@ public class CollectionViewSource : AvaloniaObject
     /// <summary>
     /// Defines the <see cref="ItemsPath"/> property
     /// </summary>
-    public static readonly DirectProperty<CollectionViewSource, string> ItemsPathProperty =
-     AvaloniaProperty.RegisterDirect<CollectionViewSource, string>(nameof(ItemsPath),
-         x => x.ItemsPath, (x, v) => x.ItemsPath = v);
+    public static readonly DirectProperty<CollectionViewSource, IBinding> ItemsBindingProperty =
+     AvaloniaProperty.RegisterDirect<CollectionViewSource, IBinding>(nameof(ItemsBinding),
+         x => x.ItemsBinding, (x, v) => x.ItemsBinding = v);
 
     /// <summary>
     /// Defines the <see cref="Source"/> property
@@ -36,34 +41,40 @@ public class CollectionViewSource : AvaloniaObject
      AvaloniaProperty.RegisterDirect<CollectionViewSource, ICollectionView>(nameof(View),
          x => x.View);
 
+    public static readonly DirectProperty<CollectionViewSource, Predicate<object>> FilterProperty =
+        AvaloniaProperty.RegisterDirect<CollectionViewSource, Predicate<object>>(nameof(Filter),
+            x => x.Filter, (x, v) => x.Filter = v);
+
+    public static readonly DirectProperty<CollectionViewSource, IList<string>> LiveFilterPropertiesProperty =
+        AvaloniaProperty.RegisterDirect<CollectionViewSource, IList<string>>(nameof(LiveFilterProperties),
+            x => x.LiveFilterProperties);
+
+    public static readonly DirectProperty<CollectionViewSource, IList<SortDescription>> SortDescriptionsProperty =
+        AvaloniaProperty.RegisterDirect<CollectionViewSource, IList<SortDescription>>(nameof(SortDescriptions),
+             x => x.SortDescriptions);
+
+    public static readonly DirectProperty<CollectionViewSource, bool> IsLiveShapingEnabledProperty =
+        AvaloniaProperty.RegisterDirect<CollectionViewSource, bool>(nameof(IsLiveShapingEnabled),
+            x => x.IsLiveShapingEnabled, (x, v) => x.IsLiveShapingEnabled = v);
+
     /// <summary>
     /// Gets or sets a value that indicates whether source data is grouped.
     /// </summary>
     public bool IsSourceGrouped
     {
         get => _isSourceGrouped;
-        set
-        {
-            if (SetAndRaise(IsSourceGroupedProperty, ref _isSourceGrouped, value))
-            {
-                UpdateView();
-            }
-        }
+        set => SetAndRaise(IsSourceGroupedProperty, ref _isSourceGrouped, value);
     }
 
     /// <summary>
     /// Gets or sets the property path to follow from the top level item to find groups within the CollectionViewSource.
     /// </summary>
-    public string ItemsPath
+    [AssignBinding]
+    [InheritDataTypeFromItems(nameof(Source))]
+    public IBinding ItemsBinding
     {
-        get => _itemsPath;
-        set
-        {
-            if (SetAndRaise(ItemsPathProperty, ref _itemsPath, value))
-            {
-                UpdateView();
-            }
-        }
+        get => _itemsBinding;
+        set => SetAndRaise(ItemsBindingProperty, ref _itemsBinding, value);
     }
 
     /// <summary>
@@ -72,13 +83,7 @@ public class CollectionViewSource : AvaloniaObject
     public IEnumerable Source
     {
         get => _source;
-        set
-        {
-            if (SetAndRaise(SourceProperty, ref _source, value))
-            {
-                UpdateView();
-            }
-        }
+        set => SetAndRaise(SourceProperty, ref _source, value);
     }
 
     /// <summary>
@@ -86,30 +91,152 @@ public class CollectionViewSource : AvaloniaObject
     /// </summary>
     public ICollectionView View
     {
+        get => _view;
+        private set => SetAndRaise(ViewProperty, ref _view, value);
+    }
+
+    public Predicate<object> Filter
+    {
+        get => _filter;
+        set
+        {
+            SetAndRaise(FilterProperty, ref _filter, value);
+            UpdateView();
+            // TODO: Refresh has problems...
+            //if ()
+            //{
+
+            //}
+            //else if (_view is IAdvancedCollectionView acv)
+            //{
+            //    acv.RefreshFilter();
+            //}
+        }
+    }
+
+    /// <summary>
+    /// Gets a list (comma separated) of properties that should be used for live filtering
+    /// of the CollectionView
+    /// </summary>
+    /// <remarks>
+    /// In order to use this property, <see cref="IsLiveShapingEnabled"/> must be set to true
+    /// or an error will be thrown when creating the ICollectionView
+    /// </remarks>
+    public AvaloniaList<string> LiveFilterProperties
+    {
         get
         {
-            if (_view == null)
+            if (_liveFilterProperties == null)
             {
-                UpdateView();
+                _liveFilterProperties = new AvaloniaList<string>();
+                _liveFilterProperties.CollectionChanged += SortOrFilterListChanged;
             }
 
-            return _view;
+            return _liveFilterProperties;
         }
-        private set => SetAndRaise(ViewProperty, ref _view, value);
+    }
+
+    /// <summary>
+    /// Gets a list of <see cref="SortDescription"/> that is used for sorting the ICollectionView
+    /// </summary>
+    public AvaloniaList<SortDescription> SortDescriptions
+    {
+        get
+        {
+            if (_sortDescriptions == null)
+            {
+                _sortDescriptions = new AvaloniaList<SortDescription>();
+                _sortDescriptions.CollectionChanged += SortOrFilterListChanged;
+            }
+
+            return _sortDescriptions;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether the ICollectionView should respond to changes of the properties 
+    /// specified in <see cref="LiveFilterProperties"/> or <see cref="SortDescription"/>
+    /// </summary>
+    public bool IsLiveShapingEnabled
+    {
+        get => _isLiveShapingEnabled;
+        set => SetAndRaise(IsLiveShapingEnabledProperty, ref _isLiveShapingEnabled, value);
+    }
+
+    public void BeginInit()
+    {
+        _isInitializing = true;
+    }
+
+    public void EndInit()
+    {
+        _isInitializing = false;
+        UpdateView();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == SourceProperty ||
+            change.Property == ItemsBindingProperty ||
+            change.Property == IsSourceGroupedProperty ||
+            change.Property == IsLiveShapingEnabledProperty)
+        {
+            UpdateView();
+        }
+    }
+
+    private void SortOrFilterListChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        UpdateView();
     }
 
     private void UpdateView()
     {
-        if (_source == null)
+        if (_isInitializing)
             return;
+
+        if (Source is ICollectionViewFactory factory)
+        {
+            View = factory.CreateView();
+            return;
+        }
 
         if (Source is IEnumerable ie)
         {
-            View = new GroupedDataCollectionView(ie, _isSourceGrouped, _itemsPath);
-        }
-        else if (Source is ICollectionViewFactory factory)
-        {
-            View = factory.CreateView();
+            if (_isSourceGrouped)
+            {
+                // We have to completely recreate the view if the source changes,
+                // live shaping changes, or the itemsbinding changes
+                // The other properties can be updated without a full recreation
+                if (_view is GroupedDataCollectionView gdcv &&
+                    (gdcv.Source == _source && gdcv.IsLiveShapingEnabled == _isLiveShapingEnabled &&
+                    gdcv.ItemsBinding == _itemsBinding))
+                {
+                    gdcv.UpdateViewFromCollectionViewSource(_filter, _liveFilterProperties, _sortDescriptions);
+                    return;
+                }
+                else
+                {
+                    View = new GroupedDataCollectionView(ie, _itemsBinding, _isLiveShapingEnabled,
+                        _filter, _liveFilterProperties, _sortDescriptions);
+                }
+            }
+            else
+            {
+                // Same as above
+                if (_view is IterableCollectionView icv &&
+                    (icv.Source == _source && icv.IsLiveShapingEnabled == _isLiveShapingEnabled))
+                {
+                    icv.UpdateViewFromCollectionViewSource(_filter, _liveFilterProperties, _sortDescriptions);
+                }
+                else
+                {
+                    View = new IterableCollectionView(ie, _isLiveShapingEnabled,
+                        _filter, _liveFilterProperties, _sortDescriptions);
+                }
+            }
         }
         else
         {
@@ -117,8 +244,15 @@ public class CollectionViewSource : AvaloniaObject
         }
     }
 
+
+
+    private bool _isInitializing;
     private bool _isSourceGrouped;
-    private string _itemsPath;
+    private IBinding _itemsBinding;
     private IEnumerable _source;
     private ICollectionView _view;
+    private AvaloniaList<string> _liveFilterProperties;
+    private AvaloniaList<SortDescription> _sortDescriptions;
+    private bool _isLiveShapingEnabled;
+    private Predicate<object> _filter;
 }

--- a/src/FluentAvalonia/UI/Data/CollectionView/GroupedDataCollectionView.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/GroupedDataCollectionView.cs
@@ -1,32 +1,71 @@
-﻿using Avalonia.Collections;
-using FluentAvalonia.Core;
-using System;
+﻿// Sorting & Filtering adapted from the WindowsCommunityToolkit
+// AdvancedCollectionView - MIT license
+
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Threading.Tasks;
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Collections.Pooled;
+using Avalonia.Data;
+using Avalonia.Logging;
 
 namespace FluentAvalonia.UI.Data;
 
-// Add IList here to satisfy ItemsSourceView in Avalonia as it only checks for the non-generic IList
-internal class GroupedDataCollectionView : ICollectionView, IList
+public sealed class GroupedDataCollectionView : ICollectionView, IAdvancedCollectionView, IList
 {
-    public GroupedDataCollectionView(IEnumerable collection, bool isGrouped, string itemsPath = null)
-    {
-        if (collection == null)
-            throw new ArgumentNullException("Collection");
+    public GroupedDataCollectionView(IEnumerable collection, IBinding itemsBinding = null)
+        : this(collection, itemsBinding, false, null, null, null) { }
 
-        _collection = collection;
-        _isGrouped = isGrouped;
-        if (isGrouped)
+    public GroupedDataCollectionView(IEnumerable collection, IBinding itemsBinding,
+        bool isLiveShaping)
+        : this(collection, itemsBinding, isLiveShaping, null, null, null) { }
+
+    public GroupedDataCollectionView(IEnumerable collection, IBinding itemsBinding,
+        Predicate<object> filter)
+        : this(collection, itemsBinding, false, filter, null, null) { }
+
+    public GroupedDataCollectionView(IEnumerable collection, IBinding itemsBinding,
+        Predicate<object> filter, IList<string> filterProperties)
+        : this(collection, itemsBinding, true, filter, filterProperties, null) { }
+
+    public GroupedDataCollectionView(IEnumerable collection, IBinding itemsBinding,
+       IList<SortDescription> sortDescriptions)
+        : this(collection, itemsBinding, false, null, null, sortDescriptions) { }
+
+    public GroupedDataCollectionView(IEnumerable collection, IBinding itemsBinding,
+        bool isLiveShaping,
+        Predicate<object> filter, IList<string> filterProperties,
+        IList<SortDescription> sortDescriptions)
+    {
+        collection = collection ?? throw new ArgumentNullException(nameof(collection));
+
+        _source = collection;
+        _itemsBinding = itemsBinding;
+
+        _hasSortOrFilter = isLiveShaping || filter != null || sortDescriptions != null;
+
+        if (_hasSortOrFilter)
         {
-            CreateGroups(collection, itemsPath);
+            IsLiveShapingEnabled = isLiveShaping;
+            _filter = filter;
+
+            if (isLiveShaping)
+            {
+                _filterProperties = filterProperties != null ? new HashSet<string>(filterProperties) :
+                    new HashSet<string>();
+            }
+
+            if (sortDescriptions != null)
+            {
+                var l = new AvaloniaList<SortDescription>(sortDescriptions);
+                l.CollectionChanged += OnSortDescriptionsChanged;
+                _sortDescriptions = l;
+            }
         }
-        else
-        {
-            _count = collection.Count();
-        }
+
+        // If sorting or filtering is enabled, this will handle the remainder of work
+        CreateGroups();
 
         if (collection is INotifyCollectionChanged incc)
         {
@@ -34,14 +73,9 @@ internal class GroupedDataCollectionView : ICollectionView, IList
         }
     }
 
-    // If you're following this class to write your own implementation of ICollectionView,
-    // this property must be **null** if no grouping is used. This check is used internally
-    // to determine whether the ICollectionView has groups.
     public IAvaloniaList<ICollectionViewGroup> CollectionGroups { get; private set; }
 
     public int CurrentPosition { get; private set; }
-
-    public bool HasMoreItems { get; private set; }
 
     public bool IsCurrentAfterLast => CurrentPosition >= Count;
 
@@ -49,352 +83,434 @@ internal class GroupedDataCollectionView : ICollectionView, IList
 
     public int Count => _count;
 
-    int ICollection.Count => _count;
+    public bool IsReadOnly => _source is IList l && l.IsReadOnly;
 
-    public object CurrentItem
-    {
-        get
-        {
-            if (!_isGrouped)
-                return CurrentPosition >= 0 && CurrentPosition < Count ? _collection.ElementAt(CurrentPosition) : null;
-
-            return GetCurrentGrouped(CurrentPosition);
-        }
-    }
-
-    public bool IsReadOnly => _collection is IReadOnlyCollection<object> || _collection is IList l && l.IsReadOnly
-        || _collection is ICollection<object> col && col.IsReadOnly;
-
-    public bool IsFixedSize => _collection is IList l && l.IsFixedSize;
-
-    public bool IsSynchronized => throw new NotSupportedException();
-
-    public object SyncRoot => throw new NotSupportedException();
+    public object CurrentItem => GetItemAtIndex(CurrentPosition);
 
     public object this[int index]
     {
-        get => _isGrouped ? GetCurrentGrouped(index) : _collection.ElementAt(index);
+        get => GetItemAtIndex(index);
+        set => ThrowICollectionViewNotMutableWhenGrouping();
+    }
+
+    public bool IsLiveShapingEnabled { get; }
+
+    public Predicate<object> Filter
+    {
+        get => _filter;
         set
         {
-            if (_isGrouped)
-                throw new NotSupportedException("Grouped list is not mutable");
-
-            if (_collection is IList l)
-            {
-                l.Add(value);
-            }
-            else if (_collection is IList<object> lGen)
-            {
-                lGen.Add(value);
-            }
-
-            throw new NotSupportedException("Collection is not a mutable list");
+            _filter = value;
+            HandleFilterChanged();
         }
     }
+
+    public IList<SortDescription> SortDescriptions
+    {
+        get
+        {
+            if (_sortDescriptions == null)
+            {
+                var l = new AvaloniaList<SortDescription>();
+                l.CollectionChanged += OnSortDescriptionsChanged;
+                _sortDescriptions = l;
+            }
+
+            return _sortDescriptions;
+        }
+    }
+
+    internal int DeferCounter { get; private set; }
+
+    internal IEnumerable Source => _source;
+
+    internal IBinding ItemsBinding => _itemsBinding;
 
     public event EventHandler<object> CurrentChanged;
     public event CurrentChangingEventHandler CurrentChanging;
     public event NotifyCollectionChangedEventHandler CollectionChanged;
+    public event PropertyChangedEventHandler PropertyChanged;
 
-    private void OnBackingCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+    public bool MoveCurrentTo(object item) =>
+        MoveCurrentToPosition(IndexOf(item));
+
+    public bool MoveCurrentToFirst() =>
+        MoveCurrentToPosition(Count > 0 ? 0 : -1);
+
+    public bool MoveCurrentToLast()
+        => MoveCurrentToPosition(Count > 0 ? Count - 1 : -1);
+
+    public bool MoveCurrentToNext() =>
+        MoveCurrentToPosition(CurrentPosition + 1);
+
+    public bool MoveCurrentToPrevious() =>
+        MoveCurrentToPosition(CurrentPosition - 1);
+
+    public bool MoveCurrentToPosition(int pos)
     {
-        // This fires if the collection holding the items source changes
-        // In the event of grouping, this means the group collection changes
-        // If a group is added, we only fire the collection changed if the group has items to add
+        if (pos == CurrentPosition)
+            return true;
 
-        if (_isGrouped)
+        if (pos < 0 || pos >= Count)
+            return false;
+
+        var args = new CurrentChangingEventArgs();
+        CurrentChanging?.Invoke(this, args);
+
+        if (args.Cancel)
+            return false;
+
+        CurrentPosition = pos;
+        CurrentChanged?.Invoke(this, null);
+
+        return true;
+    }
+
+    public int IndexOf(object item)
+    {
+        int index = 0;
+        for (int i = 0; i < CollectionGroups.Count; i++)
         {
-            int GetItemCountToIndex(int index)
+            var tmp = CollectionGroups[i].GroupItems.IndexOf(item);
+            if (tmp != -1)
+                return index + tmp;
+
+            index += CollectionGroups[i].GroupItems.Count;
+        }
+
+        return -1;
+    }
+
+    public bool Contains(object item) => IndexOf(item) != -1;
+
+    public void CopyTo(object[] array, int arrayIndex)
+    {
+        try
+        {
+            var en = GetEnumerator();
+            while (en.MoveNext())
             {
-                int ct = 0;
-                for (int i = 0; i < CollectionGroups.Count; i++)
-                {
-                    if (i == index)
-                        break;
+                array[arrayIndex++] = en.Current;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.TryGet(LogEventLevel.Error, "CollectionView")?
+                .Log("CollectionView", "Unable to copy source collection to array", ex);
+        }
+    }
 
-                    ct += CollectionGroups[i].GroupItems?.Count ?? 0;
-                }
+    public IEnumerator<object> GetEnumerator() => new GroupEnumerator(this);
 
-                return ct;
+    public IDisposable DeferRefresh()
+    {
+        DeferCounter++;
+        return new RefreshDeferer(ReleaseDefer, CurrentItem);
+    }
+
+    internal void UpdateViewFromCollectionViewSource(Predicate<object> filter, IList<string> filterProperties,
+        IList<SortDescription> sortDescriptions)
+    {
+        using var defer = DeferRefresh();
+
+        _filterProperties.Clear();
+        if (filterProperties != null)
+        {
+            foreach (var prop in filterProperties)
+            {
+                AddFilterProperty(prop);
+            }
+        }
+
+        Filter = filter;
+
+        _sortDescriptions?.Clear();
+        if (sortDescriptions != null)
+        {
+            foreach (var item in sortDescriptions)
+            {
+                SortDescriptions.Add(item);
+            }
+        }
+    }
+
+    private void ReleaseDefer(object lastCurrentItem)
+    {
+        DeferCounter--;
+
+        if (DeferCounter == 0)
+        {
+            MoveCurrentTo(lastCurrentItem);
+            Refresh();
+        }
+    }
+
+    private object GetItemAtIndex(int index)
+    {
+        if (index == -1)
+            return null;
+
+        int idx = 0;
+        for (int i = 0; i < CollectionGroups.Count; i++)
+        {
+            var g = CollectionGroups[i];
+            int max = idx + g.GroupItems.Count;
+
+            if (index < max)
+            {
+                return g.GroupItems[index - idx];
             }
 
-            // If grouping, we need to make sure to add the CollectionGroup and ensure the item count
-            // is up to date. If a group is added, but has no items, no notification is sent
-            int idx = 0;
-            int itemCount = 0;
-            switch (args.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    for (int i = 0; i < args.NewStartingIndex; i++)
-                    {
-                        itemCount += CollectionGroups[i].GroupItems?.Count ?? 0;
-                    }
+            idx = max;
+        }
 
-                    // We've added a new group, create a new CollectionGroup & update view count
-                    for (int i = args.NewStartingIndex; i < args.NewStartingIndex + args.NewItems.Count; i++)
-                    {
-                        var cg = new CollectionViewGroup(this, args.NewItems[idx++], _itemsPath);
+        return null;
+    }
 
-                        CollectionGroups.Insert(i, cg);
-                        _count += cg.GroupItems?.Count ?? 0;
+    private void CreateGroups()
+    {
+        bool useSpecialized = _hasSortOrFilter;
+        using var groups = new PooledList<CollectionViewGroup>();
 
-                        if (cg.GroupItems == null || cg.GroupItems.Count == 0)
-                            continue;
+        _ignoreGroupChanges = true;
+        var en = _source.GetEnumerator();
+        while (en.MoveNext())
+        {
+            var cvg = useSpecialized ? new SpecializedCollectionViewGroup(this, en.Current, _itemsBinding != null) :
+                new CollectionViewGroup(this, en.Current, _itemsBinding != null);
+            groups.Add(cvg);
+            _count += cvg.GroupItems.Count;
+        }
+        _ignoreGroupChanges = false;
 
-                        // If new items were added, let's raise a notification
-                        CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add,
-                            cg.GroupItems as IList, itemCount));
-
-                        itemCount += cg.GroupItems.Count;
-                    }
-                    break;
-
-                case NotifyCollectionChangedAction.Remove:
-                    for (int i = 0; i < args.OldItems.Count + args.OldStartingIndex; i++)
-                    {
-                        itemCount += CollectionGroups[i].GroupItems?.Count ?? 0;
-                    }
-
-                    for (int i = args.OldStartingIndex + args.OldItems.Count - 1; i >= args.OldStartingIndex; i--)
-                    {
-                        var cg = CollectionGroups[i];
-
-                        CollectionGroups.RemoveAt(i);
-
-                        if (cg.GroupItems == null || cg.GroupItems.Count == 0)
-                            continue;
-
-                        _count -= cg.GroupItems.Count;
-
-                        itemCount -= cg.GroupItems.Count;
-
-                        CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
-                            cg.GroupItems as IList, itemCount));
-                    }
-
-                    break;
-
-                case NotifyCollectionChangedAction.Reset:
-                    CollectionGroups.Clear();
-                    _count = 0;
-                    CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-
-                    // If this was a reset without clearing, we'll attempt to reset everything
-                    // NOTE: This is untested...
-                    CreateGroups(_collection, _itemsPath?.Path);
-
-                    break;
-
-                case NotifyCollectionChangedAction.Replace:
-                    // Replacing a group requires special handling, because we need to fire 2 CollectionChanged
-                    // notifications. One remove with all the items being removed by the old groups,
-                    // and another with the new items being added. 
-
-                    // Remove the items & fire the notification
-                    List<object> remove = new List<object>();
-                    int start = GetItemCountToIndex(args.OldStartingIndex);
-                    for (int i = args.OldStartingIndex; i < args.OldStartingIndex + args.OldItems.Count; i++)
-                    {
-                        if (CollectionGroups[i].GroupItems != null)
-                        {
-                            itemCount += CollectionGroups[i].GroupItems.Count;
-                            remove.AddRange(CollectionGroups[i].GroupItems);
-                        }
-                    }
-                    CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
-                        remove, start));
-
-                    _count -= itemCount;
-
-                    remove.Clear();
-                    itemCount = 0;
-                    // Now add the new group back in
-                    for (int i = args.NewStartingIndex; i < args.NewStartingIndex + args.NewItems.Count; i++)
-                    {
-                        var newGroup = new CollectionViewGroup(this, args.NewItems[idx++], _itemsPath);
-                        CollectionGroups[i] = newGroup;
-
-                        if (newGroup.GroupItems != null)
-                            remove.AddRange(newGroup.GroupItems);
-
-                        itemCount += newGroup.GroupItems?.Count ?? 0;
-
-                        if (newGroup.GroupItems == null || newGroup.GroupItems.Count == 0)
-                            continue;
-                    }
-
-                    CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add,
-                           remove, start));
-
-                    _count += itemCount;
-                    break;
-
-                case NotifyCollectionChangedAction.Move:
-                    // Moving doesn't adjust the overall item count, but we do need to reorder the CollectionGroups
-                    // and propagate the move notification
-
-                    for (int i = args.OldStartingIndex; i < args.OldStartingIndex + args.OldItems.Count; i++)
-                    {
-                        var group = CollectionGroups[i];
-                        int oldIndex = GetItemCountToIndex(i);
-                        int newIndex = GetItemCountToIndex(args.NewStartingIndex + idx);
-                        CollectionGroups.Move(i, args.NewStartingIndex + idx);
-
-                        if (group.GroupItems == null || group.GroupItems.Count == 0)
-                        {
-                            idx++;
-                            continue;
-                        }
-
-                        CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move,
-                            group.GroupItems as IList,
-                            newIndex, oldIndex));
-
-                        idx++;
-                    }
-                    break;
-            }
-
+        if (CollectionGroups == null)
+        {
+            // First time
+            CollectionGroups = new AvaloniaList<ICollectionViewGroup>(groups);
         }
         else
         {
-            switch (args.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    _count += args.NewItems.Count;
-                    break;
+            // Source INCC reset event
+            CollectionGroups.Clear();
+            CollectionGroups.AddRange(groups);
+        }
+    }
 
-                case NotifyCollectionChangedAction.Remove:
-                    _count -= args.OldItems.Count;
-                    break;
+    private void OnBackingCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+    {
+        bool isSpecialized = _hasSortOrFilter;
+        var groups = CollectionGroups;
+        int dItems = 0;
+        switch (args.Action)
+        {
+            case NotifyCollectionChangedAction.Add:
+                {
+                    var insertIndexInView = GetItemCountToIndex(groups, args.NewStartingIndex);
+                    using var list = new PooledList<CollectionViewGroup>(args.NewItems.Count);
 
-                case NotifyCollectionChangedAction.Reset:
-                    if (args.OldItems != null)
+                    for (int i = 0; i < args.NewItems.Count; i++)
                     {
-                        _count -= args.OldItems.Count;
+                        var g = isSpecialized ?
+                            new SpecializedCollectionViewGroup(this, args.NewItems[i], _itemsBinding != null) :
+                            new CollectionViewGroup(this, args.NewItems[i], _itemsBinding != null);
+                        dItems += g.GroupItems.Count;
+                        list.Add(g);
+                    }
+
+                    groups.InsertRange(args.NewStartingIndex, list);
+
+                    if (dItems == 0)
+                        return;
+
+                    _count += dItems;
+
+                    IList<object> inccList = PopulateINCCList(args.NewStartingIndex, args.NewItems.Count, dItems);
+
+                    OnVectorChanged(new NotifyCollectionChangedEventArgs(
+                            NotifyCollectionChangedAction.Add, (IList)inccList, insertIndexInView));
+
+                    if (inccList is IDisposable d)
+                        d.Dispose();
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Remove:
+                {
+                    var insertIndexInView = GetItemCountToIndex(CollectionGroups, args.OldStartingIndex);
+                    dItems = GetItemCount(args.OldStartingIndex, args.OldItems.Count);
+
+                    IList<object> inccList = PopulateINCCList(args.OldStartingIndex, args.OldItems.Count, dItems);
+
+                    groups.RemoveRange(args.OldStartingIndex, args.OldItems.Count);
+
+                    if (dItems > 0)
+                    {
+                        _count -= dItems;
+
+                        OnVectorChanged(new NotifyCollectionChangedEventArgs(
+                            NotifyCollectionChangedAction.Remove, (IList)inccList, insertIndexInView));
+                    }
+
+                    if (inccList is IDisposable d)
+                        d.Dispose();
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Replace:
+                {
+                    var insertIndexInView = GetItemCountToIndex(groups, args.NewStartingIndex);
+                    dItems = GetItemCount(args.OldStartingIndex, args.OldItems.Count);
+
+                    IList<object> inccListOld = PopulateINCCList(args.OldStartingIndex, args.NewItems.Count, dItems);
+
+                    _count -= dItems;
+
+                    using var list = new PooledList<CollectionViewGroup>(args.NewItems.Count);
+                    dItems = 0;
+                    for (int i = 0; i < args.NewItems.Count; i++)
+                    {
+                        var g = isSpecialized ?
+                            new SpecializedCollectionViewGroup(this, args.NewItems[i], _itemsBinding != null) :
+                            new CollectionViewGroup(this, args.NewItems[i], _itemsBinding != null);
+                        dItems += g.GroupItems.Count;
+                        list.Add(g);
+                    }
+
+                    _count += dItems;
+                    CollectionGroups.InsertRange(args.NewStartingIndex, list);
+                    IList<object> inccListNew = null;
+
+                    if (dItems > 0)
+                    {
+                        inccListNew = PopulateINCCList(args.NewStartingIndex, args.NewItems.Count, dItems);
+
+                        OnVectorChanged(new NotifyCollectionChangedEventArgs(
+                            NotifyCollectionChangedAction.Replace,
+                            (IList)inccListNew, (IList)inccListOld, insertIndexInView));
+                    }
+
+                    if (inccListNew is IDisposable d)
+                        d.Dispose();
+
+                    if (inccListOld is IDisposable d2)
+                        d2.Dispose();
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Reset:
+                {
+                    _count = 0;
+                    CollectionGroups.Clear();
+                    CreateGroups();
+
+                    OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                }
+                break;
+
+            case NotifyCollectionChangedAction.Move:
+                {
+                    var removeIndexInView = GetItemCountToIndex(CollectionGroups, args.OldStartingIndex);
+                    dItems = GetItemCount(args.OldStartingIndex, args.OldItems.Count);
+                    var inccList = PopulateINCCList(args.OldStartingIndex, args.OldItems.Count, dItems);
+
+                    if (args.OldItems.Count == 1)
+                    {
+                        CollectionGroups.Move(args.OldStartingIndex, args.NewStartingIndex);
                     }
                     else
                     {
-                        _count = _collection.Count();
+                        // MoveRange is really flaky and may not give the desired result
+                        // it will fall apart with 1 item moves
+                        //   new[] {0,1,2} --> MoveRange(0,1,2) -> {1,0,2}, but should be {1,2,0}
+                        CollectionGroups.MoveRange(args.OldStartingIndex, args.OldItems.Count, args.NewStartingIndex);
                     }
-                    break;
 
-                    // Move/Replace don't modify count, no action required
-            }
+                    var insertIndexInView = GetItemCountToIndex(CollectionGroups, args.NewStartingIndex);
 
-            CollectionChanged?.Invoke(this, args);
+                    OnVectorChanged(new NotifyCollectionChangedEventArgs(
+                            NotifyCollectionChangedAction.Move, (IList)inccList,
+                            insertIndexInView, removeIndexInView));
+                }
+                break;
         }
 
+        IList<object> PopulateINCCList(int groupStart, int groupCount, int itemCount)
+        {
+            IList<object> list;
+            if (itemCount > 1024)
+            {
+                var l = new List<object>(itemCount);
+                for (int i = groupStart; i < groupStart + groupCount; i++)
+                {
+                    var g = CollectionGroups[i];
+                    if (g.GroupItems.Count == 0)
+                        continue;
 
+                    l.AddRange(g.GroupItems);
+                }
+                list = l;
+            }
+            else
+            {
+                var l = new PooledList<object>(itemCount);
+                for (int i = groupStart; i < groupStart + groupCount; i++)
+                {
+                    var g = CollectionGroups[i];
+                    if (g.GroupItems.Count == 0)
+                        continue;
 
+                    l.AddRange(g.GroupItems);
+                }
+                list = l;
+            }
 
+            return list;
+        }
 
+        int GetItemCount(int start, int count)
+        {
+            int ct = 0;
+            for (int i = start; i < start + count; i++)
+            {
+                ct += CollectionGroups[i].GroupItems.Count;
+            }
 
+            return ct;
+        }
 
-        //int idx = 0;
-        //switch (args.Action)
-        //{
-        //	case NotifyCollectionChangedAction.Add:
-        //		if (_isGrouped) 
-        //		{
-        //			// A group has been added, we need to add a CollectionGroup and update the total count
-        //			// If the group is not empty, we'll also propagate the CollectionChanged
-        //			int tracker = 0;
-        //			for (int i = 0; i < args.NewStartingIndex; i++)
-        //			{
-        //				tracker += CollectionGroups[i].GroupItems?.Count ?? 0;
-        //			}
+        static int GetItemCountToIndex(IList<ICollectionViewGroup> groups, int index)
+        {
+            int ct = 0;
+            for (int i = 0; i < groups.Count; i++)
+            {
+                if (i == index)
+                    break;
 
-        //			for (int i = args.NewStartingIndex; i < args.NewStartingIndex + args.NewItems.Count; i++)
-        //			{
-        //				var g = new CollectionViewGroup(this, args.NewItems[idx++], _itemsPath);
-        //				_count += g.GroupItems?.Count ?? 0;
-        //				CollectionGroups.Insert(i, g);
+                ct += groups[i].GroupItems?.Count ?? 0;
+            }
 
-        //				if (g.GroupItems != null && g.GroupItems.Count > 0)
-        //				{
-        //					CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add,
-        //						g.GroupItems, tracker));
+            return ct;
+        }
+    }
 
-        //					tracker += g.GroupItems.Count;
-        //				}
-        //			}
-        //		}
-        //		break;
+    internal IEnumerable GetItemsFromGroup(object group)
+    {
+        _helper ??= new BindingHelper();
 
-        //	case NotifyCollectionChangedAction.Remove:
-        //		break;
+        var items = _helper.Evaluate(_itemsBinding, group) as IEnumerable;
 
-        //	case NotifyCollectionChangedAction.Replace:
-        //		break;
+        if (items == null)
+            throw new ArgumentException($"Unable to resolve items from group of type {group.GetType()}");
 
-        //	case NotifyCollectionChangedAction.Reset:
-        //		break;
-
-        //	case NotifyCollectionChangedAction.Move:
-        //		break;
-        //}
-
-
-
-
-        //if (_isGrouped)
-        //{
-        //	int idx = 0;
-        //	int itemCount = 0;
-        //	switch (args.Action)
-        //	{
-        //		case NotifyCollectionChangedAction.Add:
-        //			for (int i = args.NewStartingIndex; i < args.NewStartingIndex + args.NewItems.Count; i++)
-        //			{
-        //				var g = new CollectionViewGroup(this, args.NewItems[idx++], _itemsPath);
-        //				itemCount += g.GroupItems.Count;
-        //				CollectionGroups.Insert(i, g);
-        //			}
-
-        //			_count += itemCount;
-        //			break;
-
-        //		case NotifyCollectionChangedAction.Remove:
-        //			for (int i = args.OldStartingIndex + args.OldItems.Count - 1; i >= args.OldStartingIndex; i--)
-        //			{
-        //				_count -= CollectionGroups[i].GroupItems.Count;
-        //				CollectionGroups.RemoveAt(i);
-        //			}
-        //			break;
-
-        //		case NotifyCollectionChangedAction.Replace:
-        //			for (int i = args.OldStartingIndex + args.OldItems.Count - 1; i >= args.OldStartingIndex; i--)
-        //			{
-        //				_count -= CollectionGroups[i].GroupItems.Count;
-        //			}
-
-        //			for (int i = args.NewStartingIndex; i < args.NewStartingIndex + args.NewItems.Count; i++)
-        //			{
-        //				var g = new CollectionViewGroup(this, args.NewItems[idx++], _itemsPath);
-        //				itemCount += g.GroupItems.Count;
-        //				CollectionGroups.Insert(i, g);
-        //			}
-
-        //			_count += itemCount;
-        //			break;
-
-        //		case NotifyCollectionChangedAction.Reset:
-        //			break;
-
-        //		case NotifyCollectionChangedAction.Move:
-        //			break;
-        //	}
-        //}
-        //else
-        //{
-        //	// If not grouping, just propagate the event
-        //	CollectionChanged?.Invoke(sender, args);
-        //}
+        return items;
     }
 
     internal void GroupItemsChanged(ICollectionViewGroup sender, NotifyCollectionChangedEventArgs args)
     {
+        // With sorting/filtering, ignore events here when bulk operations are happening
+        if (_ignoreGroupChanges)
+            return;
+
         // We need to translate the index from the ICollectionViewGroup to the flattened collection
         // that the ICollectionView represents
         int TranslateGroupIndexToFlattenedIndex(int index)
@@ -434,22 +550,19 @@ internal class GroupedDataCollectionView : ICollectionView, IList
                 break;
 
             case NotifyCollectionChangedAction.Reset:
-                // Reset just marks the list invalid, OldItems may be null
-                if (args.OldItems != null)
+                if (sender is CollectionViewGroup g)
                 {
-                    // We're fortunate enough to get the old items, we can just subtract the count
-                    _count -= args.OldItems.Count;
+                    g.UpdateGroup(sender.Group);
                 }
-                else
+
+                // Because this is a reset, we have to recalculate the view count as we probably
+                // don't have the info in the EventArgs, and the actual list is already cleared
+                var ct = 0;
+                for (int i = 0; i < CollectionGroups.Count; i++)
                 {
-                    // Since we don't know how many were removed or changed here, we need to loop over
-                    // all the groups again and get the count
-                    _count = 0;
-                    for (int i = 0; i < CollectionGroups.Count; i++)
-                    {
-                        _count += CollectionGroups[i].GroupItems?.Count ?? 0;
-                    }
+                    ct += CollectionGroups[i].GroupItems.Count;
                 }
+                _count = ct;
 
                 newArgs = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
                 break;
@@ -472,351 +585,292 @@ internal class GroupedDataCollectionView : ICollectionView, IList
         }
 
         CollectionChanged?.Invoke(sender, newArgs);
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
     }
 
-    private void CreateGroups(IEnumerable collection, string itemsPath = null)
+
+    // SORTING & FILTERING 
+
+    internal IList<SortDescription> GetSortDescriptions()
     {
-        var groups = new List<CollectionViewGroup>();
-
-        // ItemsPath is only respected with grouping
-        if (!string.IsNullOrEmpty(itemsPath))
-            _itemsPath = new PropertyPath(itemsPath);
-
-        if (collection is IList list)
-        {
-            for (int i = 0; i < list.Count; i++)
-            {
-                var cvg = new CollectionViewGroup(this, list[i], _itemsPath);
-                groups.Add(cvg);
-                _count += groups[groups.Count - 1].GroupItems?.Count ?? 0;
-            }
-        }
-        else if (collection is IList<object> genList)
-        {
-            for (int i = 0; i < genList.Count; i++)
-            {
-                var cvg = new CollectionViewGroup(this, genList[i], _itemsPath);
-                groups.Add(cvg);
-                _count += groups[groups.Count - 1].GroupItems?.Count ?? 0;
-            }
-        }
-        else
-        {
-            foreach (var item in collection)
-            {
-                var cvg = new CollectionViewGroup(this, item, _itemsPath);
-                groups.Add(cvg);
-                _count += groups[groups.Count - 1].GroupItems?.Count ?? 0;
-            }
-        }
-
-        if (CollectionGroups == null) // First time
-        {
-            CollectionGroups = new AvaloniaList<ICollectionViewGroup>(groups);
-        }
-        else // Collection Reset (CollectionGroups should already be cleared)
-        {
-            CollectionGroups.AddRange(groups);
-        }
-
-        //CollectionGroups.CollectionChanged += (s, e) =>
-        //{
-        //	Debug.WriteLine("CollectionGroups changed");
-        //};
+        // The getter for the property will materialize the items
+        // Therefore, we need a way to get the sort descriptions for SpecializedCollectionViewGroup
+        // without materializing if there aren't any sort descriptions
+        return _sortDescriptions;
     }
 
-    private object GetCurrentGrouped(int index)
-    {
-        if (index == -1)
-            return null;
+    internal HashSet<string> GetFilterProperties() => _filterProperties;
 
-        int tracker = 0;
-        for (int i = 0; i < CollectionGroups.Count; i++)
+    public void Refresh()
+    {
+        var currentItem = CurrentItem;
+
+        var groups = CollectionGroups;
+        int count = 0;
+        foreach (var g in groups)
         {
-            if (CollectionGroups[i] is ICollectionViewGroup g)
+            count += (g as SpecializedCollectionViewGroup).Refresh();
+        }
+
+        _count = count;
+        OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        MoveCurrentTo(currentItem);
+    }
+
+    public void RefreshFilter()
+    {
+        HandleFilterChanged();
+    }
+
+    public void RefreshSorting()
+    {
+        HandleSortChanged();
+    }
+
+    public void AddFilterProperty(string propertyName)
+    {
+        if (!IsLiveShapingEnabled)
+            return;
+
+        _filterProperties.Add(propertyName);
+    }
+
+    public void RemoveFilterProperty(string propertyName)
+    {
+        if (!IsLiveShapingEnabled)
+            return;
+
+        _filterProperties.Remove(propertyName);
+    }
+
+    public void ClearFilterProperties()
+    {
+        if (!IsLiveShapingEnabled)
+            return;
+
+        _filterProperties.Clear();
+    }
+
+    private void OnSortDescriptionsChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (DeferCounter > 0)
+            return;
+
+        HandleSortChanged();
+    }
+
+    private void HandleSortChanged()
+    {
+        try
+        {
+            _ignoreGroupChanges = true;
+
+            var groups = CollectionGroups;
+            foreach (var group in groups)
             {
-                if (index >= tracker + g.GroupItems.Count)
+                (group as SpecializedCollectionViewGroup).HandleSortChanged();
+            }
+
+            OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+        finally
+        {
+            _ignoreGroupChanges = false;
+        }
+    }
+
+    private void HandleFilterChanged()
+    {
+        try
+        {
+            _ignoreGroupChanges = true;
+
+            if (_filter != null)
+            {
+                int count = 0;
+                var groups = CollectionGroups;
+                foreach (var group in groups)
                 {
-                    tracker += g.GroupItems.Count;
-                    continue;
+                    count += (group as SpecializedCollectionViewGroup).HandleFilterChanged(_filter);
                 }
 
-                int realIndex = index - tracker;
-
-                return g.GroupItems[realIndex];
+                // Now raise a collection wise reset
+                _count = count;
+                OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            }
+            else
+            {
+                Refresh();
             }
         }
-
-        return null;
-    }
-
-    public Task<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
-    {
-        throw new NotImplementedException();
-    }
-
-    public bool MoveCurrentTo(object item) =>
-        MoveCurrentToPosition(IndexOf(item));
-
-    public bool MoveCurrentToFirst() =>
-        MoveCurrentToPosition(Count > 0 ? 0 : -1);
-
-    public bool MoveCurrentToLast()
-        => MoveCurrentToPosition(Count > 0 ? Count - 1 : -1);
-
-    public bool MoveCurrentToNext() =>
-        MoveCurrentToPosition(CurrentPosition + 1);
-
-    public bool MoveCurrentToPrevious() =>
-        MoveCurrentToPosition(CurrentPosition - 1);
-
-    public bool MoveCurrentToPosition(int pos)
-    {
-        if (pos == CurrentPosition)
-            return true;
-
-        if (pos < 0 || pos >= Count)
-            return false;
-
-        var args = new CurrentChangingEventArgs();
-        CurrentChanging?.Invoke(this, args);
-
-        if (args.Cancel)
-            return false;
-
-        CurrentPosition = pos;
-        CurrentChanged?.Invoke(this, null);
-
-        return true;
-    }
-
-    public int IndexOf(object item)
-    {
-        if (!_isGrouped)
-            return _collection.IndexOf(item);
-
-        int index = 0;
-        for (int i = 0; i < CollectionGroups.Count; i++)
+        finally
         {
-            var tmp = CollectionGroups[i].GroupItems.IndexOf(item);
-            if (tmp != -1)
-                return index + tmp;
-
-            index += CollectionGroups[i].GroupItems.Count;
+            _ignoreGroupChanges = false;
         }
-
-        return -1;
     }
 
-    void IList.Insert(int index, object item) => Insert(index, item);
-
-    public void Insert(int index, object item)
+    private void OnVectorChanged(NotifyCollectionChangedEventArgs args)
     {
-        if (_isGrouped)
-            throw new NotImplementedException("Modifying a grouped CollectionView is not supported. Edit the source collection(s) instead."); // WinUI throws this when grouping
-
-        if (_collection is IList<object> genList)
-        {
-            genList.Insert(index, item);
-            _count++;
-        }
-        else if (_collection is IList list)
-        {
-            list.Insert(index, item);
-            _count++;
-        }
-        else
-            throw new NotSupportedException("Collection is not mutable");
+        CollectionChanged?.Invoke(this, args);
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
     }
 
-    void IList.RemoveAt(int index) => RemoveAt(index);
 
-    public void RemoveAt(int index)
-    {
-        if (_isGrouped)
-            throw new NotImplementedException("Modifying a grouped CollectionView is not supported. Edit the source collection(s) instead."); // WinUI throws this when grouping
 
-        if (_collection is IList<object> genList)
-        {
-            genList.RemoveAt(index);
-            _count--;
-        }
-        else if (_collection is IList list)
-        {
-            list.RemoveAt(index);
-            _count--;
-        }
-        else
-            throw new NotSupportedException("Collection is not mutable");
-    }
+    // Editing the collection view is a no-op when grouping, these all throw
 
-    int IList.Add(object item)
-    {
-        Add(item);
-        return _count;
-    }
+    public void Add(object item) => ThrowICollectionViewNotMutableWhenGrouping();
 
-    public void Add(object item) =>
-        Insert(_count, item);
-
-    void IList.Clear() => Clear();
-
-    public void Clear()
-    {
-        if (_isGrouped)
-            throw new NotImplementedException(); // WinUI throws this when grouping
-
-        if (_collection is IList<object> genList)
-        {
-            genList.Clear();
-            _count = 0;
-        }
-        else if (_collection is IList list)
-        {
-            list.Clear();
-            _count = 0;
-        }
-        else
-            throw new NotSupportedException("Collection is not mutable");
-    }
-
-    bool IList.Contains(object value) => Contains(value);
-
-    public bool Contains(object item) => IndexOf(item) != -1;
-
-    public void CopyTo(object[] array, int arrayIndex) =>
-        throw new NotImplementedException();
-
-    void IList.Remove(object item) => Remove(item);
+    public void Insert(int index, object item) => ThrowICollectionViewNotMutableWhenGrouping();
 
     public bool Remove(object item)
     {
-        if (_isGrouped)
-            throw new NotImplementedException("Modifying a grouped CollectionView is not supported. Edit the source collection(s) instead."); // WinUI throws this when grouping
-
-        if (_collection is IList<object> genList)
-        {
-            _count--;
-            return genList.Remove(item);
-        }
-        else if (_collection is IList list)
-        {
-            _count--;
-            list.Remove(item);
-            return true;
-        }
-        else
-            throw new NotSupportedException("Collection is not mutable");
+        ThrowICollectionViewNotMutableWhenGrouping();
+        return false;
     }
 
-    public IEnumerator<object> GetEnumerator()
-    {
-        if (!_isGrouped)
-            return (_collection as IEnumerable<object>)?.GetEnumerator();
+    public void RemoveAt(int index) => ThrowICollectionViewNotMutableWhenGrouping();
 
-        return new GroupEnumerator(this);
-    }
+    public void Clear() => ThrowICollectionViewNotMutableWhenGrouping();
 
-    public void CopyTo(Array array, int index)
-    {
+    bool IList.IsFixedSize => _source is IList l && l.IsFixedSize;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => null;
+
+    int ICollection.Count => _count;
+
+    Task<LoadMoreItemsResult> ICollectionView.LoadMoreItemsAsync(uint count) =>
         throw new NotImplementedException();
-    }
 
-    IEnumerator IEnumerable.GetEnumerator()
+    bool ICollectionView.HasMoreItems => false;
+
+    void IList.Insert(int index, object item) => ThrowICollectionViewNotMutableWhenGrouping();
+
+    void IList.RemoveAt(int index) => ThrowICollectionViewNotMutableWhenGrouping();
+
+    int IList.Add(object item)
     {
-        if (!_isGrouped)
-            return (_collection as IEnumerable).GetEnumerator();
-
-        return new GroupEnumerator(this);
+        ThrowICollectionViewNotMutableWhenGrouping();
+        return -1;
     }
 
-    private IEnumerable _collection;
-    private bool _isGrouped;
-    private PropertyPath _itemsPath;
+    void IList.Clear() => ThrowICollectionViewNotMutableWhenGrouping();
+
+    bool IList.Contains(object value) => Contains(value);
+
+    void IList.Remove(object value) => Remove(value);
+
+    void ICollection.CopyTo(Array array, int index)
+    {
+        CopyTo((object[])array, index);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => new GroupEnumerator(this);
+
+    private static void ThrowICollectionViewNotMutableWhenGrouping()
+    {
+        throw new InvalidOperationException("CollectionView is not mutable when grouping. Edit the source collection or group lists instead");
+    }
+
+    private IEnumerable _source;
+    private IBinding _itemsBinding;
     private int _count;
-}
+    private static BindingHelper _helper;
+    private bool _hasSortOrFilter;
+    private Predicate<object> _filter;
+    private HashSet<string> _filterProperties;
+    private IList<SortDescription> _sortDescriptions;
+    private bool _ignoreGroupChanges;
 
-internal class GroupEnumerator : IEnumerator, IEnumerator<object>
-{
-    public GroupEnumerator(GroupedDataCollectionView owner)
+    internal class BindingHelper : StyledElement
     {
-        _owner = owner;
+        public static readonly StyledProperty<object> ValueProperty =
+            AvaloniaProperty.Register<BindingHelper, object>("Value");
+
+        public object Evaluate(IBinding binding, object dataContext)
+        {
+            dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
+
+            if (binding is null)
+            {
+                _lastBinding = null;
+                return dataContext;
+            }
+
+            if (!dataContext.Equals(DataContext))
+                DataContext = dataContext;
+
+            if (_lastBinding != binding)
+            {
+                _lastBinding = binding;
+                var ib = binding.Initiate(this, ValueProperty);
+                BindingOperations.Apply(this, ValueProperty, ib, null);
+            }
+
+            return GetValue(ValueProperty);
+        }
+
+        private IBinding _lastBinding;
     }
 
-    public object Current { get; private set; }
 
-    public bool MoveNext()
+    private struct GroupEnumerator : IEnumerator, IEnumerator<object>
     {
-        int groupCount = _owner.CollectionGroups.Count;
-        if (groupCount == 0)
-            return false;
-
-        if (_lastGroupIndex == groupCount - 1)
+        public GroupEnumerator(GroupedDataCollectionView owner)
         {
-            if (_owner.CollectionGroups[_lastGroupIndex] is ICollectionViewGroup g)
-            {
-                if (_curPos == g.GroupItems.Count - 1) //End of Collection
-                {
-                    Current = null;
-                    return false;
-                }
-                else
-                {
-                    // While we're in the last group, handle this here...
-                    _curPos++;
-                    Current = g.GroupItems[_curPos];
-                    return true;
-                }
-            }
+            _owner = owner;
         }
-        else
+
+        public object Current { get; private set; }
+
+        public bool MoveNext()
         {
-            // We're not in the last group, proceed as normal
+            int groupCount = _owner.CollectionGroups.Count;
+
+            if (groupCount == 0)
+                return false;
+
             if (_lastGroupIndex == -1)
                 _lastGroupIndex = 0;
 
-            var g = _owner.CollectionGroups[_lastGroupIndex] as ICollectionViewGroup;
-            if (g == null)
-                return false;
-
-            if (_curPos == g.GroupItems.Count - 1)
-            {
-                //move to the next group
-                //Some groups may contain no items, so we need to search for it
-                for (int i = _lastGroupIndex + 1; i < groupCount; i++)
-                {
-                    if (_owner.CollectionGroups[i] is ICollectionViewGroup nextG &&
-                        g.GroupItems.Count > 0)
-                    {
-                        _lastGroupIndex = i;
-                        g = nextG;
-                        _curPos = -1;
-                        break;
-                    }
-                }
-            }
+            var g = _owner.CollectionGroups[_lastGroupIndex];
 
             _curPos++;
+
+            // We've reached the end
+            if (_curPos == g.GroupItems.Count && _lastGroupIndex == _owner.CollectionGroups.Count - 1)
+            {
+                Current = null;
+                return false;
+            }
+            else if (_curPos == g.GroupItems.Count)
+            {
+                // We've reached the end of the current group, move to the next
+                _curPos = 0;
+                _lastGroupIndex++;
+                g = _owner.CollectionGroups[_lastGroupIndex];
+            }
+
             Current = g.GroupItems[_curPos];
             return true;
         }
 
-        return false;//Not sure why this is needed, the else should handle everything???
-    }
+        public void Reset()
+        {
+            _lastGroupIndex = -1;
+            _curPos = -1;
+            Current = null;
+        }
 
-    public void Reset()
-    {
-        _lastGroupIndex = -1;
-        _curPos = -1;
-        Current = null;
-    }
+        public void Dispose()
+        {
+            // N/A
+        }
 
-    public void Dispose()
-    {
-        // N/A
+        private int _curPos = -1;
+        private int _lastGroupIndex = -1;
+        private GroupedDataCollectionView _owner;
     }
-
-    private int _curPos = -1;
-    private int _lastGroupIndex = -1;
-    private GroupedDataCollectionView _owner;
 }

--- a/src/FluentAvalonia/UI/Data/CollectionView/IAdvancedCollectionView.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/IAdvancedCollectionView.cs
@@ -1,0 +1,51 @@
+﻿using System.ComponentModel;
+
+namespace FluentAvalonia.UI.Data;
+
+/// <summary>
+/// Expands <see cref="ICollectionView"/> to support filtering and sorting of items
+/// </summary>
+public interface IAdvancedCollectionView : ICollectionView, INotifyPropertyChanged
+{
+    /// <summary>
+    /// Gets or sets the filter applied to the items in the CollectionView
+    /// </summary>
+    Predicate<object> Filter { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of items used to sort the items in the CollectionView
+    /// </summary>
+    IList<SortDescription> SortDescriptions { get; }
+
+    /// <summary>
+    /// Performs a full refresh of the items in the CollectionView
+    /// </summary>
+    void Refresh();
+
+    /// <summary>
+    /// Refreshes in the items in the CollectionView for an update to the filter
+    /// </summary>
+    void RefreshFilter();
+
+    /// <summary>
+    /// Refreshes the items in the CollectionView for an update to the sort descriptions
+    /// </summary>
+    void RefreshSorting();
+
+    /// <summary>
+    /// Adds a property the CollectionView should monitor via <see cref="INotifyPropertyChanged"/>
+    /// to trigger updates. CollectionView must support live shaping
+    /// </summary>
+    void AddFilterProperty(string propertyName);
+
+    /// <summary>
+    /// Removes a property from being observed for live shaping
+    /// </summary>
+    /// <param name="propertyName"></param>
+    void RemoveFilterProperty(string propertyName);
+
+    /// <summary>
+    /// Clears all the properties the CollectionView monitors for live shaping
+    /// </summary>
+    void ClearFilterProperties();
+}

--- a/src/FluentAvalonia/UI/Data/CollectionView/ICollectionView.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/ICollectionView.cs
@@ -1,8 +1,5 @@
 ﻿using Avalonia.Collections;
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Threading.Tasks;
 
 namespace FluentAvalonia.UI.Data;
 

--- a/src/FluentAvalonia/UI/Data/CollectionView/ICollectionViewGroup.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/ICollectionViewGroup.cs
@@ -1,6 +1,4 @@
-﻿using Avalonia.Collections;
-
-namespace FluentAvalonia.UI.Data;
+﻿namespace FluentAvalonia.UI.Data;
 
 /// <summary>
 /// Represents any grouped items within a view
@@ -16,5 +14,5 @@ public interface ICollectionViewGroup
     /// <summary>
     /// Gets the collection of grouped items that this ICollectionViewGroup implementation represents
     /// </summary>
-    IAvaloniaList<object> GroupItems { get; }
+    IList<object> GroupItems { get; }
 }

--- a/src/FluentAvalonia/UI/Data/CollectionView/IterableCollectionView.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/IterableCollectionView.cs
@@ -1,0 +1,758 @@
+﻿// Sorting & Filtering adapted from the WindowsCommunityToolkit
+// AdvancedCollectionView - MIT license
+
+using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Data;
+using FluentAvalonia.Core;
+
+namespace FluentAvalonia.UI.Data;
+
+public sealed class IterableCollectionView : ICollectionView, IAdvancedCollectionView, IList, IComparer<object>
+{
+    public IterableCollectionView(IEnumerable collection)
+        : this(collection, false, null, null, null) { }
+
+    public IterableCollectionView(IEnumerable collection, bool isLiveShaping)
+        : this(collection, isLiveShaping, null, null, null) { }
+
+    public IterableCollectionView(IEnumerable collection, Predicate<object> filter)
+        : this(collection, false, filter, null, null) { }
+
+    public IterableCollectionView(IEnumerable collection, Predicate<object> filter,
+        IList<string> filterProperties)
+        : this(collection, true, filter, filterProperties, null) { }
+
+    public IterableCollectionView(IEnumerable collection, IList<SortDescription> sortDescriptions)
+        : this(collection, false, null, null, sortDescriptions) { }
+
+    public IterableCollectionView(IEnumerable collection, bool isLiveShaping,
+        Predicate<object> filter, IList<string> filterProperties,
+        IList<SortDescription> sortDescriptions)
+    {
+        collection = collection ?? throw new ArgumentNullException(nameof(collection));
+
+        _source = collection;
+        _sourceView = ItemsSourceView.GetOrCreate(collection);
+        _sourceView.CollectionChanged += SourceCollectionChanged;
+
+        IsLiveShapingEnabled = isLiveShaping;
+
+        // _view is only initialized if absolutely necessary
+        // - Either filter or sort is specified here
+        // - isLiveShaping is true, user may not have set filter/sort yet
+        if (filter != null || sortDescriptions != null || isLiveShaping)
+        {
+            _hasFilterOrSort = true;
+            _filter = filter;
+            if (isLiveShaping)
+            {
+                _filterProperties = filterProperties != null ? new HashSet<string>(filterProperties) :
+                    new HashSet<string>();
+            }
+
+            if (sortDescriptions != null)
+            {
+                var l = new AvaloniaList<SortDescription>(sortDescriptions);
+                l.CollectionChanged += OnSortDescriptionsChanged;
+                _sortDescriptions = l;
+            }
+
+            _view = new List<object>(_sourceView.Count);
+            AttachPropertyChangedHandler(_source);
+
+            HandleSourceChanged();
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsLiveShapingEnabled { get; }
+
+    public Predicate<object> Filter
+    {
+        get => _filter;
+        set
+        {
+            // Don't run an equality check, always update - otherwise we end up in a situation
+            // where you have to clear the filter and reapply it for something like a binding
+            // the filter to text input - and that's not ideal
+            _filter = value;
+            HandleFilterChanged();
+        }
+    }
+
+    public IList<SortDescription> SortDescriptions
+    {
+        get
+        {
+            if (_sortDescriptions == null)
+            {
+                var l = new AvaloniaList<SortDescription>();
+                l.CollectionChanged += OnSortDescriptionsChanged;
+                _sortDescriptions = l;
+            }
+
+            return _sortDescriptions;
+        }
+    }
+
+    public object this[int index]
+    {
+        get => _view != null ? _view[index] : _sourceView[index];
+        set
+        {
+            if (!(_source is IList))
+                ThrowForNonMutableSource();
+
+            ((IList)_source)[index] = value;
+        }
+    }
+
+    public int Count => _view != null ? _view.Count : _sourceView.Count;
+
+    public int CurrentPosition { get; private set; }
+
+    public bool HasMoreItems { get; private set; }
+
+    public bool IsCurrentAfterLast => CurrentPosition >= Count;
+
+    public bool IsCurrentBeforeFirst => CurrentPosition < 0;
+
+    public object CurrentItem
+    {
+        get
+        {
+            var max = _view?.Count ?? _sourceView.Count;
+            var pos = CurrentPosition;
+            if (pos < 0 || pos >= max)
+                return null;
+
+            if (_view != null)
+                return _view[pos];
+            else
+                return _sourceView[pos];
+        }
+    }
+
+    public bool IsReadOnly => _source is IList l ? l.IsReadOnly : false;
+
+    internal IEnumerable Source => _source;
+
+    public event EventHandler<object> CurrentChanged;
+    public event CurrentChangingEventHandler CurrentChanging;
+    public event NotifyCollectionChangedEventHandler CollectionChanged;
+    public event PropertyChangedEventHandler PropertyChanged;
+    public void Add(object item) => Insert(Count, item);
+
+    public void Clear()
+    {
+        if (IsReadOnly || !(_source is IList))
+            ThrowForNonMutableSource();
+
+        (_source as IList).Clear();
+    }
+
+    public bool Contains(object item) =>
+        _view?.Contains(item) ?? _source.Contains(item);
+
+    public void CopyTo(object[] array, int arrayIndex)
+    {
+        if (_view != null)
+        {
+            _view.CopyTo(array, arrayIndex);
+        }
+        else
+        {
+            var en = _source.GetEnumerator();
+            while (en.MoveNext())
+            {
+                array[arrayIndex++] = en.Current;
+            }
+        }
+    }
+
+    public IEnumerator<object> GetEnumerator()
+    {
+        static IEnumerator<object> Enumerate(IEnumerable items)
+        {
+            if (items == null)
+                yield break;
+
+            foreach (var item in items)
+                yield return item;
+        }
+
+        if (_view != null)
+        {
+            return _view.GetEnumerator();
+        }
+        else
+        {
+            return Enumerate(_source);
+        }
+    }
+
+    public int IndexOf(object item)
+    {
+        if (_view != null)
+        {
+            return _view.IndexOf(item);
+        }
+        else
+        {
+            return _source.IndexOf(item);
+        }
+    }
+
+    public void Insert(int index, object item)
+    {
+        if (!(_source is IList) || IsReadOnly)
+            ThrowForNonMutableSource();
+
+        ((IList)_source).Insert(index, item);
+    }
+
+    public bool MoveCurrentTo(object item) =>
+        item == CurrentItem || MoveCurrentToPosition(IndexOf(item));
+
+    public bool MoveCurrentToFirst() =>
+        MoveCurrentToPosition(Count > 0 ? 0 : -1);
+
+    public bool MoveCurrentToLast() =>
+        MoveCurrentToPosition(Count > 0 ? Count - 1 : -1);
+
+    public bool MoveCurrentToNext() =>
+        MoveCurrentToPosition(CurrentPosition + 1);
+
+    public bool MoveCurrentToPrevious() =>
+        MoveCurrentToPosition(CurrentPosition - 1);
+
+    public bool MoveCurrentToPosition(int pos)
+    {
+        if (pos == CurrentPosition)
+            return true;
+
+        if (pos < 0 || pos >= Count)
+            return false;
+
+        var args = new CurrentChangingEventArgs();
+        CurrentChanging?.Invoke(this, args);
+
+        if (args.Cancel)
+            return false;
+
+        CurrentPosition = pos;
+        CurrentChanged?.Invoke(this, null);
+
+        return true;
+    }
+
+    public bool Remove(object item)
+    {
+        if (IsReadOnly || !(_source is IList))
+            ThrowForNonMutableSource();
+
+        ((IList)_source).Remove(item);
+        return true;
+    }
+
+    public void RemoveAt(int index)
+    {
+        if (IsReadOnly || !(_source is IList))
+            ThrowForNonMutableSource();
+
+        ((IList)_source).RemoveAt(index);
+    }
+
+    public void Refresh()
+    {
+        HandleSourceChanged();
+    }
+
+    public void RefreshFilter()
+    {
+        HandleFilterChanged();
+    }
+
+    public void RefreshSorting()
+    {
+        HandleSortChanged();
+    }
+
+    public void AddFilterProperty(string propertyName)
+    {
+        if (!IsLiveShapingEnabled)
+            return;
+
+        _filterProperties.Add(propertyName);
+    }
+
+    public void RemoveFilterProperty(string propertyName)
+    {
+        if (!IsLiveShapingEnabled)
+            return;
+
+        _filterProperties.Remove(propertyName);
+    }
+
+    public void ClearFilterProperties()
+    {
+        if (!IsLiveShapingEnabled)
+            return;
+
+        _filterProperties.Clear();
+    }
+
+    public IDisposable DeferRefresh()
+    {
+        _deferCounter++;
+        return new RefreshDeferer(ReleaseDefer, CurrentItem);
+    }
+
+    internal void UpdateViewFromCollectionViewSource(Predicate<object> filter, IList<string> filterProperties,
+        IList<SortDescription> sortDescriptions)
+    {
+        using var defer = DeferRefresh();
+
+        _filterProperties.Clear();
+        if (filterProperties != null)
+        {
+            foreach (var prop in filterProperties)
+            {
+                AddFilterProperty(prop);
+            }
+        }
+
+        Filter = filter;
+
+        _sortDescriptions?.Clear();
+        if (sortDescriptions != null)
+        {
+            foreach (var item in sortDescriptions)
+            {
+                SortDescriptions.Add(item);
+            }
+        }
+    }
+
+    private void ReleaseDefer(object lastCurrentItem)
+    {
+        _deferCounter--;
+
+        if (_deferCounter == 0)
+        {
+            MoveCurrentTo(lastCurrentItem);
+            Refresh();
+        }
+    }
+
+    private void SourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+    {
+        if (_hasFilterOrSort)
+        {
+            switch (args.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    AttachPropertyChangedHandler(args.NewItems);
+                    if (_deferCounter <= 0)
+                    {
+                        if (args.NewItems.Count == 1)
+                        {
+                            HandleItemAdded(args.NewStartingIndex, args.NewItems[0]);
+                        }
+                        else
+                        {
+                            HandleSourceChanged();
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Remove:
+                    DetachPropertyChangedHandler(args.OldItems);
+                    if (_deferCounter <= 0)
+                    {
+                        if (args.OldItems.Count == 1)
+                        {
+                            HandleItemRemoved(args.OldStartingIndex, args.OldItems[0]);
+                        }
+                        else
+                        {
+                            HandleSourceChanged();
+                        }
+                    }
+                    break;
+
+                default:
+                    HandleSourceChanged();
+                    break;
+            }
+        }
+        else
+        {
+            // Just a simple CollectionView, just propagate the args
+            OnVectorChanged(args);
+        }
+    }
+
+    private void OnSortDescriptionsChanged(object sender, NotifyCollectionChangedEventArgs args)
+    {
+        if (_deferCounter > 0)
+            return;
+
+        HandleSortChanged();
+    }
+
+    private void ItemOnPropertyChanged(object item, PropertyChangedEventArgs args)
+    {
+        if (!IsLiveShapingEnabled)
+            return;
+
+        var filterResult = _filter?.Invoke(item);
+
+        if (filterResult.HasValue && _filterProperties.Contains(args.PropertyName))
+        {
+            var viewIndex = _view.IndexOf(item);
+            if (viewIndex != -1 && !filterResult.Value)
+            {
+                RemoveFromView(viewIndex, item);
+            }
+            else if (viewIndex == -1 && filterResult.Value)
+            {
+                var index = _source.IndexOf(item);
+                HandleItemAdded(index, item);
+            }
+        }
+
+        if ((filterResult ?? true) && _sortDescriptions?.Any(sd => sd.PropertyName == args.PropertyName) == true)
+        {
+            var oldIndex = _view.IndexOf(item);
+
+            // Check if item is in view:
+            if (oldIndex < 0)
+            {
+                return;
+            }
+
+            _view.RemoveAt(oldIndex);
+            var targetIndex = _view.BinarySearch(item, this);
+            if (targetIndex < 0)
+            {
+                targetIndex = ~targetIndex;
+            }
+
+            // Only trigger expensive UI updates if the index really changed:
+            if (targetIndex != oldIndex)
+            {
+                OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, oldIndex));
+
+                _view.Insert(targetIndex, item);
+
+                OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, targetIndex));
+            }
+            else
+            {
+                _view.Insert(targetIndex, item);
+            }
+        }
+        else if (string.IsNullOrEmpty(args.PropertyName))
+        {
+            HandleSourceChanged();
+        }
+    }
+
+    private void AttachPropertyChangedHandler(IEnumerable items)
+    {
+        if (!IsLiveShapingEnabled || items == null)
+        {
+            return;
+        }
+
+        foreach (var item in items.OfType<INotifyPropertyChanged>())
+        {
+            item.PropertyChanged += ItemOnPropertyChanged;
+        }
+    }
+
+    private void DetachPropertyChangedHandler(IEnumerable items)
+    {
+        if (!IsLiveShapingEnabled || items == null)
+        {
+            return;
+        }
+
+        foreach (var item in items.OfType<INotifyPropertyChanged>())
+        {
+            item.PropertyChanged -= ItemOnPropertyChanged;
+        }
+    }
+
+    private void HandleSourceChanged()
+    {
+        var currentItem = CurrentItem;
+        _view.Clear();
+
+        foreach (var item in _source)
+        {
+            if (_filter != null && !_filter(item))
+                continue;
+
+            if (_sortDescriptions != null && _sortDescriptions.Count > 0)
+            {
+                var targetIndex = _view.BinarySearch(item, this);
+                if (targetIndex < 0)
+                    targetIndex = ~targetIndex;
+
+                _view.Insert(targetIndex, item);
+            }
+            else
+            {
+                _view.Add(item);
+            }
+        }
+
+        OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        MoveCurrentTo(currentItem);
+    }
+
+    private void HandleSortChanged()
+    {
+        _view.Sort(this);
+        OnVectorChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    private void HandleFilterChanged()
+    {
+        if (_filter != null)
+        {
+            for (int i = 0; i < _view.Count; i++)
+            {
+                var item = _view.ElementAt(i);
+                if (_filter(item))
+                    continue;
+
+                RemoveFromView(i, item);
+                i--;
+            }
+
+            var viewHash = new HashSet<object>(_view);
+            var viewIndex = 0;
+            for (int i = 0; i < _sourceView.Count; i++)
+            {
+                var item = _sourceView[i];
+                if (viewHash.Contains(item))
+                {
+                    viewIndex++;
+                    continue;
+                }
+
+                if (HandleItemAdded(i, item, viewIndex))
+                {
+                    viewIndex++;
+                }
+            }
+        }
+        else
+        {
+            Refresh();
+        }
+    }
+
+    private bool HandleItemAdded(int newStartingIndex, object newItem, int? viewIndex = null)
+    {
+        if (_filter != null && !_filter(newItem))
+            return false;
+
+        var newViewIndex = _view.Count;
+
+        if (_sortDescriptions != null && _sortDescriptions.Count > 0)
+        {
+            //_sortProperties.Clear();
+            newViewIndex = _view.BinarySearch(newItem, this);
+            if (newViewIndex < 0)
+                newViewIndex = ~newViewIndex;
+        }
+        else if (_filter != null)
+        {
+            if (_source == null)
+            {
+                HandleSourceChanged();
+                return false;
+            }
+
+            if (newStartingIndex == 0 || _view.Count == 0)
+            {
+                newViewIndex = 0;
+            }
+            else if (newStartingIndex == _sourceView.Count - 1)
+            {
+                newViewIndex = _view.Count - 1;
+            }
+            else if (viewIndex.HasValue)
+            {
+                newViewIndex = viewIndex.Value;
+            }
+            else
+            {
+                for (int i = 0, j = 0; i < _sourceView.Count; i++)
+                {
+                    if (i == newStartingIndex)
+                    {
+                        newViewIndex = j;
+                        break;
+                    }
+
+                    if (_view[j] == _sourceView[i])
+                    {
+                        j++;
+                    }
+                }
+            }
+        }
+
+        _view.Insert(newViewIndex, newItem);
+        if (newViewIndex <= CurrentPosition)
+        {
+            CurrentPosition++;
+        }
+
+        var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add,
+            newItem, newViewIndex);
+        OnVectorChanged(args);
+
+        return true;
+    }
+
+    private void HandleItemRemoved(int index, object item)
+    {
+        if (_filter != null && !_filter(item))
+        {
+            return;
+        }
+
+        if (index < 0 || index >= _view.Count || !Equals(_view[index], item))
+        {
+            index = _view.IndexOf(item);
+        }
+
+        if (index < 0)
+        {
+            return;
+        }
+
+        RemoveFromView(index, item);
+    }
+
+    private void RemoveFromView(int index, object item)
+    {
+        _view.RemoveAt(index);
+        if (index <= CurrentPosition)
+            CurrentPosition--;
+
+        var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index);
+        OnVectorChanged(args);
+    }
+
+    private void OnVectorChanged(NotifyCollectionChangedEventArgs args)
+    {
+        if (_deferCounter > 0)
+            return;
+
+        CollectionChanged?.Invoke(this, args);
+        OnPropertyChanged(nameof(Count));
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    private object EvaluateBinding(IBinding binding, object item)
+    {
+        _bindingHelper ??= new GroupedDataCollectionView.BindingHelper();
+
+        return _bindingHelper.Evaluate(binding, item);
+    }
+
+
+    int IComparer<object>.Compare(object x, object y)
+    {
+        if (_sortDescriptions != null)
+        {
+            for (int i = 0; i < _sortDescriptions.Count; i++)
+            {
+                var desc = _sortDescriptions[i];
+                object cx, cy;
+
+                if (desc.Property == null)
+                {
+                    cx = x;
+                    cy = y;
+                }
+                else
+                {
+                    cx = EvaluateBinding(desc.Property, x);
+                    cy = EvaluateBinding(desc.Property, y);
+                }
+
+                var cmp = desc.Comparer.Compare(cx, cy);
+                if (cmp != 0)
+                    return desc.Direction == SortDirection.Ascending ? cmp : -cmp;
+            }
+        }
+
+        return 0;
+    }
+
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    IAvaloniaList<ICollectionViewGroup> ICollectionView.CollectionGroups => null;
+
+    bool IList.IsFixedSize => _source is IList l && l.IsFixedSize;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => null;
+
+    int ICollection.Count => Count;
+
+    Task<LoadMoreItemsResult> ICollectionView.LoadMoreItemsAsync(uint count) =>
+        throw new NotImplementedException();
+
+    void IList.Insert(int index, object item) => Insert(index, item);
+
+    int IList.Add(object item)
+    {
+        Add(item);
+        return Count - 1;
+    }
+
+    void IList.Clear() => Clear();
+
+    bool IList.Contains(object value) => Contains(value);
+
+    void IList.Remove(object item) => Remove(item);
+
+    void ICollection.CopyTo(Array array, int index) =>
+        CopyTo((object[])array, index);
+
+    private static void ThrowForNonMutableSource()
+    {
+        throw new NotSupportedException("Underlying source of type {_collection.GetType()} is not mutable. Source collection" +
+            "must implement non-generic IList for CollectionView mutation");
+    }
+
+    private IList<SortDescription> _sortDescriptions;
+    private Predicate<object> _filter;
+    private IEnumerable _source;
+    private ItemsSourceView _sourceView;
+    private List<object> _view;
+    private HashSet<string> _filterProperties;
+    private int _deferCounter;
+    private static GroupedDataCollectionView.BindingHelper _bindingHelper;
+    private bool _hasFilterOrSort;
+}

--- a/src/FluentAvalonia/UI/Data/CollectionView/RefreshDeferer.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/RefreshDeferer.cs
@@ -1,0 +1,22 @@
+﻿// Sorting & Filtering adapted from the WindowsCommunityToolkit
+// AdvancedCollectionView - MIT license
+
+namespace FluentAvalonia.UI.Data;
+
+internal class RefreshDeferer : IDisposable
+{
+    public RefreshDeferer(Action<object> release, object currentItem)
+    {
+        _currentItem = currentItem;
+        _releaseAction = release;
+    }
+
+    public void Dispose()
+    {
+        _releaseAction(_currentItem);
+    }
+
+    private readonly Action<object> _releaseAction;
+    private readonly ICollectionView _acvs;
+    private readonly object _currentItem;
+}

--- a/src/FluentAvalonia/UI/Data/CollectionView/SortDescription.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/SortDescription.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections;
+using Avalonia.Data;
+using Avalonia.Data.Core;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings;
+
+namespace FluentAvalonia.UI.Data;
+
+/// <summary>
+/// Provides data on how a CollectionView should sort its items
+/// </summary>
+public class SortDescription
+{
+    /// <summary>
+    /// Creates a default sort description, that sorts in Ascending order using the default
+    /// object comparer (which compares the items themselves)
+    /// </summary>
+    public SortDescription()
+        : this(null, null, SortDirection.Ascending, ObjectComparer.Instance) { }
+
+    /// <summary>
+    /// Creates a sort description with the specified SortDirection and comparer
+    /// </summary>
+    /// <param name="direction">The direction this description should sort items</param>
+    /// <param name="comparer">The custom IComparer implementation</param>
+    public SortDescription(SortDirection direction, IComparer comparer = null)
+        : this(null, null, direction, comparer) { }
+
+    /// <summary>
+    /// Creates a sort description that sorts using a custom binding expression
+    /// </summary>
+    /// <param name="property">The property that should be used for sorting</param>
+    /// <param name="propertyName">The name of the property. If this is unset, the name is retrieved
+    /// from the binding, if applicable</param>
+    /// <param name="comparer">The custom IComparer implementation</param>
+    /// <remarks>Note: nested properties are not supported, particularly for live shaping</remarks>
+    public SortDescription(IBinding property, string propertyName = null, IComparer comparer = null)
+        : this(property, propertyName, SortDirection.Ascending, comparer) { }
+
+    /// <summary>
+    /// Creates a custom sort description with a specified property binding, direction, and IComparer
+    /// </summary>
+    /// <param name="property">The property that should be used for sorting</param>
+    /// <param name="propertyName">The name of the property. If this is null, the name is retrieved
+    /// from the binding, if applicable></param>
+    /// <param name="direction">The direction this description should sort items</param>
+    /// <param name="comparer">The custom IComparer implementation</param>
+    /// <remarks>Note: nested properties are not supported, particularly for live shaping</remarks>
+    public SortDescription(IBinding property, string propertyName, SortDirection direction, IComparer comparer)
+    {
+        Property = property;
+        _propertyName = propertyName;
+        Direction = direction;
+        Comparer = comparer ?? ObjectComparer.Instance;
+    }
+
+    /// <summary>
+    /// Gets or sets the property this sort description uses to sort.
+    /// </summary>
+    [AssignBinding]
+    public IBinding Property { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the property used for sorting. If the name hasn't been set,
+    /// it will be set from the binding, if possible. Note that nested properties are not supported
+    /// </summary>
+    public string PropertyName
+    {
+        get
+        {
+            if (_propertyName == null)
+            {
+                if (Property is Binding b)
+                {
+                    _propertyName = b.Path;
+                }
+                else if (Property is CompiledBindingExtension cbe)
+                {
+                    _propertyName = cbe.Path.ToString();
+                }
+            }
+
+            return _propertyName;
+        }
+        set => _propertyName = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the direction the sort description should sort
+    /// </summary>
+    public SortDirection Direction { get; set; }
+
+    /// <summary>
+    /// Gets or sets a custom IComparer implementation used to compare items for sorting
+    /// </summary>
+    public IComparer Comparer { get; set; }
+
+    public static SortDescription CreateCompiled(string propertyName,
+        Func<object, object> getter,
+        Type propertyType,
+        SortDirection direction)
+    {
+        return CreateCompiled(propertyName, getter, propertyType, direction, null);
+    }
+
+    public static SortDescription CreateCompiled(string propertyName,
+        Func<object, object> getter,
+        Type propertyType,
+        SortDirection direction,
+        IComparer comparer)
+    {
+        var x = new CompiledBindingPathBuilder();
+        x = x.Property(
+            new ClrPropertyInfo(propertyName, getter, null, propertyType),
+            PropertyInfoAccessorFactory.CreateInpcPropertyAccessor);
+        var path = x.Build();
+
+        var cb = new CompiledBindingExtension(path);
+
+        return new SortDescription(cb, propertyName, direction, comparer);
+    }
+
+    private string _propertyName;
+
+    private class ObjectComparer : IComparer
+    {
+        private ObjectComparer() { }
+
+        public static readonly IComparer Instance = new ObjectComparer();
+
+        public int Compare(object x, object y)
+        {
+            var cx = x as IComparable;
+            var cy = y as IComparable;
+
+            return cx == cy ? 0 : cx == null ? -1 : cy == null ? +1 : cx.CompareTo(cy);
+        }
+    }
+}

--- a/src/FluentAvalonia/UI/Data/CollectionView/SortDirection.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/SortDirection.cs
@@ -1,0 +1,18 @@
+﻿namespace FluentAvalonia.UI.Data;
+
+/// <summary>
+/// Defines constants that determine how a <see cref="SortDescription"/> sorts
+/// the items in a CollectionView
+/// </summary>
+public enum SortDirection
+{
+    /// <summary>
+    /// The items are sorted in ascending order (A-Z, 0-9, etc)
+    /// </summary>
+    Ascending,
+
+    /// <summary>
+    /// The items are sorted in descending order (Z-A, 9-0, etc)
+    /// </summary>
+    Descending
+}


### PR DESCRIPTION
Added WinUI's version of the `ICollectionView` and `CollectionViewSource` a while ago, but there were several issues with it and it wasn't particularly useful. This is a complete refactor of the existing version and adds some new features: Sorting and Filtering was implemented based on the AdvancedCollectionView found in the Windows Community Toolkit. There are other alternatives for list/view management, use what you prefer, but I'm planning on using this in the new sample app, so wanted to get this in now. While grouping is supported, note that grouping within Avalonia-based ItemsControls is lacking - especially if selection of items is desired.

<h3>CollectionViewSource</h3>
CollectionViewSource has been expanded to allow you to set the filter and sort descriptions and whether you want live sorting to be enabled. Note that grouping still remains as in UWP, that is the items source you supply should be the grouped items - there are no group descriptions as in WPF. However, grouping support in Avalonia is very limited right now so this may not even be that applicable. CollectionViewSource can be declared in Xaml just like WPF or UWP:
```xaml
<Window.Resources>
    <data:CollectionViewSource x:Key="MyListSource" />
</Window.Resources>
```

Properties:
- `bool IsSourceGrouped`: specifies if the items source is grouped
- `IBinding ItemsBinding`: if grouping, specifies a binding on how to retrieve the items within each group
- `IEnumerable Source`: the Items source
- `ICollectionView View`: (read-only) gets the view of items
- `Predicate<object> Filter`: The filter used for filtering the items source
- `IList<string> LiveFilterProperties`: (read-only) The list of property names that should be monitored via INotifyPropertyChanged to trigger a refresh of the CollectionView (Live shaping must be enabled for this)
- `IList<SortDescription> SortDescriptions`: the list of `SortDescription` used to sort the items
- `bool IsLiveShapingEnabled`: specifies if the CollectionView should monitor the specified properties in LiveFilterProperties to trigger an automatic refresh of the CollectionView

<h4>SortDescription</h4>
You can specify the direction (Ascending or Descending), a custom IComparer, and even a binding to resolve the property used for sorting. If no binding is provided, the objects themselves are compared. You can also optionally set the `PropertyName` property to help identify the name of the property, otherwise it will be pulled from the binding path, if possible. Nested properties are not supported here.

If you're working in C# here, there is a method `public static SortDescription CreateCompiled()` that will create a compiled binding to satisfy the `IBinding` requirement if needed. 

<h4>Using the CollectionViewSource</h4>
To use the CollectionViewSource, you will have to bind directly to the View property. Since this is a custom type, the binding engine doesn't know how to unwrap the CollectionViewSource to get the View
```xaml
<ItemsControl ItemsSource="{Binding Path=View, Source={StaticResource MyListSource}}" />
```

<h3>Built-in CollectionViews</h3>

- `IterableCollectionView`: This is the default, built-in ICollectionView for non-grouped sources. 
- `GroupedDataCollectionView`: This is the default, built-in ICollectionView for grouped sources. Same as above.
These classes have been made public so you can use them directly if you want (instead of going through a CollectionViewSource), which gives you easier access to its refresh methods and what not. Both of these classes are sealed, however.


[Not implemented now]
- All of the stuff in ICollectionView relating to the `Current` item. This is built into `Selector` in WPF/UWP, which has no support in Avalonia. I may remove these in the future.
- `LoadMoreItemsAsync` in `ICollectionView` from WinUI
- Deferred refresh of the CollectionView. Some of the infrastructure is already there, it just needs to be completed. But this isn't a priority right now.

