### PR TITLE
Update ColorPicker Control Themes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
@@ -8,13 +8,11 @@
                     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
                     x:CompileBindings="True">
 
-  <ResourceDictionary.MergedDictionaries>
-    <ResourceInclude Source="/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml" />
-  </ResourceDictionary.MergedDictionaries>
-
   <ControlTheme x:Key="{x:Type ColorPicker}"
                 TargetType="ColorPicker">
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <!-- Alpha position should match CSS (and default slider order) instead of XAML/WinUI -->
+    <Setter Property="HexInputAlphaPosition" Value="Trailing" />
     <Setter Property="Height" Value="32" />
     <Setter Property="Width" Value="64" />
     <Setter Property="MinWidth" Value="64" />
@@ -51,7 +49,8 @@
             </Panel>
           </DropDownButton.Content>
           <DropDownButton.Flyout>
-            <Flyout FlyoutPresenterClasses="nopadding">
+            <Flyout FlyoutPresenterClasses="nopadding"
+                    Placement="Top">
 
               <!-- The following is copy-pasted from the ColorView's control template.
                    It MUST always be kept in sync with the ColorView (which is master).
@@ -132,7 +131,7 @@
                                               HorizontalAlignment="Center"
                                               VerticalAlignment="Stretch"
                                               Margin="0,0,12,0"
-                                              IsVisible="{TemplateBinding IsColorSpectrumSliderVisible}"/>
+                                              IsVisible="{TemplateBinding IsColorSpectrumSliderVisible}" />
                       <primitives:ColorSpectrum x:Name="ColorSpectrum"
                                                 Grid.Column="1"
                                                 Components="{TemplateBinding ColorSpectrumComponents}"
@@ -179,7 +178,7 @@
                     </TabItem.Header>
                     <ListBox Theme="{StaticResource ColorViewPaletteListBoxTheme}"
                              ItemContainerTheme="{StaticResource ColorViewPaletteListBoxItemTheme}"
-                             Items="{TemplateBinding PaletteColors}"
+                             ItemsSource="{TemplateBinding PaletteColors}"
                              SelectedItem="{Binding Color, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource DoNothingForNullConverter}, Mode=TwoWay}"
                              UseLayoutRounding="False"
                              Margin="12">
@@ -231,6 +230,7 @@
                                        Content="RGB"
                                        CornerRadius="4,0,0,4"
                                        BorderThickness="1,1,0,1"
+                                       Height="{Binding ElementName=PART_HexTextBox, Path=Bounds.Height}"
                                        IsChecked="{TemplateBinding ColorModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static controls:ColorModel.Rgba}, Mode=TwoWay}" />
                           <RadioButton x:Name="HsvRadioButton"
                                        Theme="{StaticResource ColorViewColorModelRadioButtonTheme}"
@@ -238,6 +238,7 @@
                                        Content="HSV"
                                        CornerRadius="0,4,4,0"
                                        BorderThickness="0,1,1,1"
+                                       Height="{Binding ElementName=PART_HexTextBox, Path=Bounds.Height}"
                                        IsChecked="{TemplateBinding ColorModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static controls:ColorModel.Hsva}, Mode=TwoWay}" />
                         </Grid>
                         <Grid x:Name="HexInputGrid"
@@ -260,11 +261,12 @@
                                        VerticalAlignment="Center" />
                           </Border>
                           <!-- Color updated in code-behind -->
+                          <!-- Max length must include an optional '#' prefix (#FFFFFFFF) -->
                           <TextBox x:Name="PART_HexTextBox"
                                    Grid.Column="1"
                                    AutomationProperties.Name="Hexadecimal Color"
                                    Height="32"
-                                   MaxLength="8"
+                                   MaxLength="9"
                                    HorizontalAlignment="Stretch"
                                    CornerRadius="0,4,4,0" />
                         </Grid>
@@ -286,7 +288,7 @@
                           <TextBlock Foreground="{DynamicResource TextControlForegroundDisabled}"
                                      FontWeight="SemiBold"
                                      Text="R"
-                                     IsVisible="{TemplateBinding ColorModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static controls:ColorModel.Rgba}, Mode=OneWay}"/>
+                                     IsVisible="{TemplateBinding ColorModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static controls:ColorModel.Rgba}, Mode=OneWay}" />
                           <TextBlock Foreground="{DynamicResource TextControlForegroundDisabled}"
                                      FontWeight="SemiBold"
                                      Text="H"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPreviewer.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPreviewer.axaml
@@ -65,6 +65,7 @@
             <Border Grid.Column="1"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
+                    Background="Transparent"
                     BoxShadow="0 0 10 2 #BF000000"
                     CornerRadius="{TemplateBinding CornerRadius}"
                     Margin="10">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorSlider.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorSlider.axaml
@@ -2,12 +2,19 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:CompileBindings="True">
 
+  <!-- Note that the Slider thumb should generally follow the overall Slider dimensions.
+       Therefore, there are not currently separate resources to control it. -->
+  <x:Double x:Key="ColorSliderSize">20</x:Double>
+  <x:Double x:Key="ColorSliderTrackSize">20</x:Double>
+  <CornerRadius x:Key="ColorSliderCornerRadius">10</CornerRadius>
+  <CornerRadius x:Key="ColorSliderTrackCornerRadius">10</CornerRadius>
+
   <ControlTheme x:Key="ColorSliderThumbTheme"
                 TargetType="Thumb">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource ColorControlDefaultSelectorBrush}" />
     <Setter Property="BorderThickness" Value="3" />
