### PR TITLE
Enable CodeViewer in samples

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0.0-preview1" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0.0-preview6" />
 
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>

--- a/samples/FluentAvaloniaSamples/App.axaml
+++ b/samples/FluentAvaloniaSamples/App.axaml
@@ -37,7 +37,7 @@
 
     <Application.Styles>
         <sty:FluentAvaloniaTheme PreferUserAccentColor="True" PreferSystemTheme="True" />
-        <!--<StyleInclude Source="avares://AvaloniaEdit/AvaloniaEdit.xaml" />-->
+        <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
         <StyleInclude Source="/Styles/OptionsDisplayItemStyles.axaml" />
         <StyleInclude Source="/Styles/ControlExampleStyles.axaml" />
         <StyleInclude Source="/Styles/FAControlsPageBaseStyles.axaml" />

--- a/samples/FluentAvaloniaSamples/Controls/ControlDefinitionOverlay.cs
+++ b/samples/FluentAvaloniaSamples/Controls/ControlDefinitionOverlay.cs
@@ -63,10 +63,10 @@ public class ControlDefinitionOverlay : TemplatedControl
 
         base.OnApplyTemplate(e);
 
-       // _textEditor = e.NameScope.Find<TextEditor>("TextEditor");
+        _textEditor = e.NameScope.Find<TextEditor>("TextEditor");
 
-        //_textEditor.TextArea.IndentationStrategy = new CSharpIndentationStrategy();
-        //_textEditor.SyntaxHighlighting = CSharpHighlightingSource.CSharpDarkMode;
+        _textEditor.TextArea.IndentationStrategy = new CSharpIndentationStrategy();
+        _textEditor.SyntaxHighlighting = CSharpHighlightingSource.CSharpDarkMode;
 
         _closeButton = e.NameScope.Find<Button>("CloseButton");
         _closeButton.Click += OnCloseClick;
@@ -79,8 +79,8 @@ public class ControlDefinitionOverlay : TemplatedControl
         Inheritance = null;
         PseudoclassesList = null;
 
-        //if (_textEditor != null)
-        //    _textEditor.Text = null;
+        if (_textEditor != null)
+            _textEditor.Text = null;
 
         Opacity = 0;
         IsVisible = true;
@@ -123,7 +123,7 @@ public class ControlDefinitionOverlay : TemplatedControl
             if (value is ISolidColorBrush sb)
             {
                 var b = new ImmutableSolidColorBrush(sb.Color, 0.5);
-                //_textEditor.TextArea.SelectionBrush = b;
+                _textEditor.TextArea.SelectionBrush = b;
             }
         }
     }
@@ -181,9 +181,9 @@ public class ControlDefinitionOverlay : TemplatedControl
                 {
                     Inheritance = inheritance;
                     PseudoclassesList = ps;
-                    //_textEditor.Text = src;
+                    _textEditor.Text = src;
 
-                    //_textEditor.TextArea.IndentationStrategy.IndentLines(_textEditor.Document, 0, _textEditor.Document.LineCount);
+                    _textEditor.TextArea.IndentationStrategy.IndentLines(_textEditor.Document, 0, _textEditor.Document.LineCount);
 
                 }, DispatcherPriority.Background);
 
@@ -471,5 +471,5 @@ public class ControlDefinitionOverlay : TemplatedControl
     }
 
     private Button _closeButton;
-    //private TextEditor _textEditor;
+    private TextEditor _textEditor;
 }

--- a/samples/FluentAvaloniaSamples/Controls/ControlExample.cs
+++ b/samples/FluentAvaloniaSamples/Controls/ControlExample.cs
@@ -245,34 +245,34 @@ public class ControlExample : HeaderedContentControl
         _copyCSharpButton = e.NameScope.Find<Button>("CopyCSharpButton");
         _copyCSharpButton.Click += OnCopyCSharpClick;
 
-        //_xamlTextEditor = e.NameScope.Find<TextEditor>("XamlTextEditor");
-        //_cSharpTextEditor = e.NameScope.Find<TextEditor>("CSharpTextEditor");
+        _xamlTextEditor = e.NameScope.Find<TextEditor>("XamlTextEditor");
+        _cSharpTextEditor = e.NameScope.Find<TextEditor>("CSharpTextEditor");
 
         _usageNotesTextBlock = e.NameScope.Find<TextBlock>("UsageNotesTextBlock");
 
         SetUsageNotes();
 
