### PR TITLE
ScrollViewer fix

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ScrollViewerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ScrollViewerStyles.axaml
@@ -34,7 +34,7 @@
                                             VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
                                             HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
                                             VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
-                                            Padding="{TemplateBinding Padding}">
+                                            Margin="{TemplateBinding Padding}">
                         <ScrollContentPresenter.GestureRecognizers>
                             <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
                                                      CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"


### PR DESCRIPTION
In preview7, ScrollViewer can incorrectly measure/arrange causing visual descendants to be laid out too far to the right/bottom. Issue stems from setting Padding on the ScrollContentPresenter rather than Margin - which was previously done but was inadvertently changed when I copied the updated template from upstream for the ScrollViewer refactor.