-    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ColorSliderCornerRadius}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate>
@@ -25,27 +32,28 @@
 
     <Style Selector="^:horizontal">
       <Setter Property="BorderThickness" Value="0" />
-      <Setter Property="CornerRadius" Value="10" />
-      <Setter Property="Height" Value="20" />
+      <Setter Property="CornerRadius" Value="{DynamicResource ColorSliderCornerRadius}" />
+      <Setter Property="Height" Value="{DynamicResource ColorSliderSize}" />
       <Setter Property="Template">
         <ControlTemplate TargetType="{x:Type ColorSlider}">
           <Border BorderThickness="{TemplateBinding BorderThickness}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   CornerRadius="{TemplateBinding CornerRadius}">
             <Grid Margin="{TemplateBinding Padding}">
-              <Rectangle HorizontalAlignment="Stretch"
-                         VerticalAlignment="Stretch"
-                         Fill="{StaticResource ColorControlCheckeredBackgroundBrush}"
-                         RadiusX="{TemplateBinding CornerRadius, Converter={StaticResource TopLeftCornerRadiusConverter}}"
-                         RadiusY="{TemplateBinding CornerRadius, Converter={StaticResource BottomRightCornerRadiusConverter}}" />
-              <Rectangle HorizontalAlignment="Stretch"
-                         VerticalAlignment="Stretch"
-                         Fill="{TemplateBinding Background}"
-                         RadiusX="{TemplateBinding CornerRadius, Converter={StaticResource TopLeftCornerRadiusConverter}}"
-                         RadiusY="{TemplateBinding CornerRadius, Converter={StaticResource BottomRightCornerRadiusConverter}}" />
+              <Border HorizontalAlignment="Stretch"
+                      VerticalAlignment="Center"
+                      Height="{Binding ElementName=PART_Track, Path=Bounds.Height}"
+                      Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
+                      CornerRadius="{DynamicResource ColorSliderTrackCornerRadius}" />
+              <Border HorizontalAlignment="Stretch"
+                      VerticalAlignment="Center"
+                      Height="{Binding ElementName=PART_Track, Path=Bounds.Height}"
+                      Background="{TemplateBinding Background}"
+                      CornerRadius="{DynamicResource ColorSliderTrackCornerRadius}" />
               <Track Name="PART_Track"
+                     Height="{DynamicResource ColorSliderTrackSize}"
                      HorizontalAlignment="Stretch"
-                     VerticalAlignment="Stretch"
+                     VerticalAlignment="Center"
                      Minimum="{TemplateBinding Minimum}"
                      Maximum="{TemplateBinding Maximum}"
                      Value="{TemplateBinding Value, Mode=TwoWay}"
@@ -82,7 +90,7 @@
                   </RepeatButton>
                 </Track.IncreaseButton>
                 <Thumb Name="ColorSliderThumb"
-                       Theme="{StaticResource ColorSliderThumbTheme}"
+                       Theme="{DynamicResource ColorSliderThumbTheme}"
                        Margin="0"
                        Padding="0"
                        DataContext="{TemplateBinding Value}"
@@ -97,26 +105,27 @@
 
     <Style Selector="^:vertical">
       <Setter Property="BorderThickness" Value="0" />
-      <Setter Property="CornerRadius" Value="10" />
-      <Setter Property="Width" Value="20" />
+      <Setter Property="CornerRadius" Value="{DynamicResource ColorSliderCornerRadius}" />
+      <Setter Property="Width" Value="{DynamicResource ColorSliderSize}" />
       <Setter Property="Template">
         <ControlTemplate TargetType="{x:Type ColorSlider}">
           <Border BorderThickness="{TemplateBinding BorderThickness}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   CornerRadius="{TemplateBinding CornerRadius}">
             <Grid Margin="{TemplateBinding Padding}">