-        bool isLightMode = AvaloniaLocator.Current.GetService<FluentAvaloniaTheme>().RequestedTheme == FluentAvaloniaTheme.LightModeString;
+        var theme = _exampleThemeScopeProvider.ActualThemeVariant;
+        bool isLightMode = theme == ThemeVariant.Light;
+        _xamlTextEditor.SyntaxHighlighting = isLightMode ? XamlHighlightingSource.LightModeXaml : XamlHighlightingSource.DarkModeXaml;
+        _cSharpTextEditor.SyntaxHighlighting = isLightMode ? CSharpHighlightingSource.CSharpLightMode : CSharpHighlightingSource.CSharpDarkMode;
 
-        //_xamlTextEditor.SyntaxHighlighting = isLightMode ? XamlHighlightingSource.LightModeXaml : XamlHighlightingSource.DarkModeXaml;
-        //_cSharpTextEditor.SyntaxHighlighting = isLightMode ? CSharpHighlightingSource.CSharpLightMode : CSharpHighlightingSource.CSharpDarkMode;
+        //_xamlTextEditor.TextArea.SelectionBrush = Brushes.Transparent;
+        // _cSharpTextEditor.TextArea.SelectionBrush = Brushes.Transparent;
 
-        ////_xamlTextEditor.TextArea.SelectionBrush = Brushes.Transparent;
-        //// _cSharpTextEditor.TextArea.SelectionBrush = Brushes.Transparent;
+        _xamlTextEditor.Text = XamlSource;
+        _cSharpTextEditor.Text = CSharpSource;
 
-        //_xamlTextEditor.Text = XamlSource;
-        //_cSharpTextEditor.Text = CSharpSource;
+        _cSharpTextEditor.TextArea.IndentationStrategy = new CSharpIndentationStrategy(_cSharpTextEditor.Options);
+        _cSharpTextEditor.TextArea.IndentationStrategy.IndentLines(_cSharpTextEditor.Document, 0, _cSharpTextEditor.Document.LineCount);
 
-        //_cSharpTextEditor.TextArea.IndentationStrategy = new CSharpIndentationStrategy(_cSharpTextEditor.Options);
-        //_cSharpTextEditor.TextArea.IndentationStrategy.IndentLines(_cSharpTextEditor.Document, 0, _cSharpTextEditor.Document.LineCount);
+        // HACK: Links apparently can't be turned off (if you see this and know how, pls open a PR and fix this =D), so force links
+        //       to be the same color as attributes
+        _cSharpTextEditor.Options.EnableHyperlinks = false;
+        _xamlTextEditor.Options.EnableHyperlinks = false;
 
-        //// HACK: Links apparently can't be turned off (if you see this and know how, pls open a PR and fix this =D), so force links
-        ////       to be the same color as attributes
-        //_cSharpTextEditor.Options.EnableHyperlinks = false;
-        //_xamlTextEditor.Options.EnableHyperlinks = false;
-
-        ////_xamlTextEditor.TextArea.TextView.LinkTextForegroundBrush = new ImmutableSolidColorBrush(Color.FromRgb(255, 160, 122));
-        ////_xamlTextEditor.TextArea.TextView.LinkTextUnderline = false;
+        //_xamlTextEditor.TextArea.TextView.LinkTextForegroundBrush = new ImmutableSolidColorBrush(Color.FromRgb(255, 160, 122));
+        //_xamlTextEditor.TextArea.TextView.LinkTextUnderline = false;
 
         if (Substitutions.Count > 0 && !_hasRegisteredSubstitutions)
         {
@@ -302,8 +302,8 @@ public class ControlExample : HeaderedContentControl
             if (value is ISolidColorBrush sb)
             {
                 var b = new ImmutableSolidColorBrush(sb.Color, 0.5);
-                //_xamlTextEditor.TextArea.SelectionBrush = b;
-                //_cSharpTextEditor.TextArea.SelectionBrush = b;
+                _xamlTextEditor.TextArea.SelectionBrush = b;
+                _cSharpTextEditor.TextArea.SelectionBrush = b;
             }
         }
     }
