### PR TITLE
[WIP] preview7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0.999-cibuild0033637-beta</AvaloniaVersion>
+    <AvaloniaVersion>11.0-preview7</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0-preview6</AvaloniaVersion>
+    <AvaloniaVersion>11.0.999-cibuild0033637-beta</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/samples/FluentAvaloniaSamples/Pages/CoreControlPages/DataControlsPage.axaml.cs
+++ b/samples/FluentAvaloniaSamples/Pages/CoreControlPages/DataControlsPage.axaml.cs
@@ -14,7 +14,7 @@ public partial class DataControlsPage : UserControl
 
         var dg = this.FindControl<DataGrid>("TargetDataGrid");
 
-        dg.Items = new DataGridCollectionView(Countries.All)
+        dg.ItemsSource = new DataGridCollectionView(Countries.All)
         {
             GroupDescriptions =
             {

--- a/samples/FluentAvaloniaSamples/Pages/CoreControlPages/TextControlsPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/CoreControlPages/TextControlsPage.axaml
@@ -74,7 +74,7 @@
                                TextWrapping="Wrap"/>
                     <AutoCompleteBox HorizontalAlignment="Left"
                                      MinWidth="250"
-                                     Items="{Binding States}"
+                                     ItemsSource="{Binding States}"
                                      ValueMemberBinding="{Binding Name, DataType=vm:StateData}"
                                      Name="TargetAutoCompleteBox" />
                 </StackPanel>

--- a/samples/FluentAvaloniaSamples/Pages/CoreControlsPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/CoreControlsPage.axaml
@@ -31,7 +31,7 @@
             </Panel>
 
 
-            <ItemsRepeater Items="{Binding CoreControlGroups}"
+            <ItemsRepeater ItemsSource="{Binding CoreControlGroups}"
                            Margin="18 0 18 18">
                 <ItemsRepeater.Layout>
                     <StackLayout Spacing="4" />

--- a/samples/FluentAvaloniaSamples/Pages/FAControlPages/ContentDialogPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/FAControlPages/ContentDialogPage.axaml
@@ -33,7 +33,7 @@
                     </Expander>
                     <Expander Header="Default Button">
                         <ComboBox Name="DefButtonSelector" MinWidth="90" 
-                                  Items="{Binding ContentDialogButtons}"
+                                  ItemsSource="{Binding ContentDialogButtons}"
                                   SelectedItem="{Binding ContentDialogDefaultButton}" />
                     </Expander>
                     <Expander Header="Content">

--- a/samples/FluentAvaloniaSamples/Pages/FAControlPages/FramePage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/FAControlPages/FramePage.axaml
@@ -18,7 +18,7 @@
 
             <StackPanel>
                 <ListBox Name="PageSelection"
-                         Items="{Binding PageOptions}">
+                         ItemsSource="{Binding PageOptions}">
                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
                             <WrapPanel />

--- a/samples/FluentAvaloniaSamples/Pages/FAControlPages/IconElementPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/FAControlPages/IconElementPage.axaml
@@ -72,7 +72,7 @@ In addition, I've also added a FontSize property to the SymbolIcon to allow chan
                                TextWrapping="Wrap"
                                Margin="8 4 8 12"/>
                     
-                    <ItemsRepeater Items="{Binding Symbols}">
+                    <ItemsRepeater ItemsSource="{Binding Symbols}">
                         <ItemsRepeater.Layout>
                             <WrapLayout HorizontalSpacing="4" VerticalSpacing="4" />
                         </ItemsRepeater.Layout>

--- a/samples/FluentAvaloniaSamples/Pages/FAControlPages/StandardUICommandPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/FAControlPages/StandardUICommandPage.axaml
@@ -17,7 +17,7 @@
 
     <StackPanel Spacing="8">
         <Expander Header="Defined StandardUICommands">
-            <ItemsRepeater Items="{Binding StandardCommands}">
+            <ItemsRepeater ItemsSource="{Binding StandardCommands}">
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate>
                         <DockPanel>
@@ -45,7 +45,7 @@
                                              CommandParameter="{Binding #ListBox1.SelectedItem}"/>
                     </ui:CommandBar.SecondaryCommands>
                 </ui:CommandBar>
-                <ListBox Items="{Binding TempItems}" Name="ListBox1">
+                <ListBox ItemsSource="{Binding TempItems}" Name="ListBox1">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Border Background="Transparent">

--- a/samples/FluentAvaloniaSamples/Pages/NewControlsPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/NewControlsPage.axaml
@@ -36,7 +36,7 @@
             </Panel>
 
 
-            <ItemsRepeater Items="{Binding ControlGroups}"
+            <ItemsRepeater ItemsSource="{Binding ControlGroups}"
                            Margin="18 0 18 18">
                 <ItemsRepeater.Layout>
                     <StackLayout Spacing="20" />
@@ -52,7 +52,7 @@
                             <ScrollViewer VerticalScrollBarVisibility="Disabled"
                                           HorizontalScrollBarVisibility="Auto"
                                           Padding="0 0 0 17">
-                                <ItemsRepeater Items="{Binding Controls}">
+                                <ItemsRepeater ItemsSource="{Binding Controls}">
                                     <ItemsRepeater.Layout>
                                         <StackLayout Orientation="Horizontal" Spacing="8"  />
                                     </ItemsRepeater.Layout>

--- a/samples/FluentAvaloniaSamples/Pages/ResourcesPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/ResourcesPage.axaml
@@ -66,7 +66,7 @@
             </local:OptionsDisplayItem>
         </StackPanel>
 
-        <DataGrid Items="{Binding ResourceView}"
+        <DataGrid ItemsSource="{Binding ResourceView}"
                   AutoGenerateColumns="False"
                   CanUserResizeColumns="True"
                   CanUserSortColumns="False" 

--- a/samples/FluentAvaloniaSamples/Pages/SampleCode/StandardUICommand.xaml.txt
+++ b/samples/FluentAvaloniaSamples/Pages/SampleCode/StandardUICommand.xaml.txt
@@ -18,7 +18,7 @@ Xaml inside the control example:
             <ui:CommandBarButton Command="{StaticResource DeleteCommand}" CommandParameter="{Binding #ListBox1.SelectedItem}"/>
         </ui:CommandBar.SecondaryCommands>
     </ui:CommandBar>
-    <ListBox Items="{Binding TempItems}" Name="ListBox1" VirtualizationMode="None">
+    <ListBox ItemsSource="{Binding TempItems}" Name="ListBox1" VirtualizationMode="None">
         <ListBox.ItemTemplate>
             <DataTemplate>
                 <Border Background="Transparent">

--- a/samples/FluentAvaloniaSamples/Pages/SamplePageAssets/ContentDialogInputExample.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/SamplePageAssets/ContentDialogInputExample.axaml
@@ -12,7 +12,7 @@
         <AutoCompleteBox FilterMode="StartsWithOrdinal"
                          Watermark="Write a keyword, for example 'ok', 'not ok' or 'hide'"
                          Text="{CompiledBinding UserInput}"
-                         Items="{Binding AvailableKeyWords}"
+                         ItemsSource="{Binding AvailableKeyWords}"
                          AttachedToVisualTree="InputField_OnAttachedToVisualTree" />
     </StackPanel>
 </UserControl>

--- a/samples/FluentAvaloniaSamples/Pages/SettingsPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/SettingsPage.axaml
@@ -74,7 +74,7 @@
 
                 <ctrls:OptionsDisplayItem.ActionButton>
                     <ComboBox SelectedItem="{Binding CurrentAppTheme}"
-                              Items="{Binding AppThemes}"
+                              ItemsSource="{Binding AppThemes}"
                               MinWidth="150"/>
                 </ctrls:OptionsDisplayItem.ActionButton>
                 
@@ -86,7 +86,7 @@
 
                 <ctrls:OptionsDisplayItem.ActionButton>
                     <ComboBox SelectedItem="{Binding CurrentFlowDirection}"
-                              Items="{Binding AppFlowDirections}"
+                              ItemsSource="{Binding AppFlowDirections}"
                               MinWidth="150"/>
                 </ctrls:OptionsDisplayItem.ActionButton>
                 
@@ -165,7 +165,7 @@
                         <TextBlock Text="Pre-set Colors"
                                    Margin="24 24 0 0"/>
 
-                        <ListBox Items="{Binding PredefinedColors}"
+                        <ListBox ItemsSource="{Binding PredefinedColors}"
                                  SelectedItem="{Binding ListBoxColor}"
                                  MaxWidth="441"
                                  AutoScrollToSelectedItem="False"

--- a/samples/FluentAvaloniaSamples/Pages/WhatsNewPage.axaml
+++ b/samples/FluentAvaloniaSamples/Pages/WhatsNewPage.axaml
@@ -13,7 +13,7 @@
                        Classes="TitleTextBlockStyle" />
 
 
-            <ComboBox MinWidth="150" Items="{Binding Versions}"
+            <ComboBox MinWidth="150" ItemsSource="{Binding Versions}"
                       SelectedItem="{Binding CurrentVersion}"
                       DockPanel.Dock="Right">
                 <ComboBox.ItemTemplate>
@@ -25,7 +25,7 @@
         </DockPanel>
 
         <ScrollViewer>
-            <ItemsRepeater Items="{Binding CurrentVersion.ChangeItems}">
+            <ItemsRepeater ItemsSource="{Binding CurrentVersion.ChangeItems}">
                 <ItemsRepeater.Styles>
                     <Style Selector="TextBlock">
                         <Setter Property="TextWrapping" Value="Wrap" />

--- a/samples/FluentAvaloniaSamples/Views/MainView.axaml
+++ b/samples/FluentAvaloniaSamples/Views/MainView.axaml
@@ -141,7 +141,7 @@
                                  Watermark="Search"
                                  Classes="SampleApp"
                                  ValueMemberBinding="{Binding Header, DataType=vm:MainAppSearchItem}"
-                                 Items="{Binding MainSearchItems}"
+                                 ItemsSource="{Binding MainSearchItems}"
                                  wnd:AppWindow.AllowInteractionInTitleBar="True">
                     <AutoCompleteBox.ItemTemplate>
                         <DataTemplate x:DataType="vm:MainAppSearchItem">

--- a/samples/FluentAvaloniaSamples/Views/MainView.axaml.cs
+++ b/samples/FluentAvaloniaSamples/Views/MainView.axaml.cs
@@ -93,15 +93,16 @@ public partial class MainView : UserControl
     {
         var pt = e.GetCurrentPoint(this);
 
-        if (pt.Properties.PointerUpdateKind == PointerUpdateKind.XButton1Released)
-        {
-            if (_frameView.CanGoBack)
-            {
-                _frameView.GoBack();
-                e.Handled = true;
-            }
-        }
-        else if (pt.Properties.PointerUpdateKind == PointerUpdateKind.XButton2Released)
+        //if (pt.Properties.PointerUpdateKind == PointerUpdateKind.XButton1Released)
+        //{
+        //    if (_frameView.CanGoBack)
+        //    {
+        //        _frameView.GoBack();
+        //        e.Handled = true;
+        //    }
+        //}
+        //else 
+        if (pt.Properties.PointerUpdateKind == PointerUpdateKind.XButton2Released)
         {
             if (_frameView.CanGoForward)
             {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.0.0-preview6</Version>
+    <Version>2.0.0-preview7</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ButtonStyles.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                     x:CompileBindings="True">
     <Design.PreviewWith>
         <Border Padding="50">
@@ -32,17 +33,17 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentPresenter x:Name="PART_ContentPresenter"
-                                  Background="{TemplateBinding Background}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}"
-                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  Padding="{TemplateBinding Padding}"
-                                  RecognizesAccessKey="True"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                <uip:FAContentPresenter x:Name="PART_ContentPresenter"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        Padding="{TemplateBinding Padding}"
+                                        RecognizesAccessKey="True"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ControlTemplate>
         </Setter>
 
@@ -111,17 +112,17 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentPresenter x:Name="PART_ContentPresenter"
-                                  Background="{TemplateBinding Background}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}"
-                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  Padding="{TemplateBinding Padding}"
-                                  RecognizesAccessKey="True"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                <uip:FAContentPresenter Name="PART_ContentPresenter"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        Padding="{TemplateBinding Padding}"
+                                        RecognizesAccessKey="True"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ControlTemplate>
         </Setter>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
@@ -179,7 +179,7 @@
                     </TabItem.Header>
                     <ListBox Theme="{StaticResource ColorViewPaletteListBoxTheme}"
                              ItemContainerTheme="{StaticResource ColorViewPaletteListBoxItemTheme}"
-                             Items="{TemplateBinding PaletteColors}"
+                             ItemsSource="{TemplateBinding PaletteColors}"
                              SelectedItem="{Binding Color, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource DoNothingForNullConverter}, Mode=TwoWay}"
                              UseLayoutRounding="False"
                              Margin="12">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
@@ -347,7 +347,7 @@
               </TabItem.Header>
               <ListBox Theme="{StaticResource ColorViewPaletteListBoxTheme}"
                        ItemContainerTheme="{StaticResource ColorViewPaletteListBoxItemTheme}"
-                       Items="{TemplateBinding PaletteColors}"
+                       ItemsSource="{TemplateBinding PaletteColors}"
                        SelectedItem="{Binding Color, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource DoNothingForNullConverter}, Mode=TwoWay}"
                        UseLayoutRounding="False"
                        Margin="12">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DataValidationErrorsStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DataValidationErrorsStyles.axaml
@@ -50,7 +50,7 @@
             <DataTemplate>
                 <ItemsControl x:DataType="DataValidationErrors"
                               Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}"
-                              Items="{Binding}">
+                              ItemsSource="{Binding}">
                     <ItemsControl.Styles>
                         <Style Selector="TextBlock">
                             <Setter Property="TextWrapping" Value="Wrap" />
@@ -98,7 +98,7 @@
                         </Style>
                     </Panel.Styles>
                     <ToolTip.Tip>
-                        <ItemsControl Items="{ReflectionBinding}" />
+                        <ItemsControl ItemsSource="{ReflectionBinding}" />
                     </ToolTip.Tip>
                     <Path Width="14"
                           Height="14"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ExpanderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ExpanderStyles.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ui="using:FluentAvalonia.UI.Controls"
                     x:CompileBindings="True">
     <Design.PreviewWith>
         <Border Padding="50" Width="550">
@@ -52,17 +53,17 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="Root"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        MinHeight="{TemplateBinding MinHeight}"
-                        MinWidth="{TemplateBinding MinWidth}"
-                        MaxWidth="{TemplateBinding MaxWidth}"
-                        Width="{TemplateBinding Width}"
-                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                        Padding="{TemplateBinding Padding}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-						CornerRadius="{TemplateBinding CornerRadius}">
+                <ui:FABorder Name="Root"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             MinHeight="{TemplateBinding MinHeight}"
+                             MinWidth="{TemplateBinding MinWidth}"
+                             MaxWidth="{TemplateBinding MaxWidth}"
+                             Width="{TemplateBinding Width}"
+                             HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                             Padding="{TemplateBinding Padding}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+						     CornerRadius="{TemplateBinding CornerRadius}">
 
                     <Grid ColumnDefinitions="*,Auto">
 
@@ -99,12 +100,12 @@
                             </TextBlock>
                         </Border>
                     </Grid>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
         
         <Style Selector="^:pointerover">
-            <Style Selector="^ /template/ Border#Root">
+            <Style Selector="^ /template/ ui|FABorder#Root">
                 <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderPointerOverBrush}" />
             </Style>
             <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
@@ -120,7 +121,7 @@
         </Style>
 
         <Style Selector="^:pressed">
-            <Style Selector="^ /template/ Border#Root">
+            <Style Selector="^ /template/ ui|FABorder#Root">
                 <Setter Property="BorderBrush" Value="{DynamicResource ExpanderBorderPressedBrush}" />
             </Style>
             <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
@@ -136,7 +137,7 @@
         </Style>
 
         <Style Selector="^:disabled">
-            <Style Selector="^ /template/ Border#Root">
+            <Style Selector="^ /template/ ui|FABorder#Root">
                 <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderDisabledBorderBrush}" />
             </Style>
             <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
@@ -152,7 +153,7 @@
         </Style>
 
         <Style Selector="^:checked">
-            <Style Selector="^ /template/ Border#Root">
+            <Style Selector="^ /template/ ui|FABorder#Root">
                 <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderBrush}" />
             </Style>
             <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
@@ -168,7 +169,7 @@
             </Style>
 
             <Style Selector="^:pointerover">
-                <Style Selector="^ /template/ Border#Root">
+                <Style Selector="^ /template/ ui|FABorder#Root">
                     <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderPointerOverBrush}" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