-              <Rectangle HorizontalAlignment="Stretch"
-                         VerticalAlignment="Stretch"
-                         Fill="{StaticResource ColorControlCheckeredBackgroundBrush}"
-                         RadiusX="{TemplateBinding CornerRadius, Converter={StaticResource TopLeftCornerRadiusConverter}}"
-                         RadiusY="{TemplateBinding CornerRadius, Converter={StaticResource BottomRightCornerRadiusConverter}}" />
-              <Rectangle HorizontalAlignment="Stretch"
-                         VerticalAlignment="Stretch"
-                         Fill="{TemplateBinding Background}"
-                         RadiusX="{TemplateBinding CornerRadius, Converter={StaticResource TopLeftCornerRadiusConverter}}"
-                         RadiusY="{TemplateBinding CornerRadius, Converter={StaticResource BottomRightCornerRadiusConverter}}" />
+              <Border HorizontalAlignment="Center"
+                      VerticalAlignment="Stretch"
+                      Width="{Binding ElementName=PART_Track, Path=Bounds.Width}"
+                      Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
+                      CornerRadius="{DynamicResource ColorSliderTrackCornerRadius}" />
+              <Border HorizontalAlignment="Center"
+                      VerticalAlignment="Stretch"
+                      Width="{Binding ElementName=PART_Track, Path=Bounds.Width}"
+                      Background="{TemplateBinding Background}"
+                      CornerRadius="{DynamicResource ColorSliderTrackCornerRadius}" />
               <Track Name="PART_Track"
-                     HorizontalAlignment="Stretch"
+                     Width="{DynamicResource ColorSliderTrackSize}"
+                     HorizontalAlignment="Center"
                      VerticalAlignment="Stretch"
                      Minimum="{TemplateBinding Minimum}"
                      Maximum="{TemplateBinding Maximum}"
@@ -154,7 +163,7 @@
                   </RepeatButton>
                 </Track.IncreaseButton>
                 <Thumb Name="ColorSliderThumb"
-                       Theme="{StaticResource ColorSliderThumbTheme}"
+                       Theme="{DynamicResource ColorSliderThumbTheme}"
                        Margin="0"
                        Padding="0"
                        DataContext="{TemplateBinding Value}"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
@@ -10,7 +10,6 @@
 
   <pc:ContrastBrushConverter x:Key="ContrastBrushConverter" />
   <converters:ColorToDisplayNameConverter x:Key="ColorToDisplayNameConverter" />
-  <converters:ColorToHexConverter x:Key="ColorToHexConverter" />
   <converters:DoNothingForNullConverter x:Key="DoNothingForNullConverter" />
   <globalization:NumberFormatInfo x:Key="ColorViewComponentNumberFormat" NumberDecimalDigits="0" />
   <x:Double x:Key="ColorViewTabStripHeight">48</x:Double>
@@ -228,6 +227,8 @@
   <ControlTheme x:Key="{x:Type ColorView}"
                 TargetType="ColorView">
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <!-- Alpha position should match CSS (and default slider order) instead of XAML/WinUI -->
+    <Setter Property="HexInputAlphaPosition" Value="Trailing" />
     <Setter Property="Palette">
       <controls:FluentColorPalette />
     </Setter>
@@ -347,7 +348,7 @@
               </TabItem.Header>
               <ListBox Theme="{StaticResource ColorViewPaletteListBoxTheme}"
                        ItemContainerTheme="{StaticResource ColorViewPaletteListBoxItemTheme}"
-                       Items="{TemplateBinding PaletteColors}"
+                       ItemsSource="{TemplateBinding PaletteColors}"
                        SelectedItem="{Binding Color, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource DoNothingForNullConverter}, Mode=TwoWay}"
                        UseLayoutRounding="False"
                        Margin="12">
@@ -399,6 +400,7 @@
                                  Content="RGB"
                                  CornerRadius="4,0,0,4"
                                  BorderThickness="1,1,0,1"
+                                 Height="{Binding ElementName=PART_HexTextBox, Path=Bounds.Height}"
                                  IsChecked="{TemplateBinding ColorModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static controls:ColorModel.Rgba}, Mode=TwoWay}" />
                     <RadioButton x:Name="HsvRadioButton"
                                  Theme="{StaticResource ColorViewColorModelRadioButtonTheme}"
@@ -406,6 +408,7 @@
                                  Content="HSV"
                                  CornerRadius="0,4,4,0"
                                  BorderThickness="0,1,1,1"
+                                 Height="{Binding ElementName=PART_HexTextBox, Path=Bounds.Height}"
                                  IsChecked="{TemplateBinding ColorModel, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static controls:ColorModel.Hsva}, Mode=TwoWay}" />
                   </Grid>
                   <Grid x:Name="HexInputGrid"
@@ -428,11 +431,12 @@
                                  VerticalAlignment="Center" />
                     </Border>
                     <!-- Color updated in code-behind -->
+                    <!-- Max length must include an optional '#' prefix (#FFFFFFFF) -->
                     <TextBox x:Name="PART_HexTextBox"
                              Grid.Column="1"
                              AutomationProperties.Name="Hexadecimal Color"
                              Height="32"
-                             MaxLength="8"
+                             MaxLength="9"
                              HorizontalAlignment="Stretch"
                              CornerRadius="0,4,4,0" />
                   </Grid>


### PR DESCRIPTION
Syncs all ColorPicker control themes with upstream changes.

~This is currently draft because it requires latest Avalonia nightly to build.~