@@ -336,19 +336,20 @@ public class ControlExample : HeaderedContentControl
 
     private void OnResourcesChanged(object sender, ResourcesChangedEventArgs e)
     {
-        //if (_cSharpTextEditor != null)
-        //{
-        //    bool isLightMode = AvaloniaLocator.Current.GetService<FluentAvaloniaTheme>().RequestedTheme == FluentAvaloniaTheme.LightModeString;
+        if (_cSharpTextEditor != null)
+        {
+            var theme = _exampleThemeScopeProvider.ActualThemeVariant;
+            bool isLightMode = theme == ThemeVariant.Light;
 
-        //    _xamlTextEditor.SyntaxHighlighting = isLightMode ? XamlHighlightingSource.LightModeXaml : XamlHighlightingSource.DarkModeXaml;
-        //    _cSharpTextEditor.SyntaxHighlighting = isLightMode ? CSharpHighlightingSource.CSharpLightMode : CSharpHighlightingSource.CSharpDarkMode;
-        //}
+            _xamlTextEditor.SyntaxHighlighting = isLightMode ? XamlHighlightingSource.LightModeXaml : XamlHighlightingSource.DarkModeXaml;
+            _cSharpTextEditor.SyntaxHighlighting = isLightMode ? CSharpHighlightingSource.CSharpLightMode : CSharpHighlightingSource.CSharpDarkMode;
+        }
     }
 
     public void SetExampleTheme()
     {
         var theme = _exampleThemeScopeProvider.ActualThemeVariant;
-
+        bool isLightMode = theme == ThemeVariant.Light;
         if (theme == ThemeVariant.Light)
         {
             _exampleThemeScopeProvider.RequestedThemeVariant = ThemeVariant.Dark;
@@ -362,21 +363,21 @@ public class ControlExample : HeaderedContentControl
             NotifyChildResourcesChanged(ResourcesChangedEventArgs.Empty);
         }
 
-        //if (_cSharpTextEditor != null)
-        //{
-        //    _xamlTextEditor.SyntaxHighlighting = isLightMode ? XamlHighlightingSource.LightModeXaml : XamlHighlightingSource.DarkModeXaml;
-        //    _cSharpTextEditor.SyntaxHighlighting = isLightMode ? CSharpHighlightingSource.CSharpLightMode : CSharpHighlightingSource.CSharpDarkMode;
+        if (_cSharpTextEditor != null)
+        {
+            _xamlTextEditor.SyntaxHighlighting = isLightMode ? XamlHighlightingSource.LightModeXaml : XamlHighlightingSource.DarkModeXaml;
+            _cSharpTextEditor.SyntaxHighlighting = isLightMode ? CSharpHighlightingSource.CSharpLightMode : CSharpHighlightingSource.CSharpDarkMode;
 
-        //    if (this.TryFindResource("TextControlSelectionHighlightColor", out var value))
-        //    {
-        //        if (value is ISolidColorBrush sb)
-        //        {
-        //            var b = new ImmutableSolidColorBrush(sb.Color, 0.5);
-        //            //_xamlTextEditor.TextArea.SelectionBrush = b;
-        //            //_cSharpTextEditor.TextArea.SelectionBrush = b;
-        //        }
-        //    }
-        //}
+            if (this.TryFindResource("TextControlSelectionHighlightColor", out var value))
+            {
+                if (value is ISolidColorBrush sb)
+                {
+                    var b = new ImmutableSolidColorBrush(sb.Color, 0.5);
+                    _xamlTextEditor.TextArea.SelectionBrush = b;
+                    _cSharpTextEditor.TextArea.SelectionBrush = b;
+                }
+            }
+        }
     }
 
     private void OnSubstitutionValueChanged(ControlExampleSubstitution sender, object args)
@@ -420,19 +421,19 @@ public class ControlExample : HeaderedContentControl
             });
         }
 
-        //if (isCSharpSample && _cSharpTextEditor != null)
-        //{
-        //    TrimAndSubstitute();
+        if (isCSharpSample && _cSharpTextEditor != null)
+        {
+            TrimAndSubstitute();
 
-        //    _cSharpTextEditor.Text = sampleString;
-        //    _cSharpTextEditor.TextArea.IndentationStrategy.IndentLines(_cSharpTextEditor.Document, 0, _cSharpTextEditor.Document.LineCount);
-        //}
-        //else if (_xamlTextEditor != null)
-        //{
-        //    TrimAndSubstitute();
+            _cSharpTextEditor.Text = sampleString;
+            _cSharpTextEditor.TextArea.IndentationStrategy.IndentLines(_cSharpTextEditor.Document, 0, _cSharpTextEditor.Document.LineCount);
+        }
+        else if (_xamlTextEditor != null)
+        {
+            TrimAndSubstitute();
 
-        //    _xamlTextEditor.Text = sampleString;
-        //}
+            _xamlTextEditor.Text = sampleString;
+        }
     }
 
     public void LaunchAvaloniaDocs(object sender, RoutedEventArgs e)