@@ -185,7 +186,7 @@
             </Style>
 
             <Style Selector="^:pressed">
-                <Style Selector="^ /template/ Border#Root">
+                <Style Selector="^ /template/ ui|FABorder#Root">
                     <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderPressedBrush}" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
@@ -202,7 +203,7 @@
             </Style>
 
             <Style Selector="^:disabled">
-                <Style Selector="^ /template/ Border#Root">
+                <Style Selector="^ /template/ ui|FABorder#Root">
                     <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderDisabledBorderBrush}" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
@@ -234,15 +235,15 @@
                               Tag="{StaticResource ExpanderChevronDownGlyph}"
                               CornerRadius="{TemplateBinding CornerRadius}"/>
 
-                <Border Name="ExpanderContent"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource BottomCornerRadiusFilterConverter}}"
-                        MinHeight="{TemplateBinding MinHeight}"
-                        MinWidth="{TemplateBinding MinWidth}"
-                        Grid.Row="1"
-                        IsVisible="False">
+                <ui:FABorder Name="ExpanderContent"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource BottomCornerRadiusFilterConverter}}"
+                             MinHeight="{TemplateBinding MinHeight}"
+                             MinWidth="{TemplateBinding MinWidth}"
+                             Grid.Row="1"
+                             IsVisible="False">
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Margin="{TemplateBinding Padding}"
                                       IsVisible="{TemplateBinding IsExpanded}"
@@ -250,7 +251,7 @@
                                       Content="{TemplateBinding Content}"
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-                </Border>
+                </ui:FABorder>
             </Grid>
         </Border>
     </ControlTemplate>
@@ -269,15 +270,15 @@
                               Tag="{StaticResource ExpanderChevronUpGlyph}"
                               CornerRadius="{TemplateBinding CornerRadius}"/>
 
-                <Border Name="ExpanderContent"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}"
-                        MinHeight="{TemplateBinding MinHeight}"
-                        MinWidth="{TemplateBinding MinWidth}"
-                        Grid.Row="0"
-                        IsVisible="False">
+                <ui:FABorder Name="ExpanderContent"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}"
+                             MinHeight="{TemplateBinding MinHeight}"
+                             MinWidth="{TemplateBinding MinWidth}"
+                             Grid.Row="0"
+                             IsVisible="False">
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Margin="0"
                                       IsVisible="{TemplateBinding IsExpanded}"
