### PR TITLE
Unsubscribe from ColorValuesChanged on window close

### DIFF
--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
@@ -33,6 +33,7 @@ internal unsafe class Win32WindowManager
 
         var ps = AvaloniaLocator.Current.GetService<IPlatformSettings>();
         ps.ColorValuesChanged += OnPlatformColorValuesChanged;
+        _window.Closed += WindowOnClosed;
     }
 
     public HWND Hwnd { get; }
@@ -370,6 +371,13 @@ internal unsafe class Win32WindowManager
         // in dark mode, which matches what windows do on Win 10/11, regardless of the actual
         // app or system theme.
         Win32Interop.ApplyTheme(Hwnd, true);
+    }
+    
+    private void WindowOnClosed(object sender, EventArgs e)
+    {
+        var ps = AvaloniaLocator.Current.GetService<IPlatformSettings>();
+        ps.ColorValuesChanged -= OnPlatformColorValuesChanged;
+        _window.Closed -= WindowOnClosed;
     }
 
     private void UpdateMaximizeState()


### PR DESCRIPTION
I noticed an issue where any closed window would stay in memory indefinitely.

This is troublesome for applications with tray icons because it means no part of the UI ever gets GC'd after the main window closes.

dotMemory pointed out this event handler as the culprit so I made it unsubscribe when the related window has closed.