@@ -454,49 +455,49 @@ public class ControlExample : HeaderedContentControl
 
     private async void OnCopyCSharpClick(object sender, RoutedEventArgs e)
     {
-        //try
-        //{
-        //    if (_cSharpTextEditor.SelectionLength > 0)
-        //    {
-        //        // Copy the selected text
-        //        _cSharpTextEditor.Copy();
-        //    }
-        //    else
-        //    {
-        //        // Copy everything
-        //        await Application.Current.Clipboard.SetTextAsync(_cSharpTextEditor.Text);
-        //    }
+        try
+        {
+            if (_cSharpTextEditor.SelectionLength > 0)
+            {
+                // Copy the selected text
+                _cSharpTextEditor.Copy();
+            }
+            else
+            {
+                // Copy everything
+                await Application.Current.Clipboard.SetTextAsync(_cSharpTextEditor.Text);
+            }
 
 
-        //    ShowCopiedFlyout(sender as Button);
-        //}
-        //catch
-        //{
-        //    ShowCopiedFlyout(sender as Button, "Failed to copy code", true);
-        //}
+            ShowCopiedFlyout(sender as Button);
+        }
+        catch
+        {
+            ShowCopiedFlyout(sender as Button, "Failed to copy code", true);
+        }
     }
 
     private async void OnCopyXamlClick(object sender, RoutedEventArgs e)
     {
-        //try
-        //{
-        //    if (_xamlTextEditor.SelectionLength > 0)
-        //    {
-        //        // Copy the selected text
-        //        _xamlTextEditor.Copy();
-        //    }
-        //    else
-        //    {
-        //        // Copy everything
-        //        await Application.Current.Clipboard.SetTextAsync(_xamlTextEditor.Text);
-        //    }
+        try
+        {
+            if (_xamlTextEditor.SelectionLength > 0)
+            {
+                // Copy the selected text
+                _xamlTextEditor.Copy();
+            }
+            else
+            {
+                // Copy everything
+                await Application.Current.Clipboard.SetTextAsync(_xamlTextEditor.Text);
+            }
 
-        //    ShowCopiedFlyout(sender as Button);
-        //}
-        //catch
-        //{
-        //    ShowCopiedFlyout(sender as Button, "Failed to copy code", true);
-        //}
+            ShowCopiedFlyout(sender as Button);
+        }
+        catch
+        {
+            ShowCopiedFlyout(sender as Button, "Failed to copy code", true);
+        }
     }
 
     private void ShowCopiedFlyout(Button host, string message = "Copied!", bool fail = false)
@@ -613,8 +614,8 @@ public class ControlExample : HeaderedContentControl
     private ThemeVariantScope _exampleThemeScopeProvider;
 
     private Button _optionsMenuButton;
-    //private TextEditor _xamlTextEditor;
-    //private TextEditor _cSharpTextEditor;
+    private TextEditor _xamlTextEditor;
+    private TextEditor _cSharpTextEditor;
     private TextBlock _usageNotesTextBlock;
 
     private IList<ControlExampleSubstitution> _substitutions;
@@ -636,13 +637,13 @@ public class XamlHighlightingSource : IHighlightingDefinition
                 {
                     StartExpression = new System.Text.RegularExpressions.Regex(@"<!--"),
                     EndExpression = new System.Text.RegularExpressions.Regex(@"-->"),
-                    //SpanColor = new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(107,142,35) : Colors.Green) }
+                    SpanColor = new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(107,142,35) : Colors.Green) }
                 },
                 new HighlightingSpan // XML tag
                 {
                     StartExpression = new System.Text.RegularExpressions.Regex("<"),
                     EndExpression = new System.Text.RegularExpressions.Regex(@">"),
-                    //SpanColor =new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(121,121,121) : Colors.Blue) },
+                    SpanColor =new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(121,121,121) : Colors.Blue) },
                     SpanColorIncludesEnd = true,
                     SpanColorIncludesStart = true,
                     RuleSet = new HighlightingRuleSet