@@ -286,7 +287,7 @@
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                       Padding="{TemplateBinding Padding}" />
-                </Border>
+                </ui:FABorder>
             </Grid>
         </Border>
     </ControlTemplate>
@@ -305,15 +306,15 @@
                               Theme="{StaticResource ExpanderToggleButton}"
                               Tag="{StaticResource ExpanderChevronLeftGlyph}" />
 
-                <Border Name="ExpanderContent"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
-                        MinHeight="{TemplateBinding MinHeight}"
-                        MinWidth="{TemplateBinding MinWidth}"
-                        Grid.Column="0"
-                        IsVisible="False">
+                <ui:FABorder Name="ExpanderContent"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
+                             MinHeight="{TemplateBinding MinHeight}"
+                             MinWidth="{TemplateBinding MinWidth}"
+                             Grid.Column="0"
+                             IsVisible="False">
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Margin="0"
                                       IsVisible="{TemplateBinding IsExpanded}"
@@ -322,7 +323,7 @@
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                       Padding="{TemplateBinding Padding}" />
-                </Border>
+                </ui:FABorder>
             </Grid>
         </Border>
     </ControlTemplate>
@@ -341,15 +342,15 @@
                               Theme="{StaticResource ExpanderToggleButton}"
                               Tag="{StaticResource ExpanderChevronRightGlyph}" />
 
-                <Border Name="ExpanderContent"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
-                        MinHeight="{TemplateBinding MinHeight}"
-                        MinWidth="{TemplateBinding MinWidth}"
-                        Grid.Column="1"
-                        IsVisible="False">
+                <ui:FABorder Name="ExpanderContent"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
+                             MinHeight="{TemplateBinding MinHeight}"
+                             MinWidth="{TemplateBinding MinWidth}"
+                             Grid.Column="1"
+                             IsVisible="False">
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Margin="0"
                                       IsVisible="{TemplateBinding IsExpanded}"
@@ -358,7 +359,7 @@
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                       Padding="{TemplateBinding Padding}" />
-                </Border>
+                </ui:FABorder>
             </Grid>
         </Border>
     </ControlTemplate>
@@ -415,7 +416,7 @@
             </Style>
         </Style>
 
-        <Style Selector="^:expanded /template/ Border#ExpanderContent">
+        <Style Selector="^:expanded /template/ ui|FABorder#ExpanderContent">
             <Setter Property="IsVisible" Value="True" />
         </Style>
     </ControlTheme>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ManagedFileChooserStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ManagedFileChooserStyles.axaml
@@ -139,7 +139,7 @@
                 <Grid ColumnDefinitions="1*,0,4*">
                     <ListBox x:Name="PART_QuickLinks"
                              Grid.Column="0"
-                             Items="{Binding QuickLinks}"
+                             ItemsSource="{Binding QuickLinks}"
                              SelectedIndex="{Binding QuickLinksSelectedIndex}"
                              Focusable="False">
                         <ListBox.ItemTemplate>
@@ -209,7 +209,7 @@
                                 <DockPanel DockPanel.Dock="Top">
                                     <ComboBox DockPanel.Dock="Right"
                                               IsVisible="{Binding ShowFilters}"
-                                              Items="{Binding Filters}"
+                                              ItemsSource="{Binding Filters}"
                                               SelectedItem="{Binding SelectedFilter}"
                                               Margin="2 0 0 0"/>
                                     <TextBox Text="{Binding FileName}" 
@@ -264,7 +264,7 @@
                                 <TextBlock Grid.Column="8" Text="Size" />
                             </Grid>
                             <ListBox x:Name="PART_Files"
-                                     Items="{Binding Items}"
+                                     ItemsSource="{Binding Items}"
                                      Margin="0 5"
                                      SelectionMode="{Binding SelectionMode}"
                                      SelectedItems="{Binding SelectedItems}"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
@@ -211,5 +211,25 @@
             </Setter>
         </Style>
     </ControlTheme>
+
+    <ControlTheme x:Key="{x:Type Separator}"
+                  TargetType="Separator">
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Background" Value="{DynamicResource MenuFlyoutSeparatorBackground}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="Margin" Value="{DynamicResource MenuFlyoutSeparatorThemePadding}" />
+        <Setter Property="Height" Value="{DynamicResource MenuFlyoutSeparatorHeight}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Padding="{TemplateBinding Margin}"
+                        Height="{TemplateBinding Height}"
+                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"/>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
     
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/NativeMenuBarStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/NativeMenuBarStyles.axaml
@@ -10,13 +10,13 @@
             <ControlTemplate>
                 <Menu
                   IsVisible="{Binding $parent[TopLevel].(NativeMenu.IsNativeMenuExported), Converter={StaticResource AvaloniaThemesFluentNativeMenuBarInverseBooleanValueConverter}}"
-                  Items="{Binding $parent[TopLevel].(NativeMenu.Menu).Items}">
+                  ItemsSource="{Binding $parent[TopLevel].(NativeMenu.Menu).Items}">
                     <Menu.Styles>
                         <Style x:CompileBindings="False" Selector="MenuItem">
                             <Setter Property="Header" Value="{Binding Header}"/>
                             <Setter Property="IsEnabled" Value="{Binding IsEnabled}"/>
                             <Setter Property="InputGesture" Value="{Binding Gesture}"/>
-                            <Setter Property="Items" Value="{Binding Menu.Items}"/>
+                            <Setter Property="ItemsSource" Value="{Binding Menu.Items}"/>
                             <Setter Property="Command" Value="{Binding Command}"/>
                             <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
                             <Setter Property="(NativeMenuBar.EnableMenuItemClickForwarding)" Value="True"/>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/RepeatButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/RepeatButtonStyles.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                     x:CompileBindings="True">
     <Design.PreviewWith>
         <Border Padding="50">
@@ -30,16 +31,16 @@
         <Setter Property="RenderTransform" Value="none" />
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentPresenter x:Name="PART_ContentPresenter"
-                                  Background="{TemplateBinding Background}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}"
-                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  Padding="{TemplateBinding Padding}"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                <uip:FAContentPresenter x:Name="PART_ContentPresenter"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        Padding="{TemplateBinding Padding}"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ControlTemplate>
         </Setter>
 
@@ -86,17 +87,17 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentPresenter x:Name="PART_ContentPresenter"
-                                  Background="{TemplateBinding Background}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}"
-                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  Padding="{TemplateBinding Padding}"
-                                  RecognizesAccessKey="True"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                <uip:FAContentPresenter x:Name="PART_ContentPresenter"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        Padding="{TemplateBinding Padding}"
+                                        RecognizesAccessKey="True"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ControlTemplate>
         </Setter>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ScrollViewerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ScrollViewerStyles.axaml
@@ -30,42 +30,24 @@
                                             Grid.RowSpan="2"
                                             Grid.ColumnSpan="2"
                                             Background="{TemplateBinding Background}"
-                                            CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"
-                                            CanVerticallyScroll="{TemplateBinding CanVerticallyScroll}"
-                                            Content="{TemplateBinding Content}"
-                                            Extent="{TemplateBinding Extent, Mode=TwoWay}"
-                                            Margin="{TemplateBinding Padding}"
-                                            Offset="{TemplateBinding Offset, Mode=TwoWay}"
-                                            Viewport="{TemplateBinding Viewport, Mode=TwoWay}">
+                                            HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
+                                            VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
+                                            HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
+                                            VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
+                                            Padding="{TemplateBinding Padding}">
                         <ScrollContentPresenter.GestureRecognizers>
-                            <ScrollGestureRecognizer
-                              CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"
-                              CanVerticallyScroll="{TemplateBinding CanVerticallyScroll}" />
+                            <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+                                                     CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
+                                                     IsScrollInertiaEnabled="{Binding IsScrollInertiaEnabled, RelativeSource={RelativeSource TemplatedParent}}" />
                         </ScrollContentPresenter.GestureRecognizers>
                     </ScrollContentPresenter>
                     <ScrollBar Name="PART_HorizontalScrollBar"
-                               AllowAutoHide="{TemplateBinding AllowAutoHide}"
                                Orientation="Horizontal"