@@ -652,17 +653,17 @@ public class XamlHighlightingSource : IHighlightingDefinition
                             new HighlightingRule // Attribute Name
                             {
                                  Regex = new System.Text.RegularExpressions.Regex(@"[\d\w_\-\.]+(?=(\s*=))"),
-                                 //Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(135,206,250) : Colors.Red) }
+                                 Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(135,206,250) : Colors.Red) }
                             },
                             new HighlightingRule // Tag Name
                             {
                                  Regex = new System.Text.RegularExpressions.Regex(@"(?!(\/|<))[\w\d\#]+"),
-                                 //Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(87,117,202) : Color.FromRgb(163, 21, 21)) }
+                                 Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(87,117,202) : Color.FromRgb(163, 21, 21)) }
                             },
                             new HighlightingRule
                             {
                                 Regex = new System.Text.RegularExpressions.Regex("/"),
-                                //Color =new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(121,121,121) : Colors.Blue) },
+                                Color =new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(121,121,121) : Colors.Blue) },
                             }
                         },
                         Spans =
@@ -671,7 +672,7 @@ public class XamlHighlightingSource : IHighlightingDefinition
                             {
                                 StartExpression = new System.Text.RegularExpressions.Regex("\""),
                                 EndExpression = new System.Text.RegularExpressions.Regex("\"|(?=<)"),
-                                //SpanColor = new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(255,160,122) : Colors.Blue) },
+                                SpanColor = new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(255,160,122) : Colors.Blue) },
                             }
                         }
                     }
@@ -680,7 +681,7 @@ public class XamlHighlightingSource : IHighlightingDefinition
                 {
                     StartExpression = new System.Text.RegularExpressions.Regex("\""),
                     EndExpression = new System.Text.RegularExpressions.Regex("\""),
-                    //SpanColor = new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(255,160,122) : Colors.Blue) },
+                    SpanColor = new HighlightingColor { Foreground =new SimpleHighlightingBrush(isDark ? Color.FromRgb(255,160,122) : Colors.Blue) },
                     SpanColorIncludesEnd = true,
                     SpanColorIncludesStart = true
                 },
@@ -726,22 +727,22 @@ public class CSharpHighlightingSource : IHighlightingDefinition
                 new HighlightingRule // blue keywords
                 {
                     Regex = new System.Text.RegularExpressions.Regex("\\b(this|base|as|is|new|sizeof|typeof|stackalloc|default|true|false|get|set|add|remove|ref|out)\\b"),
-                    //Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(86,156,214) : Colors.Blue) },
+                    Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(86,156,214) : Colors.Blue) },
                 },
                 new HighlightingRule // purple keywords
                 {
                     Regex = new System.Text.RegularExpressions.Regex("\\b(switch|else|if|case|break|return|for|foreach|while|do|continue|try|catch|finally)\\b"),
-                    //Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(Color.FromRgb(216,160,223)) }, // TODO...
+                    Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(Color.FromRgb(216,160,223)) }, // TODO...
                 },
                 new HighlightingRule // value types (also blue)
                 {
                     Regex = new System.Text.RegularExpressions.Regex("\\b(bool|byte|char|decimal|double|enum|float|int|long|sbyte|short|struct|uint|ushort|ulong)\\b"),
-                    //Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(86,156,214) : Colors.Blue) },
+                    Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(86,156,214) : Colors.Blue) },
                 },
                 new HighlightingRule // other blue stuff
                 {
                     Regex = new System.Text.RegularExpressions.Regex("\\b(class|delegate|object|string|void|abstract|const|override|readonly|sealed|static|partial|virtual|async|public|protected|private|internal|namespace|using|null|nameof|explicit|implicit|operator)\\b"),
-                   // Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(86,156,214) : Colors.Blue) },
+                    Color = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(86,156,214) : Colors.Blue) },
                 },
             },
             Spans =
@@ -752,13 +753,13 @@ public class CSharpHighlightingSource : IHighlightingDefinition
                     EndExpression = new Regex("$"),
                     SpanColorIncludesStart = true,
                     SpanColorIncludesEnd = true,