-                               LargeChange="{Binding LargeChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                               SmallChange="{Binding SmallChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                               Maximum="{TemplateBinding HorizontalScrollBarMaximum}"
-                               Value="{TemplateBinding HorizontalScrollBarValue, Mode=TwoWay}"
-                               ViewportSize="{TemplateBinding HorizontalScrollBarViewportSize}"
-                               Visibility="{TemplateBinding HorizontalScrollBarVisibility}"
-                               Grid.Row="1"
-                               Focusable="False" />
-                    <ScrollBar Name="PART_VerticalScrollBar"
-                               AllowAutoHide="{TemplateBinding AllowAutoHide}"
-                               Orientation="Vertical"
-                               LargeChange="{Binding LargeChange.Height, RelativeSource={RelativeSource TemplatedParent}}"
-                               SmallChange="{Binding SmallChange.Height, RelativeSource={RelativeSource TemplatedParent}}"
-                               Maximum="{TemplateBinding VerticalScrollBarMaximum}"
-                               Value="{TemplateBinding VerticalScrollBarValue, Mode=TwoWay}"
-                               ViewportSize="{TemplateBinding VerticalScrollBarViewportSize}"
-                               Visibility="{TemplateBinding VerticalScrollBarVisibility}"
-                               Grid.Column="1"
-                               Focusable="False" />
-                    <Panel x:Name="PART_ScrollBarsSeparator"
+                               Grid.Row="1" />
+                    <ScrollBar Name="PART_VerticalScrollBar"                               
+                               Orientation="Vertical"                              
+                               Grid.Column="1" />
+                    <Panel Name="PART_ScrollBarsSeparator"
                            Grid.Row="1" Grid.Column="1"
                            Background="{DynamicResource ScrollViewerScrollBarsSeparatorBackground}">
                         <Panel.Transitions>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleButtonStyles.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                     x:CompileBindings="True">
     <Design.PreviewWith>
         <Border Padding="50">
@@ -27,16 +28,16 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentPresenter Name="PART_ContentPresenter"
-                                  Background="{TemplateBinding Background}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}"
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                  Padding="{TemplateBinding Padding}"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                <uip:FAContentPresenter Name="PART_ContentPresenter"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Padding="{TemplateBinding Padding}"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ControlTemplate>
         </Setter>
 
@@ -126,16 +127,16 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentPresenter Name="PART_ContentPresenter"
-                                  Background="{TemplateBinding Background}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}"
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                  Padding="{TemplateBinding Padding}"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                <uip:FAContentPresenter Name="PART_ContentPresenter"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Padding="{TemplateBinding Padding}"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ControlTemplate>
         </Setter>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/ColorPickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/ColorPickerStyles.axaml
@@ -477,7 +477,7 @@
                                                               VerticalScrollBarVisibility="Auto"
                                                               MaxHeight="450">
                                                     <ItemsRepeater Margin="5"
-                                                                   Items="{TemplateBinding CustomPaletteColors}">
+                                                                   ItemsSource="{TemplateBinding CustomPaletteColors}">
                                                         <ItemsRepeater.Layout>
                                                             <UniformGridLayout MaximumRowsOrColumns="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PaletteColumnCount}"
                                                                                Orientation="Horizontal"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
@@ -171,6 +171,7 @@
         <!--Handle open dialog-->
         <Style Selector="^:open /template/ Panel#LayoutRoot">
             <Setter Property="IsVisible" Value="True"/>
+            <Setter Property="Opacity" Value="0" />
             <Style.Animations>
                  <!--Animation applies with priority of LocalValue
                  To overrule the IsVisible=False in :hidden, set

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
@@ -96,11 +96,16 @@
                                                 Padding="1 0 0 0"
                                                 KeyboardNavigation.TabNavigation="Once"
                                                 Content="{TemplateBinding Content}"
-                                                CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"
-                                                CanVerticallyScroll="{TemplateBinding CanVerticallyScroll}"
-                                                Extent="{TemplateBinding Extent, Mode=TwoWay}"
-                                                Offset="{TemplateBinding Offset, Mode=TwoWay}"
-                                                Viewport="{TemplateBinding Viewport, Mode=TwoWay}"/>
+                                                HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
+                                                VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
+                                                HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
+                                                VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}">
+                            <ScrollContentPresenter.GestureRecognizers>
+                                <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=ScrollContentPresenter}"
+                                                         CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=ScrollContentPresenter}"
+                                                         IsScrollInertiaEnabled="{Binding IsScrollInertiaEnabled, RelativeSource={RelativeSource TemplatedParent}}" />
+                            </ScrollContentPresenter.GestureRecognizers>
+                        </ScrollContentPresenter>
 
                         <Border Name="ScrollIncreaseButtonContainer"
                                 IsVisible="{Binding HorizontalScrollBarVisibility, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource SVVTBC}}"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
@@ -300,6 +300,7 @@
             <!--Handle open dialog-->
             <Style Selector="^:open /template/ Panel#LayoutRoot">
                 <Setter Property="IsVisible" Value="True"/>
+                <Setter Property="Opacity" Value="0" />
                 <Style.Animations>
                      <!--Animation applies with priority of LocalValue
                          To overrule the IsVisible=False in :hidden, set