-                    //SpanColor = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(89,166,74) : Colors.Green) }
+                    SpanColor = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(89,166,74) : Colors.Green) }
                 },
                 new HighlightingSpan // String or carh
                 {
                     StartExpression = new System.Text.RegularExpressions.Regex("(\"|')"),
                     EndExpression = new System.Text.RegularExpressions.Regex("(\"|')"),
-                    //SpanColor = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(214,157,133) : Color.FromRgb(162,21,21)) }, 
+                    SpanColor = new HighlightingColor { Foreground = new SimpleHighlightingBrush(isDark ? Color.FromRgb(214,157,133) : Color.FromRgb(162,21,21)) },
                     SpanColorIncludesEnd = true,
                     SpanColorIncludesStart = true
                 }

--- a/samples/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
+++ b/samples/FluentAvaloniaSamples/FluentAvaloniaSamples.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-      <TargetFramework>net6.0</TargetFramework>
-      <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <TargetFramework>net7.0</TargetFramework>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -22,5 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <TrimmerRootDescriptor Include="link.xml" />
+    <TrimmerRootAssembly Include="FluentAvaloniaSamples" />
   </ItemGroup>
 </Project>

--- a/samples/FluentAvaloniaSamples/Styles/ControlExampleStyles.axaml
+++ b/samples/FluentAvaloniaSamples/Styles/ControlExampleStyles.axaml
@@ -142,9 +142,10 @@
                                         <ui:SymbolIcon Symbol="Copy" FontSize="18" />
                                     </Button>
 
-                                    <!--<aedit:TextEditor Name="XamlTextEditor" IsReadOnly="True"
+                                    <aedit:TextEditor Name="XamlTextEditor" IsReadOnly="True"
+                                                      FontFamily="Consolas"
                                                       Margin="8 32 8 8"
-                                                      MinHeight="50"/>-->
+                                                      MinHeight="50"/>
                                 </DockPanel>
                             </Expander>
                             <Expander Header="C# Sample Code"
@@ -156,9 +157,10 @@
                                                VerticalAlignment="Top">
                                         <ui:SymbolIcon Symbol="Copy" FontSize="18" />
                                     </Button>
-                                    <!--<aedit:TextEditor Name="CSharpTextEditor" IsReadOnly="True"
+                                    <aedit:TextEditor Name="CSharpTextEditor" IsReadOnly="True"
                                                       Grid.Row="1" Margin="8 32 8 8"
-                                                      MinHeight="50" />-->
+                                                      FontFamily="Consolas"
+                                                      MinHeight="50" />
                                 </DockPanel>
                             </Expander>
                             <Expander Header="Additional Notes"

--- a/samples/FluentAvaloniaSamples/ViewModels/CoreControlsGroupItem.cs
+++ b/samples/FluentAvaloniaSamples/ViewModels/CoreControlsGroupItem.cs
@@ -11,15 +11,15 @@ public class CoreControlsGroupItem : ViewModelBase
         InvokeCommand = new FACommand(OnInvokeCommandExecute);
     }
 
-    public string IconResourceKey { get; init; }
+    public string IconResourceKey { get; set; }
 
-    public string Header { get; init; }
+    public string Header { get; set; }
 
-    public string Description { get; init; }
+    public string Description { get; set; }
 
-    public bool Navigates { get; init; }
+    public bool Navigates { get; set; }
 
-    public string PageType { get; init; }
+    public string PageType { get; set; }
 
     public FACommand InvokeCommand { get; }
 

--- a/samples/FluentAvaloniaSamples/ViewModels/CoreControlsPageViewModel.cs
+++ b/samples/FluentAvaloniaSamples/ViewModels/CoreControlsPageViewModel.cs
@@ -8,7 +8,7 @@ public class CoreControlsPageViewModel : ViewModelBase
     public CoreControlsPageViewModel()
     {
         var coreControls = GetAssemblyResource("avares://FluentAvaloniaSamples/Assets/CoreControlsGroups.json");
-        CoreControlGroups = JsonSerializer.Deserialize<List<CoreControlsGroupItem>>(coreControls);
+        CoreControlGroups = JsonSerializer.Deserialize(coreControls, FASampleJsonContext.Default.ListCoreControlsGroupItem);
     }
 
     public string PageHeader => "Core Controls";

--- a/samples/FluentAvaloniaSamples/ViewModels/FAControlsGroupItem.cs
+++ b/samples/FluentAvaloniaSamples/ViewModels/FAControlsGroupItem.cs
@@ -6,5 +6,5 @@ public class FAControlsGroupItem
 {
     public string Header { get; set; }
 
-    public List<FAControlsItem> Controls { get; init; }
+    public List<FAControlsItem> Controls { get; set; }
 }