--- a/src/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.windows.cs
+++ b/src/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.windows.cs
@@ -145,7 +145,7 @@ public partial class FluentAvaloniaTheme
 
         try
         {
-            Win32Interop.ApplyTheme(window.PlatformImpl.Handle.Handle, theme == ThemeVariant.Dark);
+            Win32Interop.ApplyTheme(window.TryGetPlatformHandle().Handle, theme == ThemeVariant.Dark);
         }
         catch
         {

--- a/src/FluentAvalonia/UI/Controls/ColorPicker/ColorPaletteItem.cs
+++ b/src/FluentAvalonia/UI/Controls/ColorPicker/ColorPaletteItem.cs
@@ -100,8 +100,11 @@ public partial class ColorPaletteItem : Control
 
         void Update(Size finalSize, Thickness borderThickness, CornerRadius cornerRadius)
         {
-            _backendSupportsIndividualCorners ??= AvaloniaLocator.Current.GetService<IPlatformRenderInterface>()
-                .SupportsIndividualRoundRects;
+            // v2p6.1 - no longer have access to this, always default to false
+            // (probably was the case anyway)
+            _backendSupportsIndividualCorners = false; 
+                //??= AvaloniaLocator.Current.GetService<IPlatformRenderInterface>()
+                //.SupportsIndividualRoundRects;
             _size = finalSize;
             _borderThickness = borderThickness;
             _cornerRadius = cornerRadius;

--- a/src/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
@@ -22,13 +22,14 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
     {
         ItemsView.CollectionChanged += ItemsCollectionChanged;
     }
+
     Type IStyleable.StyleKey => typeof(CommandBarOverflowPresenter);
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
 
-        if (change.Property == ItemsProperty)
+        if (change.Property == ItemsSourceProperty)
         {
             ItemsChanged(change);
         }

--- a/src/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/src/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -530,21 +530,25 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         }
         else
         {
-            var popupPosition = (_popup?.Host as PopupRoot)?.PlatformImpl?.Position;
+            // v2-p6.1, PlatformImpl was hidden and they're stupidly doing it without providing
+            // access to common APIs that are only accessible in the PlatformImpl, like the 
+            // Window position, so popup will always have the unrounded top, rounded bottoms
 
-            // If we can't get the screen position of the popup, cancel now, the result will
-            // be the default behavior of unrounded bottom ComboBox and unrounded top popup
-            if (!popupPosition.HasValue)
-                return;
+            //var popupPosition = (_popup?.Host as PopupRoot)?.PlatformImpl?.Position;
 
-            var pt = child.PointToScreen(new Point(0, 0));
-            var thisInScreenSpace = this.PointToScreen(new Point(0, 0));
+            //// If we can't get the screen position of the popup, cancel now, the result will
+            //// be the default behavior of unrounded bottom ComboBox and unrounded top popup
+            //if (!popupPosition.HasValue)
+            //    return;
 
-            isPopupAbove = pt.Y < thisInScreenSpace.Y;
+            //var pt = child.PointToScreen(new Point(0, 0));
+            //var thisInScreenSpace = this.PointToScreen(new Point(0, 0));
 
-            // HACK: Windowed popups appear to be +1 offset on x-axis for some reason
-            // which makes the popup look off center. Overlay popups are fine
-            _popup.HorizontalOffset = -1;
+            //isPopupAbove = pt.Y < thisInScreenSpace.Y;
+
+            //// HACK: Windowed popups appear to be +1 offset on x-axis for some reason
+            //// which makes the popup look off center. Overlay popups are fine
+            //_popup.HorizontalOffset = -1;
         }
 
         PseudoClasses.Set(s_pcPopupAbove, isPopupAbove);

--- a/src/FluentAvalonia/UI/Controls/Internal/BorderRenderHelper.cs
+++ b/src/FluentAvalonia/UI/Controls/Internal/BorderRenderHelper.cs
@@ -71,8 +71,10 @@ internal class BorderRenderHelper
 
     void Update(Size finalSize)
     {
-        _backendSupportsIndividualCorners ??= AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>()
-            .SupportsIndividualRoundRects;
+        // v2p6.1 - lost access to this, always false now (probably the case anyway)
+        _backendSupportsIndividualCorners = false;
+        //??= AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>()
+        //    .SupportsIndividualRoundRects;
         _size = finalSize;
 
         _initialized = true;

--- a/src/FluentAvalonia/UI/Controls/Internal/FAContentPresenter.cs
+++ b/src/FluentAvalonia/UI/Controls/Internal/FAContentPresenter.cs
@@ -1,0 +1,743 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.Metadata;
+using Avalonia.Styling;
+using Avalonia.Utilities;
+
+namespace FluentAvalonia.UI.Controls.Primitives;
+
+[PseudoClasses(":empty")]
+public class FAContentPresenter : Control, IContentPresenter, IStyleable
+{
+    public FAContentPresenter()
+    {
+        UpdatePseudoClasses();
+    }
+
+    Type IStyleable.StyleKey => typeof(ContentPresenter);
+
+    /// <summary>
+    /// Defines the <see cref="Background"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IBrush> BackgroundProperty =
+        Border.BackgroundProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="BorderBrush"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IBrush> BorderBrushProperty =
+        Border.BorderBrushProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="BorderThickness"/> property.
+    /// </summary>
+    public static readonly StyledProperty<Thickness> BorderThicknessProperty =
+        Border.BorderThicknessProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="CornerRadius"/> property.
+    /// </summary>
+    public static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
+        Border.CornerRadiusProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="BoxShadow"/> property.
+    /// </summary>
+    public static readonly StyledProperty<BoxShadows> BoxShadowProperty =
+        Border.BoxShadowProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="Foreground"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IBrush> ForegroundProperty =
+        TextElement.ForegroundProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="FontFamily"/> property.
+    /// </summary>
+    public static readonly StyledProperty<FontFamily> FontFamilyProperty =
+        TextElement.FontFamilyProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="FontSize"/> property.
+    /// </summary>
+    public static readonly StyledProperty<double> FontSizeProperty =
+        TextElement.FontSizeProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="FontStyle"/> property.
+    /// </summary>
+    public static readonly StyledProperty<FontStyle> FontStyleProperty =
+        TextElement.FontStyleProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="FontWeight"/> property.
+    /// </summary>
+    public static readonly StyledProperty<FontWeight> FontWeightProperty =
+        TextElement.FontWeightProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="FontStretch"/> property.
+    /// </summary>
+    public static readonly StyledProperty<FontStretch> FontStretchProperty =
+        TextElement.FontStretchProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="TextAlignment"/> property
+    /// </summary>
+    public static readonly StyledProperty<TextAlignment> TextAlignmentProperty =
+        TextBlock.TextAlignmentProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="TextWrapping"/> property
+    /// </summary>
+    public static readonly StyledProperty<TextWrapping> TextWrappingProperty =
+        TextBlock.TextWrappingProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="TextTrimming"/> property
+    /// </summary>
+    public static readonly StyledProperty<TextTrimming> TextTrimmingProperty =
+        TextBlock.TextTrimmingProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="LineHeight"/> property
+    /// </summary>
+    public static readonly StyledProperty<double> LineHeightProperty =
+        TextBlock.LineHeightProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="MaxLines"/> property
+    /// </summary>
+    public static readonly StyledProperty<int> MaxLinesProperty =
+        TextBlock.MaxLinesProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="Child"/> property.
+    /// </summary>
+    public static readonly DirectProperty<ContentPresenter, Control> ChildProperty =
+        AvaloniaProperty.RegisterDirect<ContentPresenter, Control>(
+            nameof(Child),
+            o => o.Child);
+
+    /// <summary>
+    /// Defines the <see cref="Content"/> property.
+    /// </summary>
+    public static readonly StyledProperty<object> ContentProperty =
+        ContentControl.ContentProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="ContentTemplate"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IDataTemplate> ContentTemplateProperty =
+        ContentControl.ContentTemplateProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="HorizontalContentAlignment"/> property.
+    /// </summary>
+    public static readonly StyledProperty<HorizontalAlignment> HorizontalContentAlignmentProperty =
+        ContentControl.HorizontalContentAlignmentProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="VerticalContentAlignment"/> property.
+    /// </summary>
+    public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
+        ContentControl.VerticalContentAlignmentProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="Padding"/> property.
+    /// </summary>
+    public static readonly StyledProperty<Thickness> PaddingProperty =
+        Decorator.PaddingProperty.AddOwner<ContentPresenter>();
+
+    /// <summary>
+    /// Defines the <see cref="RecognizesAccessKey"/> property
+    /// </summary>
+    public static readonly StyledProperty<bool> RecognizesAccessKeyProperty =
+        AvaloniaProperty.Register<ContentPresenter, bool>(nameof(RecognizesAccessKey));
+
+    /// <summary>
+    /// Defines the <see cref="BackgroundSizing" property
+    /// </summary>
+    public static readonly StyledProperty<BackgroundSizing> BackgroundSizingProperty =
+        FABorder.BackgroundSizingProperty.AddOwner<FAContentPresenter>();
+
+    /// <summary>
+    /// Gets or sets a brush with which to paint the background.
+    /// </summary>
+    public IBrush Background
+    {
+        get => GetValue(BackgroundProperty);
+        set => SetValue(BackgroundProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a brush with which to paint the border.
+    /// </summary>
+    public IBrush BorderBrush
+    {
+        get => GetValue(BorderBrushProperty); 
+        set => SetValue(BorderBrushProperty, value); 
+    }
+
+    /// <summary>
+    /// Gets or sets the thickness of the border.
+    /// </summary>
+    public Thickness BorderThickness
+    {
+        get => GetValue(BorderThicknessProperty); 
+        set => SetValue(BorderThicknessProperty, value); 
+    }
+
+    /// <summary>
+    /// Gets or sets the radius of the border rounded corners.
+    /// </summary>
+    public CornerRadius CornerRadius
+    {
+        get => GetValue(CornerRadiusProperty); 
+        set => SetValue(CornerRadiusProperty, value); 
+    }
+
+    /// <summary>
+    /// Gets or sets the box shadow effect parameters
+    /// </summary>
+    public BoxShadows BoxShadow
+    {
+        get => GetValue(BoxShadowProperty);
+        set => SetValue(BoxShadowProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a brush used to paint the text.
+    /// </summary>
+    public IBrush Foreground
+    {
+        get => GetValue(ForegroundProperty);
+        set => SetValue(ForegroundProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font family.
+    /// </summary>
+    public FontFamily FontFamily
+    {
+        get => GetValue(FontFamilyProperty);
+        set => SetValue(FontFamilyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font size.
+    /// </summary>
+    public double FontSize
+    {
+        get => GetValue(FontSizeProperty);
+        set => SetValue(FontSizeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font style.
+    /// </summary>
+    public FontStyle FontStyle
+    {
+        get => GetValue(FontStyleProperty);
+        set => SetValue(FontStyleProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font weight.
+    /// </summary>
+    public FontWeight FontWeight
+    {
+        get => GetValue(FontWeightProperty);
+        set => SetValue(FontWeightProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font stretch.
+    /// </summary>
+    public FontStretch FontStretch
+    {
+        get => GetValue(FontStretchProperty);
+        set => SetValue(FontStretchProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the text alignment
+    /// </summary>
+    public TextAlignment TextAlignment
+    {
+        get => GetValue(TextAlignmentProperty);
+        set => SetValue(TextAlignmentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the text wrapping
+    /// </summary>
+    public TextWrapping TextWrapping
+    {
+        get => GetValue(TextWrappingProperty);
+        set => SetValue(TextWrappingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the text trimming
+    /// </summary>
+    public TextTrimming TextTrimming
+    {
+        get => GetValue(TextTrimmingProperty);
+        set => SetValue(TextTrimmingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the line height
+    /// </summary>
+    public double LineHeight
+    {
+        get => GetValue(LineHeightProperty);
+        set => SetValue(LineHeightProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the max lines
+    /// </summary>
+    public int MaxLines
+    {
+        get => GetValue(MaxLinesProperty);
+        set => SetValue(MaxLinesProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the control displayed by the presenter.
+    /// </summary>
+    public Control Child
+    {
+        get => _child;
+        private set => SetAndRaise(ChildProperty, ref _child, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the content to be displayed by the presenter.
+    /// </summary>
+    [DependsOn(nameof(ContentTemplate))]
+    public object Content
+    {
+        get => GetValue(ContentProperty);
+        set => SetValue(ContentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the data template used to display the content of the control.
+    /// </summary>
+    public IDataTemplate ContentTemplate
+    {
+        get => GetValue(ContentTemplateProperty);
+        set => SetValue(ContentTemplateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the horizontal alignment of the content within the border the control.
+    /// </summary>
+    public HorizontalAlignment HorizontalContentAlignment
+    {
+        get => GetValue(HorizontalContentAlignmentProperty);
+        set => SetValue(HorizontalContentAlignmentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the vertical alignment of the content within the border of the control.
+    /// </summary>
+    public VerticalAlignment VerticalContentAlignment
+    {
+        get => GetValue(VerticalContentAlignmentProperty);
+        set => SetValue(VerticalContentAlignmentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the space between the border and the <see cref="Child"/> control.
+    /// </summary>
+    public Thickness Padding
+    {
+        get => GetValue(PaddingProperty);
+        set => SetValue(PaddingProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value that indicates how far the background extends in relation to this element's border.
+    /// </summary>
+    public BackgroundSizing BackgroundSizing
+    {
+        get => GetValue(BackgroundSizingProperty);
+        set => SetValue(BackgroundSizingProperty, value);
+    }
+
+    /// <summary>
+    /// Determine if <see cref="ContentPresenter"/> should use <see cref="AccessText"/> in its style
+    /// </summary>
+    public bool RecognizesAccessKey
+    {
+        get => GetValue(RecognizesAccessKeyProperty);
+        set => SetValue(RecognizesAccessKeyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the host content control.
+    /// </summary>
+    internal IContentPresenterHost Host { get; private set; }
+
+    private Thickness LayoutThickness
+    {
+        get
+        {
+            VerifyScale();
+
+            if (_layoutThickness == null)
+            {
+                var borderThickness = BorderThickness;
+
+                if (UseLayoutRounding)
+                    borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, _scale, _scale);
+
+                _layoutThickness = borderThickness;
+            }
+
+            return _layoutThickness.Value;
+        }
+    }
+
+    /// <inheritdoc/>
+    public sealed override void ApplyTemplate()
+    {
+        if (!_createdChild && ((ILogical)this).IsAttachedToLogicalTree)
+        {
+            UpdateChild();
+        }
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        
+        switch (change.Property.Name)
+        {
+            case nameof(Content):
+            case nameof(ContentTemplate):
+                ContentChanged(change);
+                break;
+            case nameof(TemplatedParent):
+                TemplatedParentChanged(change);
+                break;
+            case nameof(UseLayoutRounding):
+            case nameof(BorderThickness):
+                _layoutThickness = null;
+                InvalidateMeasure();
+                break;
+
+            case nameof(Padding):
+            case nameof(HorizontalContentAlignment):
+            case nameof(VerticalContentAlignment):
+                InvalidateMeasure();
+                break;
+        }
+
+        if (_helper != null)
+        {
+            if (change.Property == BackgroundProperty)
+            {
+                _helper.Background = change.GetNewValue<IBrush>();
+                InvalidateVisual();
+            }
+            else if (change.Property == BorderBrushProperty)
+            {
+                _helper.BorderBrush = change.GetNewValue<IBrush>();
+                InvalidateVisual();
+            }
+            else if (change.Property == BorderThicknessProperty)
+            {
+                _helper.BorderThickness = change.GetNewValue<Thickness>();
+                InvalidateMeasure();
+            }
+            else if (change.Property == CornerRadiusProperty)
+            {
+                _helper.CornerRadius = change.GetNewValue<CornerRadius>();
+                InvalidateVisual();
+            }
+            else if (change.Property == BoxShadowProperty)
+            {
+                _helper.BoxShadow = change.GetNewValue<BoxShadows>();
+                InvalidateVisual();
+            }
+            else if (change.Property == BackgroundSizingProperty)
+            {
+                _helper.BackgroundSizing = change.GetNewValue<BackgroundSizing>();
+                InvalidateVisual();
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToLogicalTree(e);
+        _recyclingDataTemplate = null;
+        _createdChild = false;
+        InvalidateMeasure();
+    }
+
+    /// <inheritdoc/>
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        return LayoutHelper.MeasureChild(Child, availableSize, Padding, BorderThickness);
+    }
+
+    /// <inheritdoc/>
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        if (Child == null)
+            return finalSize;
+
+        var useLayoutRounding = UseLayoutRounding;
+        var scale = LayoutHelper.GetLayoutScale(this);
+        var padding = Padding;
+        var borderThickness = BorderThickness;
+
+        if (useLayoutRounding)
+        {
+            padding = LayoutHelper.RoundLayoutThickness(padding, scale, scale);
+            borderThickness = LayoutHelper.RoundLayoutThickness(borderThickness, scale, scale);
+        }
+
+        padding += borderThickness;
+        var horizontalContentAlignment = HorizontalContentAlignment;
+        var verticalContentAlignment = VerticalContentAlignment;
+        var availableSize = finalSize;
+        var sizeForChild = availableSize;
+        var originX = 0d;
+        var originY = 0d;
+
+        if (horizontalContentAlignment != HorizontalAlignment.Stretch)
+        {
+            sizeForChild = sizeForChild.WithWidth(Math.Min(sizeForChild.Width, DesiredSize.Width));
+        }
+
+        if (verticalContentAlignment != VerticalAlignment.Stretch)
+        {
+            sizeForChild = sizeForChild.WithHeight(Math.Min(sizeForChild.Height, DesiredSize.Height));
+        }
+
+        if (useLayoutRounding)
+        {
+            sizeForChild = LayoutHelper.RoundLayoutSizeUp(sizeForChild, scale, scale);
+            availableSize = LayoutHelper.RoundLayoutSizeUp(availableSize, scale, scale);
+        }
+
+        switch (horizontalContentAlignment)
+        {
+            case HorizontalAlignment.Center:
+                originX += (availableSize.Width - sizeForChild.Width) / 2;
+                break;
+            case HorizontalAlignment.Right:
+                originX += availableSize.Width - sizeForChild.Width;
+                break;
+        }
+
+        switch (verticalContentAlignment)
+        {
+            case VerticalAlignment.Center:
+                originY += (availableSize.Height - sizeForChild.Height) / 2;
+                break;
+            case VerticalAlignment.Bottom:
+                originY += availableSize.Height - sizeForChild.Height;
+                break;
+        }
+
+        if (useLayoutRounding)
+        {
+            originX = LayoutHelper.RoundLayoutValue(originX, scale);
+            originY = LayoutHelper.RoundLayoutValue(originY, scale);
+        }
+
+        var boundsForChild =
+            new Rect(originX, originY, sizeForChild.Width, sizeForChild.Height).Deflate(padding);
+
+        Child.Arrange(boundsForChild);
+
+        return finalSize;
+    }
+
+    /// <inheritdoc/>
+    public sealed override void Render(DrawingContext context)
+    {
+        _helper ??= new BorderRenderHelper(Background, BorderBrush, BorderThickness,
+            CornerRadius, BoxShadow, BackgroundSizing);
+
+        _helper.Render(context, Bounds.Size);
+    }
+
+    /// <summary>
+    /// Updates the <see cref="Child"/> control based on the control's <see cref="Content"/>.
+    /// </summary>
+    /// <remarks>
+    /// Usually the <see cref="Child"/> control is created automatically when 
+    /// <see cref="ApplyTemplate"/> is called; however for this to happen, the control needs to
+    /// be attached to a logical tree (if the control is not attached to the logical tree, it
+    /// is reasonable to expect that the DataTemplates needed for the child are not yet 
+    /// available). This method forces the <see cref="Child"/> control's creation at any point, 
+    /// and is particularly useful in unit tests.
+    /// </remarks>
+    public void UpdateChild()
+    {
+        var content = Content;
+        UpdateChild(content);
+    }
+
+    private void UpdateChild(object content)
+    {
+        var contentTemplate = ContentTemplate;
+        var oldChild = Child;
+        var newChild = CreateChild(content, oldChild, contentTemplate);
+        var logicalChildren = Host?.LogicalChildren ?? LogicalChildren;
+
+        // Remove the old child if we're not recycling it.
+        if (newChild != oldChild)
+        {
+
+            if (oldChild != null)
+            {
+                VisualChildren.Remove(oldChild);
+                logicalChildren.Remove(oldChild);
+                ((ISetInheritanceParent)oldChild).SetParent(oldChild.Parent);
+            }
+        }
+
+        // Set the DataContext if the data isn't a control.
+        if (contentTemplate is { } || !(content is Control))
+        {
+            DataContext = content;
+        }
+        else
+        {
+            ClearValue(DataContextProperty);
+        }
+
+        // Update the Child.
+        if (newChild == null)
+        {
+            Child = null;
+        }
+        else if (newChild != oldChild)
+        {
+            ((ISetInheritanceParent)newChild).SetParent(this);
+            Child = newChild;
+
+            if (!logicalChildren.Contains(newChild))
+            {
+                logicalChildren.Add(newChild);
+            }
+
+            VisualChildren.Add(newChild);
+        }
+
+        _createdChild = true;
+
+    }
+
+    private void VerifyScale()
+    {
+        var currentScale = LayoutHelper.GetLayoutScale(this);
+        if (MathUtilities.AreClose(currentScale, _scale))
+            return;
+
+        _scale = currentScale;
+        _layoutThickness = null;
+    }
+
+    private Control CreateChild(object content, Control oldChild, IDataTemplate template)
+    {
+        var newChild = content as Control;
+
+        // We want to allow creating Child from the Template, if Content is null.
+        // But it's important to not use DataTemplates, otherwise we will break content presenters in many places,
+        // otherwise it will blow up every ContentPresenter without Content set.
+        if ((newChild == null
+            && (content != null || template != null)) || (newChild is { } && template is { }))
+        {
+            var dataTemplate = this.FindDataTemplate(content, template) ??
+                (
+                    RecognizesAccessKey
+                        ? FuncDataTemplate.Access
+                        : FuncDataTemplate.Default
+                );
+
+            if (dataTemplate is IRecyclingDataTemplate rdt)
+            {
+                var toRecycle = rdt == _recyclingDataTemplate ? oldChild : null;
+                newChild = rdt.Build(content, toRecycle);
+                _recyclingDataTemplate = rdt;
+            }
+            else
+            {
+                newChild = dataTemplate.Build(content);
+                _recyclingDataTemplate = null;
+            }
+        }
+        else
+        {
+            _recyclingDataTemplate = null;
+        }
+
+        return newChild;
+    }
+       
+    private void ContentChanged(AvaloniaPropertyChangedEventArgs e)
+    {
+        _createdChild = false;
+
+        if (((ILogical)this).IsAttachedToLogicalTree)
+        {
+            if (e.Property.Name == nameof(Content))
+            {
+                UpdateChild(e.NewValue);
+            }
+            else
+            {
+                UpdateChild();
+            }
+        }
+        else if (Child != null)
+        {
+            VisualChildren.Remove(Child);
+            LogicalChildren.Remove(Child);
+            ((ISetInheritanceParent)Child).SetParent(Child.Parent);
+            Child = null;
+            _recyclingDataTemplate = null;
+        }
+
+        UpdatePseudoClasses();
+        InvalidateMeasure();
+    }
+
+    private void UpdatePseudoClasses()
+    {
+        PseudoClasses.Set(":empty", Content is null);
+    }
+
+    private void TemplatedParentChanged(AvaloniaPropertyChangedEventArgs e)
+    {
+        var host = e.NewValue as IContentPresenterHost;
+        Host = host?.RegisterContentPresenter(this) == true ? host : null;
+    }
+
+    private Control _child;
+    private bool _createdChild;
+    private IRecyclingDataTemplate _recyclingDataTemplate;
+    private BorderRenderHelper _helper;
+    private Thickness? _layoutThickness;
+    private double _scale;
+}

--- a/src/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutInteractionHandler.cs
+++ b/src/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutInteractionHandler.cs
@@ -70,9 +70,10 @@ internal class MenuFlyoutInteractionHandler : IMenuInteractionHandler
             window.Deactivated += WindowDeactivated;
         }
 
-        if (_root is TopLevel tl && tl.PlatformImpl != null)
-            tl.PlatformImpl.LostFocus += TopLevelLostPlatformFocus;
-
+        // v2p6.1: Don't have access to this anymore...
+        //if (_root is TopLevel tl && tl.PlatformImpl != null)
+        //    tl.PlatformImpl.LostFocus += TopLevelLostPlatformFocus;
+        
         _inputManagerSubscription = InputManager?.Process.Subscribe(RawInput);
     }
 
@@ -103,8 +104,8 @@ internal class MenuFlyoutInteractionHandler : IMenuInteractionHandler
             root.Deactivated -= WindowDeactivated;
         }
 
-        if (_root is TopLevel tl && tl.PlatformImpl != null)
-            tl.PlatformImpl.LostFocus -= TopLevelLostPlatformFocus;
+        //if (_root is TopLevel tl && tl.PlatformImpl != null)
+        //    tl.PlatformImpl.LostFocus -= TopLevelLostPlatformFocus;
 
         _inputManagerSubscription?.Dispose();
 

--- a/src/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.cs
+++ b/src/FluentAvalonia/UI/Controls/NavigationView/Items/NavigationViewItem.cs
@@ -166,7 +166,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
 
             var miSource = MenuItemsSource;
 
-            _repeater.Items = miSource != null ? miSource : _menuItems;
+            _repeater.ItemsSource = miSource != null ? miSource : _menuItems;
 
             if (_repeater.ItemsSourceView != null)
             {
@@ -577,7 +577,7 @@ public partial class NavigationViewItem : NavigationViewItemBase
             {
                 _repeater.ItemsSourceView.CollectionChanged -= OnItemsSourceViewChanged;
             }
-            _repeater.Items = null;
+            _repeater.ItemsSource = null;
             _repeater = null;
         }
 

--- a/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -809,7 +809,7 @@ public partial class NavigationView : HeaderedContentControl
             if (items != null)
             {
                 var itemsSource = _topDataProvider.GetOverflowItems();
-                _topNavRepeaterOverflowView.Items = itemsSource;
+                _topNavRepeaterOverflowView.ItemsSource = itemsSource;
 
                 // We listen to changes to the overflow menu item collection so we can set the visibility of the overflow button
                 // to collapsed when it no longer has any items.
@@ -826,7 +826,7 @@ public partial class NavigationView : HeaderedContentControl
             }
             else
             {
-                _topNavRepeaterOverflowView.Items = null;
+                _topNavRepeaterOverflowView.ItemsSource = null;
             }
         }
     }
@@ -835,7 +835,7 @@ public partial class NavigationView : HeaderedContentControl
     {
         if (ir != null)
         {
-            ir.Items = source;
+            ir.ItemsSource = source;
         }
     }
 

--- a/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -44,7 +44,8 @@ public partial class NavigationView : HeaderedContentControl
                 
         _topDataProvider.OnRawDataChanged((args) => OnTopNavDataSourceChanged(args));
 
-        //Loaded & Unloaded Event...
+        Loaded += OnNavViewLoaded;
+        // Unloaded is titlebar related - ignore
 
         _selectionModel = new SelectionModel();
         _selectionModel.SingleSelect = true;
@@ -118,7 +119,7 @@ public partial class NavigationView : HeaderedContentControl
                 _leftNavRepeater.ElementPrepared += OnRepeaterElementPrepared;
                 _leftNavRepeater.ElementClearing += OnRepeaterElementClearing;
 
-                //repeater Loaded Event
+                _leftNavRepeater.Loaded += OnRepeaterLoaded;
                 _leftNavRepeater.GotFocus += OnRepeaterGettingFocus;
 
                 _leftNavRepeater.ItemTemplate = _itemsFactory;
@@ -134,7 +135,7 @@ public partial class NavigationView : HeaderedContentControl
                 _topNavRepeater.ElementPrepared += OnRepeaterElementPrepared;
                 _topNavRepeater.ElementClearing += OnRepeaterElementClearing;
 
-                //repeater Loaded Event
+                _topNavRepeater.Loaded += OnRepeaterLoaded;
                 _topNavRepeater.GotFocus += OnRepeaterGettingFocus;
 
                 _topNavRepeater.ItemTemplate = _itemsFactory;
@@ -181,7 +182,7 @@ public partial class NavigationView : HeaderedContentControl
                 _leftNavFooterMenuRepeater.ElementPrepared += OnRepeaterElementPrepared;
                 _leftNavFooterMenuRepeater.ElementClearing += OnRepeaterElementClearing;
 
-                //repeater Loaded Event
+                _leftNavFooterMenuRepeater.Loaded += OnRepeaterLoaded;
                 _leftNavFooterMenuRepeater.GotFocus += OnRepeaterGettingFocus;
 
                 _leftNavFooterMenuRepeater.ItemTemplate = _itemsFactory;
@@ -197,7 +198,7 @@ public partial class NavigationView : HeaderedContentControl
                 _topNavFooterMenuRepeater.ElementPrepared += OnRepeaterElementPrepared;
                 _topNavFooterMenuRepeater.ElementClearing += OnRepeaterElementClearing;
 
-                //repeater Loaded Event
+                _topNavFooterMenuRepeater.Loaded += OnRepeaterLoaded;
                 _topNavFooterMenuRepeater.GotFocus += OnRepeaterGettingFocus;
 
                 _topNavFooterMenuRepeater.ItemTemplate = _itemsFactory;
@@ -693,11 +694,8 @@ public partial class NavigationView : HeaderedContentControl
         }
     }
 
-    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    private void OnNavViewLoaded(object sender, RoutedEventArgs e)
     {
-        base.OnAttachedToVisualTree(e);
-        //Takes place on OnLoaded event
-
         if (_updateVisualStateForDisplayModeFromOnLoaded)
         {
             _updateVisualStateForDisplayModeFromOnLoaded = false;
@@ -712,12 +710,11 @@ public partial class NavigationView : HeaderedContentControl
 
 
 
-
     /////////////////////////////////////////////
     //////// ITEMS REPEATER RELATED ////////////
     ///////////////////////////////////////////
 
-    private void OnRepeaterLoaded()
+    private void OnRepeaterLoaded(object sender, RoutedEventArgs args)
     {
         var item = SelectedItem;
         if (item != null && !IsSelectionSuppressed(item))

--- a/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
+++ b/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
@@ -6,9 +6,7 @@ using Avalonia.Layout;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
 using FluentAvalonia.UI.Media.Animation;
-using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -538,7 +536,7 @@ public partial class NavigationView : HeaderedContentControl
             _leftNavRepeater.ElementClearing -= OnRepeaterElementClearing;
             _leftNavRepeater.ElementPrepared -= OnRepeaterElementPrepared;
 
-            //loaded event;
+            _leftNavRepeater.Loaded -= OnRepeaterLoaded;
             _leftNavRepeater.GotFocus -= OnRepeaterGettingFocus;
             _leftNavRepeater = null;
         }
@@ -548,7 +546,7 @@ public partial class NavigationView : HeaderedContentControl
             _topNavRepeater.ElementClearing -= OnRepeaterElementClearing;
             _topNavRepeater.ElementPrepared -= OnRepeaterElementPrepared;
 
-            //loaded event;
+            _topNavRepeater.Loaded -= OnRepeaterLoaded;
             _topNavRepeater.GotFocus -= OnRepeaterGettingFocus;
             _topNavRepeater = null;
         }
@@ -575,7 +573,7 @@ public partial class NavigationView : HeaderedContentControl
             _leftNavFooterMenuRepeater.ElementClearing -= OnRepeaterElementClearing;
             _leftNavFooterMenuRepeater.ElementPrepared -= OnRepeaterElementPrepared;
 
-            //loaded event;
+            _leftNavFooterMenuRepeater.Loaded -= OnRepeaterLoaded;
             _leftNavFooterMenuRepeater.GotFocus -= OnRepeaterGettingFocus;
             _leftNavFooterMenuRepeater = null;
         }
@@ -585,7 +583,7 @@ public partial class NavigationView : HeaderedContentControl
             _topNavFooterMenuRepeater.ElementClearing -= OnRepeaterElementClearing;
             _topNavFooterMenuRepeater.ElementPrepared -= OnRepeaterElementPrepared;
 
-            //loaded event;
+            _topNavFooterMenuRepeater.Loaded -= OnRepeaterLoaded;
             _topNavFooterMenuRepeater.GotFocus -= OnRepeaterGettingFocus;
             _topNavFooterMenuRepeater = null;
         }

--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
@@ -90,6 +90,11 @@ public partial class NumberBox : TemplatedControl
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
+
+        if (change.Property == ValueProperty)
+        {
+            OnValueChanged(change.GetOldValue<double>(), change.GetNewValue<double>());
+        }
         if (change.Property == IsWrapEnabledProperty)
         {
             UpdateSpinButtonEnabled();
@@ -117,6 +122,10 @@ public partial class NumberBox : TemplatedControl
                 throw new InvalidOperationException("NumberFormatter must be null");
 
             UpdateTextToValue();
+        }
+        else if (change.Property == MinimumProperty || change.Property == MaximumProperty)
+        {
+            UpdateSpinButtonEnabled();
         }
     }
 

--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
@@ -61,16 +61,34 @@ public partial class NumberBox
     /// <summary>
     /// Defines the <see cref="Minimum"/> property
     /// </summary>
-    public static readonly DirectProperty<NumberBox, double> MinimumProperty =
-        RangeBase.MinimumProperty.AddOwner<NumberBox>(x => x.Minimum,
-            (x, v) => x.Minimum = v);
+    public static readonly StyledProperty<double> MinimumProperty =
+        RangeBase.MinimumProperty.AddOwner<NumberBox>(
+            new StyledPropertyMetadata<double>(
+                coerce: (ao, d1) =>
+                {
+                    var nb = ao as NumberBox;
+                    var max = nb.Maximum;
+                    if (d1 > max)
+                        d1 = max;
+                    nb.CoerceValueIfNeeded(d1, max);
+                    return d1;
+                }));
 
     /// <summary>
     /// Defines the <see cref="Maximum"/> property
     /// </summary>
-    public static readonly DirectProperty<NumberBox, double> MaximumProperty =
-        RangeBase.MaximumProperty.AddOwner<NumberBox>(x => x.Maximum,
-            (x, v) => x.Maximum = v);
+    public static readonly StyledProperty<double> MaximumProperty =
+        RangeBase.MaximumProperty.AddOwner<NumberBox>(
+            new StyledPropertyMetadata<double>(
+                coerce: (ao, d1) =>
+                {
+                    var nb = ao as NumberBox;
+                    var min = nb.Minimum;
+                    if (d1 < min)
+                        d1 = min;
+                    nb.CoerceValueIfNeeded(min, d1);
+                    return d1;
+                }));
 
     //Skip NumberFormatter
 
@@ -129,9 +147,11 @@ public partial class NumberBox
     /// <summary>
     /// Defines the <see cref="Value"/> property
     /// </summary>
-    public static readonly DirectProperty<NumberBox, double> ValueProperty =
-         RangeBase.ValueProperty.AddOwnerWithDataValidation<NumberBox>(x => x.Value,
-             (x, v) => x.Value = v, defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
+    public static readonly StyledProperty<double> ValueProperty =
+         RangeBase.ValueProperty.AddOwner<NumberBox>(
+             new StyledPropertyMetadata<double>(
+                 enableDataValidation: true,
+                 coerce: (ao, d1) => ((NumberBox)ao).CoerceValueToRange(d1)));
 
     //Skip InputScope
 
@@ -209,16 +229,8 @@ public partial class NumberBox
     /// </summary>
     public double Minimum
     {
-        get => _minimum;
-        set
-        {
-            if (value > _maxmimum)
-                value = _maxmimum;
-
-            SetAndRaise(MinimumProperty, ref _minimum, value);
-            CoerceValueIfNeeded(value, _maxmimum);
-            UpdateSpinButtonEnabled();
-        }
+        get => GetValue(MinimumProperty);
+        set => SetValue(MinimumProperty, value);
     }
 
     /// <summary>
@@ -226,16 +238,8 @@ public partial class NumberBox
     /// </summary>
     public double Maximum
     {
-        get => _maxmimum;
-        set
-        {
-            if (value < _minimum)
-                value = _minimum;
-
-            SetAndRaise(MaximumProperty, ref _maxmimum, value);
-            CoerceValueIfNeeded(_minimum, value);
-            UpdateSpinButtonEnabled();
-        }
+        get => GetValue(MaximumProperty);
+        set => SetValue(MaximumProperty, value);
     }
 
     /// <summary>
@@ -352,19 +356,8 @@ public partial class NumberBox
     /// </summary>
     public double Value
     {
-        get => _value;
-        set
-        {
-            if (!double.IsNaN(value) || !double.IsNaN(_value))
-            {
-                var old = _value;
-                value = CoerceValueToRange(value);
-                if (SetAndRaise(ValueProperty, ref _value, value))
-                {
-                    OnValueChanged(old, value);
-                }
-            }
-        }
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
     }
 
     /// <summary>

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -473,7 +473,7 @@ public partial class TabViewItem : ListBoxItem
             if (headerContent != null)
             {
                 _toolTip = headerContent;
-                ToolTip.SetTip(this, _toolTip);
+                //ToolTip.SetTip(this, _toolTip);
             }
         }
     }

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
@@ -233,7 +233,7 @@ public partial class AppWindow : Window, IStyleable
 
             // What we know is that the default title bar will always be [0,0,WindowWidth,TitleBar.Height]
             // Therefore, we only need to do check the Y coordinate
-            var hgt = _titleBar.Height * PlatformImpl.RenderScaling;
+            var hgt = _titleBar.Height * GetScaling();
             if (p.Y < hgt)
             {
                 if (TitleBar.TitleBarHitTestType == TitleBarHitTestType.Complex &&
@@ -344,6 +344,12 @@ public partial class AppWindow : Window, IStyleable
         {
             OnExtendsContentIntoTitleBarChanged(_titleBar.ExtendsContentIntoTitleBar);
         }
+    }
+
+    private double GetScaling()
+    {
+        // This is stupid
+        return Screens.ScreenFromWindow(PlatformImpl).Scaling;
     }
 
     private void SetTitleBarColors()

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32AppWindowFeatures.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32AppWindowFeatures.cs
@@ -26,7 +26,7 @@ internal class Win32AppWindowFeatures : IAppWindowPlatformFeatures
         }
 
         // Enum values are mapped to TMPF_ from Win32
-        _taskBarList.SetProgressState(_owner.PlatformImpl.Handle.Handle, (int)state);
+        _taskBarList.SetProgressState(_owner.TryGetPlatformHandle().Handle, (int)state);
     }
 
     public void SetTaskBarProgressBarValue(ulong currentValue, ulong totalValue)
@@ -40,7 +40,7 @@ internal class Win32AppWindowFeatures : IAppWindowPlatformFeatures
                 return;
         }
 
-        _taskBarList.SetProgressValue(_owner.PlatformImpl.Handle.Handle, currentValue, totalValue);
+        _taskBarList.SetProgressValue(_owner.TryGetPlatformHandle().Handle, currentValue, totalValue);
     }
 
     public unsafe void SetWindowBorderColor(Color color)
@@ -52,7 +52,7 @@ internal class Win32AppWindowFeatures : IAppWindowPlatformFeatures
             // DON'T USE .ToUint32, COLORREF has B & R components switched
             // and expects alpha to be 0 (it will return hr = Parameter not correct)
             COLORREF cr = ((uint)0 << 24) | ((uint)color.B << 16) | ((uint)color.G << 8) | (uint)color.R;
-            var hr = (HRESULT)DwmSetWindowAttribute(_owner.PlatformImpl.Handle.Handle, DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR,
+            var hr = (HRESULT)DwmSetWindowAttribute(_owner.TryGetPlatformHandle().Handle, DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR,
                 &cr, sizeof(COLORREF));
             if (!hr.SUCCEEDED)
             {


### PR DESCRIPTION
WIP towards either preview7 or rc1, whichever upstream decides on.

Branch is on: 11.0.999-cibuild0033637-beta

**Required updates:**
- Items->ItemsSource on remaining Avalonia controls that were updated
- Updated ScrollViewer template based on changed logic
- Dealt with reduced Avalonia public API...which is making me absolutely lose my mind...

Note for users of FAComboBox: 
- Because of the loss of IWindowImpl APIs, using the FAComboBox with `IsEditable=true` where the popup has to flip to the top of the ComboBox (not enough space below), the popup will retain the default below display for rounded corners - the top will be unrounded and the bottom will be. This only affects windowed popups - overlay popups, if enabled, are not affected.

**Changes & Fixes:**
- Added the missing `Separator` `ControlTheme` (fixes #330)
- Added a hack fix to prevent the flickering when opening a ContentDialog or TaskDialog - issue stems from something about the animation timer is de-sync'd from rendering, and who knows if that'll get fixed soon
- Added the logic in the NavigationView for `Loaded` events, which wasn't previously implemented as we didn't have `Loaded` at the time NavView was ported
- Disabled the auto ToolTip in TabViewItem...this needs some thought. Currently the auto tooltip was just using the Content, which was loading the Tab content into the tooltip b/c of the implicit DataTemplate lookup Avalonia does - which isn't ideal. 
- Changes the function pointer signature on net5+ for AppWindow's Win32WindowManager so that it doesn't kill the WASM build (fixes #333)

**Special change:**
Added `FAContentPresenter` control to support `BackgroundSizing`. To address some rendering issues, see #262, I've added this special control to support BackgroundSizing for some controls. Currently this is only implemented on `Button`, `ToggleButton`, and `RepeatButton` where this change makes a noticeable difference. I've mapped the `IStyleable.StyleKey` to the normal `ContentPresenter` meaning if you're using custom styles you do NOT have to make changes here and if in the future BackgroundSizing is added upstream, you don't have to make more changes to undo this...so that's a plus.

Before and After:
![image](https://user-images.githubusercontent.com/40413319/233807903-12aee9be-2d50-460f-9885-dd2dff808e93.png)

I've also changed the root border in `Expander` to use a FABorder. This, however, will require updates if you're using custom styles for Expander as FABorder is not mapped to a normal Border. The change ensures the toggle button in the expander header gets the same treatment, and aligns it with SettingsExpander too.