--- a/samples/FluentAvaloniaSamples/ViewModels/FAControlsItem.cs
+++ b/samples/FluentAvaloniaSamples/ViewModels/FAControlsItem.cs
@@ -17,7 +17,7 @@ public class FAControlsItem
 
     public string PreviewImageSource { get; set; }
 
-    public string PageType { get; init; }
+    public string PageType { get; set; }
 
     public FACommand InvokeCommand { get; }
 

--- a/samples/FluentAvaloniaSamples/ViewModels/MainViewViewModel.cs
+++ b/samples/FluentAvaloniaSamples/ViewModels/MainViewViewModel.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using FluentAvalonia.Styling;
 using System.Text.Json;
 using Avalonia.Styling;
+using System.Text.Json.Serialization;
 
 namespace FluentAvaloniaSamples.ViewModels;
 
@@ -207,7 +208,7 @@ public class MainViewViewModel : ViewModelBase
         }
 
         var file = GetAssemblyResource("avares://FluentAvaloniaSamples/Assets/CoreControlsGroups.json");
-        var coreControls = JsonSerializer.Deserialize<List<CoreControlsGroupItem>>(file);
+        var coreControls = JsonSerializer.Deserialize(file, FASampleJsonContext.Default.ListCoreControlsGroupItem);
         for (int i = 1; i < coreControls.Count; i++)
         {
             var desc = coreControls[i].Description.Split(',');
@@ -220,7 +221,7 @@ public class MainViewViewModel : ViewModelBase
 
         // Get all FluentAvalonia pages
         file = GetAssemblyResource("avares://FluentAvaloniaSamples/Assets/FAControlsGroups.json");
-        var controls = JsonSerializer.Deserialize<List<FAControlsGroupItem>>(file);
+        var controls = JsonSerializer.Deserialize(file, FASampleJsonContext.Default.ListFAControlsGroupItem);
         foreach (var group in controls)
         {
             foreach (var ctrl in group.Controls)
@@ -247,6 +248,13 @@ public class MainViewViewModel : ViewModelBase
     private FlowDirection _currentFlowDirection;
     private Color _listBoxColor;
     private bool _ignoreSetListBoxColor = false;
+}
+
+[JsonSerializable(typeof(List<CoreControlsGroupItem>))]
+[JsonSerializable(typeof(List<FAControlsGroupItem>))]
+public partial class FASampleJsonContext : JsonSerializerContext
+{
+
 }
 
 public class MainAppSearchItem

--- a/samples/FluentAvaloniaSamples/ViewModels/NewControlsPageViewModel.cs
+++ b/samples/FluentAvaloniaSamples/ViewModels/NewControlsPageViewModel.cs
@@ -8,7 +8,7 @@ public class NewControlsPageViewModel : ViewModelBase
     public NewControlsPageViewModel()
     {
         var controls = GetAssemblyResource("avares://FluentAvaloniaSamples/Assets/FAControlsGroups.json");
-        ControlGroups = JsonSerializer.Deserialize<List<FAControlsGroupItem>>(controls);
+        ControlGroups = JsonSerializer.Deserialize(controls, FASampleJsonContext.Default.ListFAControlsGroupItem);
     }
 
     public string PageHeader => "New Controls in FluentAvalonia";

--- a/samples/FluentAvaloniaSamples/Views/MainView.axaml
+++ b/samples/FluentAvaloniaSamples/Views/MainView.axaml
@@ -216,9 +216,10 @@
                                                            Theme="{StaticResource SubtitleTextBlockStyle}"
                                                            Margin="12 4"/>
 
-                                                <!--<aedit:TextEditor Name="TextEditor"
+                                                <aedit:TextEditor Name="TextEditor"
                                                                   Margin="12 0"
-                                                                  Background="Transparent" />-->
+                                                                  FontFamily="Consolas"
+                                                                  Background="Transparent" />
                                             </StackPanel>
                                         </ScrollViewer>
 


### PR DESCRIPTION
- Enable CodeViewer in samples
- Use Json source generator to avoid trimming issue
  - Change `init` to `set` as json source generator in .NET 7 doesn't support `init` properties yet, we can revert them back once we upgrade to .NET 8

![image](https://user-images.githubusercontent.com/14960345/231049357-c9d3466d-c96a-4361-9493-e59d05dd86e1.png)
