### PR TITLE
[WIP] v2 Preview 7.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0-preview7</AvaloniaVersion>
+    <AvaloniaVersion>11.0.999-cibuild0033818-beta</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0.999-cibuild0033818-beta</AvaloniaVersion>
+    <AvaloniaVersion>11.0.999-cibuild0034035-beta</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/samples/FluentAvaloniaSamples/Controls/ControlExample.cs
+++ b/samples/FluentAvaloniaSamples/Controls/ControlExample.cs
@@ -252,7 +252,7 @@ public class ControlExample : HeaderedContentControl
 
         SetUsageNotes();
 
-        bool isLightMode = AvaloniaLocator.Current.GetService<FluentAvaloniaTheme>().RequestedTheme == FluentAvaloniaTheme.LightModeString;
+        bool isLightMode = Application.Current.ActualThemeVariant == ThemeVariant.Light;
 
         //_xamlTextEditor.SyntaxHighlighting = isLightMode ? XamlHighlightingSource.LightModeXaml : XamlHighlightingSource.DarkModeXaml;
         //_cSharpTextEditor.SyntaxHighlighting = isLightMode ? CSharpHighlightingSource.CSharpLightMode : CSharpHighlightingSource.CSharpDarkMode;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.0.0-preview7</Version>
+    <Version>2.0.0-preview7.1</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
@@ -175,20 +175,20 @@
                                PlacementTarget="Background"
                                IsLightDismissEnabled="True"
                                InheritsTransform="True">
-                            <Border x:Name="PopupBorder"
-                                    Background="{DynamicResource ComboBoxDropDownBackground}"
-                                    BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                                    BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
-                                    Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
-                                    HorizontalAlignment="Stretch"
-                                    CornerRadius="{DynamicResource OverlayCornerRadius}">
+                            <ui:FABorder x:Name="PopupBorder"
+                                         Background="{DynamicResource ComboBoxDropDownBackground}"
+                                         BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                                         BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
+                                         Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
+                                         HorizontalAlignment="Stretch"
+                                         CornerRadius="{DynamicResource OverlayCornerRadius}">
                                 <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                               VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
                                     <ItemsPresenter Name="PART_ItemsPresenter"
                                                     Margin="{DynamicResource ComboBoxDropdownContentMargin}"
                                                     ItemsPanel="{TemplateBinding ItemsPanel}" />
                                 </ScrollViewer>
-                            </Border>
+                            </ui:FABorder>
                         </Popup>
                     </Grid>
                 </DataValidationErrors>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DatePickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DatePickerStyles.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:ui="using:FluentAvalonia.UI.Controls"
+                    xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                     xmlns:sys="using:System"
                     x:CompileBindings="True">
 
@@ -37,6 +38,8 @@
     <Thickness x:Key="LoopingSelectorUpDownButtonMargin">0</Thickness>
     <x:Double  x:Key="LoopingSelectorUpDownButtonHeight">34</x:Double>
     <!--<x:Double  x:Key="LoopingSelectorUpDownButtonScalePressed">0.875</x:Double>-->
+
+    <Thickness x:Key="DateTimeFlyoutBorderThickness">1</Thickness>
 
     <ControlTheme x:Key="DateTimePickerItem" TargetType="ListBoxItem">
         <Setter Property="Foreground" Value="{DynamicResource LoopingSelectorItemForeground}" />
@@ -136,12 +139,16 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <ControlTemplate>
-                <!-- I don't know what black magic Microsoft is doing here, but these are supposed to be opaque
-                     and that's how they show in WinUI, but no background is assigned here, AND the pointerover/
-                     pressed resources are transparent. So i'm just gonna force it to be opaque
+                <!-- 
+                I think...Microsoft is using a CompositionClip to make these buttons appear
+                opaque here - as no background is set in WinUI and the other visual state
+                styles are using transparent resources. Adding a clip is quite complex here
+                and would require changes in the actual code base, so we'll just add an
+                opaque background here
                 -->
                 <Border Name="ForcedOpaqueBorder"
-                        Background="{DynamicResource DatePickerFlyoutPresenterBackground}">
+                        Background="{DynamicResource DatePickerFlyoutPresenterBackground}"
+                        CornerRadius="{DynamicResource OverlayCornerRadius}">
                     <Border Name="RootBorder"
                             Padding="{TemplateBinding Padding}"
                             Background="{DynamicResource LoopingSelectorUpDownButtonBackground}">
@@ -212,14 +219,14 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-               <ContentPresenter Background="{TemplateBinding Background}"
-                                 Foreground="{TemplateBinding Foreground}"
-                                 Content="{TemplateBinding Content}"
-                                 HorizontalContentAlignment="Stretch"
-                                 VerticalContentAlignment="Stretch"
-                                 CornerRadius="{TemplateBinding CornerRadius}"
-                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                 BorderThickness="{TemplateBinding BorderThickness}" />
+               <uip:FAContentPresenter Background="{TemplateBinding Background}"
+                                       Foreground="{TemplateBinding Foreground}"
+                                       Content="{TemplateBinding Content}"
+                                       HorizontalContentAlignment="Stretch"
+                                       VerticalContentAlignment="Stretch"
+                                       CornerRadius="{TemplateBinding CornerRadius}"
+                                       BorderBrush="{TemplateBinding BorderBrush}"
+                                       BorderThickness="{TemplateBinding BorderThickness}" />
             </ControlTemplate>
         </Setter>
 
@@ -354,12 +361,12 @@
         <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="Background" Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Padding="{DynamicResource DateTimeFlyoutBorderPadding}"
-                        MaxHeight="398"
-                        CornerRadius="{TemplateBinding CornerRadius}">
+                <ui:FABorder Name="Background" Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             Padding="{DynamicResource DateTimeFlyoutBorderPadding}"
+                             MaxHeight="398"
+                             CornerRadius="{TemplateBinding CornerRadius}">
                     <Grid Name="ContentRoot" RowDefinitions="*,Auto">
                         <Grid Name="PART_PickerContainer">
                             <Grid.Styles>
@@ -451,7 +458,7 @@
                             </Button>
                         </Grid>
                     </Grid>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DropDownButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DropDownButtonStyles.axaml
@@ -6,81 +6,79 @@
     <x:Double x:Key="DropDownButtonMinHeight">32</x:Double>
 
     <ControlTheme x:Key="{x:Type DropDownButton}" TargetType="DropDownButton">
-      <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
-      <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThemeThickness}" />
-      <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
-      <Setter Property="MinHeight" Value="{DynamicResource DropDownButtonMinHeight}" />
-      <Setter Property="HorizontalAlignment" Value="Left" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Border x:Name="RootBorder"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}"
-                    ClipToBounds="True">
-              <Grid x:Name="InnerGrid">
-                <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="*" />
-                  <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                
-                <ContentPresenter x:Name="PART_ContentPresenter"
-                                  Grid.Column="0" 
-                                  Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                  Padding="{TemplateBinding Padding}"
-                                  RecognizesAccessKey="True"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThemeThickness}" />
+        <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+        <Setter Property="MinHeight" Value="{DynamicResource DropDownButtonMinHeight}" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <ui:FABorder x:Name="RootBorder"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius}"
+                             ClipToBounds="True">
+                    <Grid x:Name="InnerGrid">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
 
-                <ui:FontIcon Name="DropDownGlyph"
-                             Grid.Column="1"
-                             UseLayoutRounding="False"
-                             IsHitTestVisible="False"
-                             Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}"
-                             Margin="0,0,10,0"
-                             FontFamily="{DynamicResource SymbolThemeFontFamily}"
-                             FontSize="12"
-                             Glyph="&#xE70D;"
-                             HorizontalAlignment="Right"
-                             VerticalAlignment="Center" />
-              </Grid>
-            </Border>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+                        <ContentPresenter x:Name="PART_ContentPresenter"
+                                          Grid.Column="0"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Padding="{TemplateBinding Padding}"
+                                          RecognizesAccessKey="True"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
 
-      <!--  PointerOver State  -->
-      <Style Selector="^:pointerover /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
-      </Style>
+                        <ui:FontIcon Name="DropDownGlyph"
+                                     Grid.Column="1"
+                                     UseLayoutRounding="False"
+                                     IsHitTestVisible="False"
+                                     Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}"
+                                     Margin="0,0,10,0"
+                                     FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                     FontSize="12"
+                                     Glyph="&#xE70D;"
+                                     HorizontalAlignment="Right"
+                                     VerticalAlignment="Center" />
+                    </Grid>
+                </ui:FABorder>
+            </ControlTemplate>
+        </Setter>
 
-      <!--  Pressed State  -->
-      <Style Selector="^:pressed /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
-      </Style>
+        <!--  PointerOver State  -->
+        <Style Selector="^:pointerover /template/ Border#RootBorder">
+            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
+        </Style>
 
-      <!--  Disabled State  -->
-      <Style Selector="^:disabled /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
-      </Style>
-      <Style Selector="^:disabled /template/ ui|FontIcon#DropDownGlyph">
-        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
-      </Style>
+        <!--  Pressed State  -->
+        <Style Selector="^:pressed /template/ Border#RootBorder">
+            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+        </Style>
+
+        <!--  Disabled State  -->
+        <Style Selector="^:disabled /template/ Border#RootBorder">
+            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+        </Style>
+        <Style Selector="^:disabled /template/ ui|FontIcon#DropDownGlyph">
+            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+        </Style>
     </ControlTheme>
 
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/FlyoutPresenterStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/FlyoutPresenterStyles.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ui="using:FluentAvalonia.UI.Controls"
                     x:CompileBindings="True">
 
     <!-- FlyoutResources moved to BaseResources.axaml -->
@@ -20,11 +21,11 @@
         <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}"
-                        Padding="{DynamicResource FlyoutBorderThemePadding}">
+                <ui:FABorder Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius}"
+                             Padding="{DynamicResource FlyoutBorderThemePadding}">
                     <ScrollViewer Name="ScrollViewer"
                                   HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                   VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
@@ -34,7 +35,7 @@
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                     </ScrollViewer>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
     </ControlTheme>
@@ -52,12 +53,12 @@
         <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="LayoutRoot"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Padding="{DynamicResource FlyoutBorderThemePadding}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
+                <ui:FABorder Name="LayoutRoot"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             Padding="{DynamicResource FlyoutBorderThemePadding}"
+                             CornerRadius="{TemplateBinding CornerRadius}">
                     <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                   VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                                   Margin="{TemplateBinding Padding}">
@@ -66,7 +67,7 @@
                                         KeyboardNavigation.TabNavigation="Continue"
                                         Grid.IsSharedSizeScope="True" />
                     </ScrollViewer>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
     </ControlTheme>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ListBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ListBoxStyles.axaml
@@ -20,6 +20,8 @@
         <Setter Property="BorderThickness" Value="{DynamicResource ListBoxBorderThemeThickness}" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+        <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="True" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="Template">
             <ControlTemplate>
@@ -27,11 +29,18 @@
                         BorderThickness="{TemplateBinding BorderThickness}">
                     <ScrollViewer Name="PART_ScrollViewer"
                                   Background="{TemplateBinding Background}"
+                                  VerticalSnapPointsType="{TemplateBinding (ScrollViewer.VerticalSnapPointsType)}"
+                                  HorizontalSnapPointsType="{TemplateBinding (ScrollViewer.HorizontalSnapPointsType)}"
                                   HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
+                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                                  IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                                  IsScrollInertiaEnabled="{TemplateBinding (ScrollViewer.IsScrollInertiaEnabled)}"
+                                  AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
                         <ItemsPresenter Name="PART_ItemsPresenter"
                                         ItemsPanel="{TemplateBinding ItemsPanel}"
-                                        Margin="{TemplateBinding Padding}" />
+                                        Margin="{TemplateBinding Padding}"
+                                        AreVerticalSnapPointsRegular="{TemplateBinding AreVerticalSnapPointsRegular}"
+                                        AreHorizontalSnapPointsRegular="{TemplateBinding AreHorizontalSnapPointsRegular}"/>
                     </ScrollViewer>
                 </Border>
             </ControlTemplate>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
@@ -126,13 +126,13 @@
                            HorizontalOffset="{DynamicResource MenuFlyoutSubItemPopupHorizontalOffset}"
                            IsLightDismissEnabled="False"
                            IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">
-                        <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
-                                BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                                BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
-                                MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
-                                MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
-                                HorizontalAlignment="Stretch"
-                                CornerRadius="{DynamicResource OverlayCornerRadius}">
+                        <ui:FABorder Background="{DynamicResource MenuFlyoutPresenterBackground}"
+                                     BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
+                                     BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
+                                     MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
+                                     MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
+                                     HorizontalAlignment="Stretch"
+                                     CornerRadius="{DynamicResource OverlayCornerRadius}">
                             <ScrollViewer HorizontalScrollBarVisibility="Auto"
                                           VerticalScrollBarVisibility="Auto">
                                 <ItemsPresenter Name="PART_ItemsPresenter"
@@ -140,7 +140,7 @@
                                                 Margin="{DynamicResource MenuFlyoutPresenterThemePadding}"
                                                 Grid.IsSharedSizeScope="True" />
                             </ScrollViewer>
-                        </Border>
+                        </ui:FABorder>
                     </Popup>
                 </Panel>
             </ControlTemplate>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuStyles.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=netstandard"
+                    xmlns:ui="using:FluentAvalonia.UI.Controls"
                     x:CompileBindings="True">
 
     <Design.PreviewWith>
@@ -90,20 +91,20 @@
                                IsLightDismissEnabled="True"
                                IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
                                OverlayInputPassThroughElement="{Binding $parent[Menu]}">
-                            <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
-                                    BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                                    BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
-                                    MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
-                                    MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
-                                    HorizontalAlignment="Stretch"
-                                    CornerRadius="{DynamicResource OverlayCornerRadius}">
+                            <ui:FABorder Background="{DynamicResource MenuFlyoutPresenterBackground}"
+                                         BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
+                                         BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
+                                         MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
+                                         MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
+                                         HorizontalAlignment="Stretch"
+                                         CornerRadius="{DynamicResource OverlayCornerRadius}">
                                 <ScrollViewer>
                                     <ItemsPresenter Name="PART_ItemsPresenter"
                                                     ItemsPanel="{TemplateBinding ItemsPanel}"
                                                     Margin="{DynamicResource MenuFlyoutPresenterThemePadding}"
                                                     Grid.IsSharedSizeScope="True" />
                                 </ScrollViewer>
-                            </Border>
+                            </ui:FABorder>
                         </Popup>
                     </Panel>
                 </Border>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/SplitButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/SplitButtonStyles.axaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:CompileBindings="True"
                     xmlns:converters="using:Avalonia.Controls.Converters"
-                    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia">
+                    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+                    xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">
 
   <x:Double x:Key="SplitButtonPrimaryButtonSize">32</x:Double>
   <x:Double x:Key="SplitButtonSecondaryButtonSize">32</x:Double>
@@ -16,17 +17,17 @@
   <ControlTheme x:Key="FluentSplitButtonComponent" TargetType="Button">
     <Setter Property="Template">
       <ControlTemplate>
-        <ContentPresenter x:Name="PART_ContentPresenter"
-                          Background="{TemplateBinding Background}"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="{TemplateBinding BorderThickness}"
-                          CornerRadius="{TemplateBinding CornerRadius}"
-                          Content="{TemplateBinding Content}"
-                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                          Padding="{TemplateBinding Padding}"
-                          RecognizesAccessKey="True"
-                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+        <uip:FAContentPresenter x:Name="PART_ContentPresenter"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                Padding="{TemplateBinding Padding}"
+                                RecognizesAccessKey="True"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
       </ControlTemplate>
     </Setter>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBoxStyles.axaml
@@ -141,6 +141,7 @@
         <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
         <Setter Property="FocusAdorner" Value="{x:Null}" />
         <Setter Property="ContextFlyout" Value="{StaticResource DefaultTextBoxContextFlyout}" />
+        <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
@@ -192,6 +193,7 @@
                                                           TextAlignment="{TemplateBinding TextAlignment}"
                                                           TextWrapping="{TemplateBinding TextWrapping}"
                                                           LineHeight="{TemplateBinding LineHeight}"
+                                                          LetterSpacing="{TemplateBinding LetterSpacing}"
                                                           PasswordChar="{TemplateBinding PasswordChar}"
                                                           RevealPassword="{TemplateBinding RevealPassword}"
                                                           SelectionBrush="{TemplateBinding SelectionBrush}"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:ui="using:FluentAvalonia.UI.Controls"
+                    xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                     xmlns:sys="using:System"
                     x:CompileBindings="True">
 
@@ -28,14 +29,14 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentPresenter Background="{TemplateBinding Background}"
-                                  Foreground="{TemplateBinding Foreground}"
-                                  Content="{TemplateBinding Content}"
-                                  HorizontalContentAlignment="Stretch"
-                                  VerticalContentAlignment="Stretch"
-                                  CornerRadius="{TemplateBinding CornerRadius}"
-                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}"/>
+                <uip:FAContentPresenter Background="{TemplateBinding Background}"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Content="{TemplateBinding Content}"
+                                        HorizontalContentAlignment="Stretch"
+                                        VerticalContentAlignment="Stretch"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"/>
             </ControlTemplate>
         </Setter>
 
@@ -183,13 +184,13 @@
         <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="Background"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}"
-                        Padding="{DynamicResource DateTimeFlyoutBorderPadding}"
-                        MaxHeight="398">
+                <ui:FABorder Name="Background"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius}"
+                             Padding="{DynamicResource DateTimeFlyoutBorderPadding}"
+                             MaxHeight="398">
                     <Grid Name="ContentPanel" RowDefinitions="*,Auto">
                         <Grid.Styles>
                             <Style Selector="DateTimePickerPanel > ListBoxItem">
@@ -303,7 +304,7 @@
                         </Grid>
 
                     </Grid>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TreeViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TreeViewStyles.axaml
@@ -36,13 +36,16 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}">
                     <ScrollViewer Background="{TemplateBinding Background}"
                                   HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
+                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                                  IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                                  AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
                         <ItemsPresenter Name="PART_ItemsPresenter"
                                         ItemsPanel="{TemplateBinding ItemsPanel}"
                                         Margin="{TemplateBinding Padding}" />

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarButtonStyles.axaml
@@ -28,7 +28,7 @@
                 </ui:CommandBarOverflowPresenter>
 
                 <ui:CommandBar ClosedDisplayMode="Compact" IsOpen="False"
-							   DefaultLabelPosition="Right">
+							   DefaultLabelPosition="Bottom">
                     <ui:CommandBar.PrimaryCommands>
                         <ui:CommandBarButton Label="Test" IconSource="Save" IsCompact="False" />
                     </ui:CommandBar.PrimaryCommands>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarOverflowPresenterStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/CommandBar/CommandBarOverflowPresenterStyles.axaml
@@ -14,7 +14,7 @@
         <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="LayoutRoot"
+                <ui:FABorder Name="LayoutRoot"
 						Background="{TemplateBinding Background}"
 						Padding="{TemplateBinding Padding}"
 						BorderBrush="{TemplateBinding BorderBrush}"
@@ -26,7 +26,7 @@
 										Margin="{DynamicResource CommandBarOverflowPresenterMargin}"
 										KeyboardNavigation.TabNavigation="Cycle" />
                     </ScrollViewer>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
     </ControlTheme>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
@@ -22,7 +22,7 @@
                 <Border Name="Container">
                     <Panel Name="LayoutRoot"
                            Background="{DynamicResource ContentDialogSmokeFill}">
-                        <Border Name="BackgroundElement"
+                        <ui:FABorder Name="BackgroundElement"
                                 Background="{TemplateBinding Background}"
                                 BorderThickness="{StaticResource ContentDialogBorderWidth}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -133,7 +133,7 @@
                                     </Border>
                                 </Grid>
                             </Border>
-                        </Border>
+                        </ui:FABorder>
                     </Panel>
                 </Border>
             </ControlTemplate>
@@ -209,7 +209,7 @@
         </Style>
 
         <!--Handle FullDialogSizing-->
-        <Style Selector="^:fullsize /template/ Border#BackgroundElement">
+        <Style Selector="^:fullsize /template/ ui|FABorder#BackgroundElement">
             <Setter Property="VerticalAlignment" Value="Stretch"/>
         </Style>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutItemStyles.axaml
@@ -6,7 +6,7 @@
     <Design.PreviewWith>
         <Border Padding="50">
             <ui:FAMenuFlyoutPresenter>
-                <ui:MenuFlyoutItem Text="Hello" Icon="SaveFilled" InputGesture="Ctrl+k"/>
+                <ui:MenuFlyoutItem Text="Hello" IconSource="SaveFilled" InputGesture="Ctrl+k"/>
             </ui:FAMenuFlyoutPresenter>
         </Border>
     </Design.PreviewWith>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutSeparatorStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutSeparatorStyles.axaml
@@ -6,9 +6,9 @@
     <Design.PreviewWith>
         <Border Padding="50">
             <ui:FAMenuFlyoutPresenter>
-                <ui:MenuFlyoutItem Text="Hello" Icon="SaveFilled" InputGesture="Ctrl+k"/>
+                <ui:MenuFlyoutItem Text="Hello" IconSource="SaveFilled" InputGesture="Ctrl+k"/>
                 <ui:MenuFlyoutSeparator />
-                <ui:MenuFlyoutItem Text="Hello" Icon="SaveFilled" InputGesture="Ctrl+k"/>
+                <ui:MenuFlyoutItem Text="Hello" IconSource="SaveFilled" InputGesture="Ctrl+k"/>
             </ui:FAMenuFlyoutPresenter>
         </Border>
     </Design.PreviewWith>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutSubItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/MenuFlyoutSubItemStyles.axaml
@@ -6,7 +6,7 @@
     <Design.PreviewWith>
         <Border Padding="50">
             <ui:FAMenuFlyoutPresenter>
-                <ui:MenuFlyoutSubItem Text="Hello" Icon="SaveFilled" />
+                <ui:MenuFlyoutSubItem Text="Hello" IconSource="SaveFilled" />
             </ui:FAMenuFlyoutPresenter>
         </Border>
     </Design.PreviewWith>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/RadioMenuFlyoutItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/RadioMenuFlyoutItemStyles.axaml
@@ -6,7 +6,7 @@
     <Design.PreviewWith>
         <Border Padding="50">
             <ui:FAMenuFlyoutPresenter>
-                <ui:RadioMenuFlyoutItem Text="Hello" Icon="SaveFilled" InputGesture="Ctrl+k"/>
+                <ui:RadioMenuFlyoutItem Text="Hello" IconSource="SaveFilled" InputGesture="Ctrl+k"/>
             </ui:FAMenuFlyoutPresenter>
         </Border>
     </Design.PreviewWith>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/ToggleMenuFlyoutItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAMenuFlyout/ToggleMenuFlyoutItemStyles.axaml
@@ -6,7 +6,7 @@
     <Design.PreviewWith>
         <Border Padding="50">
             <ui:FAMenuFlyoutPresenter>
-                <ui:ToggleMenuFlyoutItem Text="Hello" Icon="SaveFilled" InputGesture="Ctrl+k"/>
+                <ui:ToggleMenuFlyoutItem Text="Hello" IconSource="SaveFilled" InputGesture="Ctrl+k"/>
             </ui:FAMenuFlyoutPresenter>
         </Border>
     </Design.PreviewWith>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/InfoBarStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/InfoBarStyles.axaml
@@ -98,11 +98,11 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="ContentRoot"
-                        VerticalAlignment="Top"
-                        BorderBrush="{DynamicResource InfoBarBorderBrush}"
-                        BorderThickness="{DynamicResource InfoBarBorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
+                <ui:FABorder Name="ContentRoot"
+                             VerticalAlignment="Top"
+                             BorderBrush="{DynamicResource InfoBarBorderBrush}"
+                             BorderThickness="{DynamicResource InfoBarBorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius}">
 
                     <!-- Background is used here so that it overrides the severity status color if set. 
                     Padding="{StaticResource InfoBarContentRootPadding}" applied as margin on grid b/c no Padding
@@ -196,12 +196,12 @@
                             </Button>
                         </Grid>
                     </Panel>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
 
         <Style Selector="^:informational">
-            <Style Selector="^ /template/ Border#ContentRoot">
+            <Style Selector="^ /template/ ui|FABorder#ContentRoot">
                 <Setter Property="Background" Value="{DynamicResource InfoBarInformationalSeverityBackgroundBrush}" />
             </Style>
             <Style Selector="^ /template/ Ellipse#IconBackground">
@@ -215,7 +215,7 @@
         </Style>
 
         <Style Selector="^:error">
-            <Style Selector="^ /template/ Border#ContentRoot">
+            <Style Selector="^ /template/ ui|FABorder#ContentRoot">
                 <Setter Property="Background" Value="{DynamicResource InfoBarErrorSeverityBackgroundBrush}" />
             </Style>
             <Style Selector="^ /template/ Ellipse#IconBackground">
@@ -230,7 +230,7 @@
         </Style>
 
         <Style Selector="^:warning">
-            <Style Selector="^ /template/ Border#ContentRoot">
+            <Style Selector="^ /template/ ui|FABorder#ContentRoot">
                 <Setter Property="Background" Value="{DynamicResource InfoBarWarningSeverityBackgroundBrush}" />
             </Style>
             <Style Selector="^ /template/ Ellipse#IconBackground">
@@ -244,7 +244,7 @@
         </Style>
 
         <Style Selector="^:success">
-            <Style Selector="^ /template/ Border#ContentRoot">
+            <Style Selector="^ /template/ ui|FABorder#ContentRoot">
                 <Setter Property="Background" Value="{DynamicResource InfoBarSuccessSeverityBackgroundBrush}" />
             </Style>
             <Style Selector="^ /template/ Ellipse#IconBackground">
@@ -283,7 +283,7 @@
         </Style>
 
         <!-- Visible -->
-        <Style Selector="^:hidden /template/ Border#ContentRoot">
+        <Style Selector="^:hidden /template/ ui|FABorder#ContentRoot">
             <Setter Property="IsVisible" Value="False" />
         </Style>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
@@ -7,7 +7,7 @@
     <Design.PreviewWith>
         <Border Padding="50">
             <StackPanel Spacing="4">
-                <uip:NavigationViewItemPresenter Content="Hello" Icon="Save" />
+                <uip:NavigationViewItemPresenter Content="Hello" IconSource="Save" />
             </StackPanel>
         </Border>
     </Design.PreviewWith>
@@ -55,8 +55,7 @@
                                  for Foreground
                                  Thinking this is something with the new styling system but not entirely sure yet
                             -->
-                            <Border Name="IconColumn"
-                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SmallerIconWidth}">
+                            <Border Name="IconColumn">
                                 <Viewbox Name="IconBox"
                                          Height="{DynamicResource NavigationViewItemOnLeftIconBoxHeight}"
 										 HorizontalAlignment="Center"
@@ -112,6 +111,11 @@
                 </Border>
             </ControlTemplate>
         </Setter>
+
+        <!-- Bindings in control templates still apply with local value -->
+        <Style Selector="^ /template/ Border#IconColumn">
+            <Setter Property="Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SmallerIconWidth}" />
+        </Style>
 
         <Style Selector="^:pointerover">
             <Style Selector="^ /template/ Border#LayoutRoot">

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
@@ -4,9 +4,9 @@
 
     <Design.PreviewWith>
         <Border Padding="40" >
-            <ui:NavigationView PaneDisplayMode="Top">
+            <ui:NavigationView PaneDisplayMode="Left">
                 <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Icon="Save" Content="Save" />
+                    <ui:NavigationViewItem Content="Save" />
                 </ui:NavigationView.MenuItems>
                 
                 <TextBlock Text="CONTENT" Margin="20" />

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NumberBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NumberBoxStyles.axaml
@@ -165,7 +165,6 @@
                                           FontSize="{TemplateBinding FontSize}"
                                           FontFamily="{TemplateBinding FontFamily}"
                                           VerticalAlignment="Top"
-                                          Foreground="{DynamicResource TextControlHeaderForeground}"
                                           IsVisible="{TemplateBinding Header, Converter={x:Static ObjectConverters.IsNotNull}}"/>
 
                         <TextBox Name="InputBox"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/PickerFlyoutPresenterStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/PickerFlyoutPresenterStyles.axaml
@@ -54,11 +54,11 @@
         <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}"
-                        Padding="{DynamicResource FlyoutBorderThemePadding}">
+                <ui:FABorder Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius}"
+                             Padding="{DynamicResource FlyoutBorderThemePadding}">
                     <DockPanel>
                         <Panel Name="AcceptDismissContainer"
                                DockPanel.Dock="Bottom"
@@ -96,7 +96,7 @@
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                         </ScrollViewer>
                     </DockPanel>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogButtonStyles.axaml
@@ -19,11 +19,11 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Name="Root">
-                    <Border.Transitions>
+                    <ui:FABorder.Transitions>
                         <Transitions>
                             <BrushTransition Duration="00:00:00.083" Property="Background" />
                         </Transitions>
-                    </Border.Transitions>
+                    </ui:FABorder.Transitions>
                     <StackPanel Spacing="12" 
                                 Orientation="Horizontal"
                                 HorizontalAlignment="Center"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogButtonStyles.axaml
@@ -14,7 +14,7 @@
         <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{TemplateBinding Background}"
+                <ui:FABorder Background="{TemplateBinding Background}"
                         CornerRadius="{TemplateBinding CornerRadius}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
@@ -40,7 +40,7 @@
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           CornerRadius="{TemplateBinding CornerRadius}" />
                     </StackPanel>
-                </Border>
+                </ui:FABorder>
             </ControlTemplate>
         </Setter>
 
@@ -49,7 +49,7 @@
         </Style>
 
         <Style Selector="^:pointerover">
-            <Style Selector="^ /template/ Border#Root">
+            <Style Selector="^ /template/ ui|FABorder#Root">
                 <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
@@ -57,7 +57,7 @@
         </Style>
 
         <Style Selector="^:pressed">
-            <Style Selector="^ /template/ Border#Root">
+            <Style Selector="^ /template/ ui|FABorder#Root">
                 <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
@@ -65,7 +65,7 @@
         </Style>
 
         <Style Selector="^:disabled">
-            <Style Selector="^ /template/ Border#Root">
+            <Style Selector="^ /template/ ui|FABorder#Root">
                 <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
@@ -73,22 +73,22 @@
         </Style>
 
         <!--Accent Button-->
-        <Style Selector="^.accent /template/ Border#Root">
+        <Style Selector="^.accent /template/ ui|FABorder#Root">
             <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
             <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrush}" />
             <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentButtonForeground}" />
         </Style>
-        <Style Selector="^.accent:pointerover /template/ Border#Root">
+        <Style Selector="^.accent:pointerover /template/ ui|FABorder#Root">
             <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
             <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPointerOver}" />
             <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
         </Style>
-        <Style Selector="^.accent:pressed /template/ Border#Root">
+        <Style Selector="^.accent:pressed /template/ ui|FABorder#Root">
             <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundPressed}" />
             <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPressed}" />
             <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentButtonForegroundPressed}" />
         </Style>
-        <Style Selector="^.accent:disabled /template/ Border#Root">
+        <Style Selector="^.accent:disabled /template/ ui|FABorder#Root">
             <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundDisabled}" />
             <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushDisabled}" />
             <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentButtonForegroundDisabled}" />

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
@@ -77,7 +77,7 @@
             <ControlTemplate>
                 <Panel Name="LayoutRoot"
                        Background="{x:Null}">
-                    <Border Background="{TemplateBinding Background}"
+                    <ui:FABorder Background="{TemplateBinding Background}"
                             MinWidth="{DynamicResource TaskDialogMinWidth}"
                             MaxWidth="{DynamicResource TaskDialogMaxWidth}"
                             MinHeight="{DynamicResource TaskDialogMinHeight}"
@@ -185,7 +185,7 @@
                                 </ItemsControl>
                             </Border>
                         </Grid>
-                    </Border>
+                    </ui:FABorder>
                 </Panel>
             </ControlTemplate>
         </Setter>
@@ -253,7 +253,7 @@
             <Style Selector="^ /template/ Panel#LayoutRoot">
                 <Setter Property="Background" Value="{DynamicResource TaskDialogSmokeFill}" />
             </Style>
-            <Style Selector="^ /template/ Border#ContentRoot">
+            <Style Selector="^ /template/ ui|FABorder#ContentRoot">
                 <Setter Property="BorderBrush" Value="{DynamicResource TaskDialogBorderBrush}" />
                 <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
                 <Setter Property="BorderThickness" Value="{DynamicResource TaskDialogBorderWidth}" />
@@ -282,7 +282,7 @@
                     </Animation>
                 </Style.Animations>
             </Style>
-            <Style Selector="^:hidden /template/ Border#ContentRoot">
+            <Style Selector="^:hidden /template/ ui|FABorder#ContentRoot">
                 <Style.Animations>
                     <Animation Duration="00:00:00.167" FillMode="Forward">
                         <KeyFrame Cue="0%">
@@ -317,7 +317,7 @@
                     </Animation>
                 </Style.Animations>
             </Style>
-            <Style Selector="^:open /template/ Border#ContentRoot">
+            <Style Selector="^:open /template/ ui|FABorder#ContentRoot">
                 <Style.Animations>
                     <Animation Duration="00:00:00.250" FillMode="Forward">
                         <KeyFrame Cue="0%">

--- a/src/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.axaml.cs
+++ b/src/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.axaml.cs
@@ -20,44 +20,13 @@ namespace FluentAvalonia.Styling;
 /// </summary>
 public partial class FluentAvaloniaTheme : Styles, IResourceProvider
 {
-    public FluentAvaloniaTheme(Uri baseUri)
+    public FluentAvaloniaTheme()
     {
-        _baseUri = baseUri;
-        Init();
-    }
-
-    public FluentAvaloniaTheme(IServiceProvider serviceProvider)
-    {
-        _baseUri = ((IUriContext)serviceProvider.GetService(typeof(IUriContext))).BaseUri;
         Init();
     }
 
     public static readonly ThemeVariant HighContrastTheme = new ThemeVariant(HighContrastModeString,
         ThemeVariant.Light);
-
-    /// <summary>
-    /// Gets or sets the desired theme mode (Light, Dark, or HighContrast) for the app
-    /// </summary>
-    /// <remarks>
-    /// If <see cref="PreferSystemTheme"/> is set to true, on startup this value will
-    /// be overwritten with the system theme unless the attempt to read from the system
-    /// fails, in which case setting this can provide a fallback.
-    /// </remarks>
-    [Obsolete]
-    public string RequestedTheme
-    {
-        get => Application.Current.ActualThemeVariant.ToString();
-        set
-        {
-            Application.Current.RequestedThemeVariant = value switch
-            {
-                LightModeString => ThemeVariant.Light,
-                DarkModeString => ThemeVariant.Dark,
-                HighContrastModeString => HighContrastTheme,
-                _ => ThemeVariant.Default
-            };
-        }
-    }
 
     /// <summary>
     /// Gets or sets whether the system font should be used on Windows. Value only applies at startup
@@ -147,9 +116,6 @@ public partial class FluentAvaloniaTheme : Styles, IResourceProvider
       
     bool IResourceNode.HasResources => true;
 
-    [Obsolete]
-    public event TypedEventHandler<FluentAvaloniaTheme, RequestedThemeChangedEventArgs> RequestedThemeChanged;
-
     public new bool TryGetResource(object key, ThemeVariant theme, out object value)
     {
         // Github build failing with this not being set, even tho it passes locally
@@ -170,49 +136,6 @@ public partial class FluentAvaloniaTheme : Styles, IResourceProvider
 
     bool IResourceNode.TryGetResource(object key, ThemeVariant theme, out object value) =>
         this.TryGetResource(key, theme, out value);
-
-    /// <summary>
-    /// Call this method if you monitor for notifications from the OS that theme colors have changed. This can be
-    /// SystemAccentColor or Light/Dark/HighContrast theme. This method only works for AccentColors if
-    /// <see cref="UseUserAccentColorOnWindows"/> is true, and for app theme if <see cref="UseSystemThemeOnWindows"/> is true
-    /// </summary>
-    [Obsolete]
-    public void InvalidateThemingFromSystemThemeChanged()
-    {
-        if (PreferUserAccentColor)
-        {
-            if (OSVersionHelper.IsWindows())
-            {
-                TryLoadWindowsAccentColor();
-            }           
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                TryLoadLinuxAccentColor();
-            }
-            else
-            {
-                // This is used for Mac & WASM/Mobile
-                TryLoadMacOSAccentColor(AvaloniaLocator.Current.GetService<IPlatformSettings>());
-            }
-        }
-
-        if (PreferSystemTheme)
-        {
-           // Refresh(null);
-        }
-    }
-
-    private bool IsValidRequestedTheme(string thm)
-    {
-        if (LightModeString.Equals(thm, StringComparison.OrdinalIgnoreCase) ||
-            DarkModeString.Equals(thm, StringComparison.OrdinalIgnoreCase) ||
-            HighContrastModeString.Equals(thm, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return false;
-    }
 
     private void Init()
     {
@@ -578,7 +501,6 @@ public partial class FluentAvaloniaTheme : Styles, IResourceProvider
     }
 
     private bool _hasLoaded;
-    private Uri _baseUri;
     private Color? _customAccentColor;
     private bool _preferSystemTheme;
     private bool _preferUserAccentColor;

--- a/src/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.properties.cs
@@ -68,12 +68,6 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         ComboBox.PlaceholderTextProperty.AddOwner<FAComboBox>();
 
     /// <summary>
-    /// Defines the <see cref="HeaderTemplate"/> property
-    /// </summary>
-    public static StyledProperty<IDataTemplate> HeaderTemplateProperty =
-        HeaderedContentControl.HeaderTemplateProperty.AddOwner<FAComboBox>();
-
-    /// <summary>
     /// Defines the <see cref="SelectionChangedTrigger"/> property
     /// </summary>
     public static StyledProperty<FAComboBoxSelectionChangedTrigger> SelectionChangedTriggerProperty =
@@ -189,15 +183,6 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
     {
         get => GetValue(PlaceholderTextProperty);
         set => SetValue(PlaceholderTextProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the DataTemplate used to display the content of the control's header.
-    /// </summary>
-    public IDataTemplate HeaderTemplate
-    {
-        get => GetValue(HeaderTemplateProperty);
-        set => SetValue(HeaderTemplateProperty, value);
     }
 
     /// <summary>

--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
@@ -5,7 +5,6 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using FluentAvalonia.Core;
-using System;
 using System.Globalization;
 
 namespace FluentAvalonia.UI.Controls;
@@ -65,7 +64,7 @@ public partial class NumberBox : TemplatedControl
 
         //UpdateVisualStateForIsEnabledChange();
 
-        if (_value == double.NaN &&
+        if (double.IsNaN(Value) &&
             !string.IsNullOrEmpty(_text))
         {
             // If Text has been set, but Value hasn't, update Value based on Text.
@@ -255,7 +254,7 @@ public partial class NumberBox : TemplatedControl
             }
             else
             {
-                if (value.Value == _value)
+                if (value.Value == Value)
                 {
                     // Even if the value hasn't changed, we still want to update the text (e.g. Value is 3, user types 1 + 2, we want to replace the text with 3)
                     UpdateTextToValue();
@@ -336,17 +335,19 @@ public partial class NumberBox : TemplatedControl
         // Before adjusting the value, validate the contents of the textbox so we don't override it.
         ValidateInput();
 
-        var newVal = _value;
+        var newVal = Value;
+        var max = Maximum;
+        var min = Minimum;
         if (!double.IsNaN(newVal))
         {
             newVal += change;
 
             if (IsWrapEnabled)
             {
-                if (newVal > _maxmimum)
-                    newVal = _minimum;
-                else if (newVal < _minimum)
-                    newVal = _maxmimum;
+                if (newVal > max)
+                    newVal = min;
+                else if (newVal < min)
+                    newVal = max;
             }
 
             Value = newVal;
@@ -364,12 +365,13 @@ public partial class NumberBox : TemplatedControl
             return;
 
         string newText = "";
+        var value = Value;
 
-        if (!double.IsNaN(_value))
+        if (!double.IsNaN(value))
         {
             // Round to 12 digits (standard .net rounding per WinUI in the NumberBox source)
             // We do this to prevent weirdness from floating point imprecision
-            var newValue = Math.Round(_value, 12);
+            var newValue = Math.Round(value, 12);
             if (SimpleNumberFormat != null)
             {
                 newText = newValue.ToString(SimpleNumberFormat);
@@ -451,7 +453,8 @@ public partial class NumberBox : TemplatedControl
         bool isUpEnabled = false;
         bool isDownEnabled = false;
 
-        if (!double.IsNaN(_value))
+        var value = Value;
+        if (!double.IsNaN(value))
         {
             if (IsWrapEnabled || ValidationMode != NumberBoxValidationMode.InvalidInputOverwritten)
             {
@@ -461,10 +464,10 @@ public partial class NumberBox : TemplatedControl
             }
             else
             {
-                if (_value < _maxmimum)
+                if (value < Maximum)
                     isUpEnabled = true;
 
-                if (_value > _minimum)
+                if (value > Minimum)
                     isDownEnabled = true;
             }
         }
@@ -511,24 +514,27 @@ public partial class NumberBox : TemplatedControl
 
     private void CoerceValueIfNeeded(double min, double max)
     {
-        if (double.IsNaN(_value))
+        var value = Value;
+        if (double.IsNaN(value))
             return;
 
-        if (_value < min)
+        if (value < min)
             Value = min;
-        else if (_value > max)
+        else if (value > max)
             Value = max;
     }
 
     private double CoerceValueToRange(double val)
     {
-        if (!double.IsNaN(val) && (val > _maxmimum || val < _minimum) && ValidationMode == NumberBoxValidationMode.InvalidInputOverwritten)
+        var maximum = Maximum;
+        var minimum = Minimum;
+        if (!double.IsNaN(val) && (val > maximum || val < minimum) && ValidationMode == NumberBoxValidationMode.InvalidInputOverwritten)
         {
-            if (val > _maxmimum)
-                return _maxmimum;
+            if (val > maximum)
+                return maximum;
 
-            if (val < _minimum)
-                return _minimum;
+            if (val < minimum)
+                return minimum;
         }
 
         return val;

--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
@@ -6,7 +6,6 @@ using Avalonia.Media;
 using Avalonia;
 using FluentAvalonia.Core.Attributes;
 using FluentAvalonia.Core;
-using System;
 using Avalonia.Controls.Metadata;
 
 namespace FluentAvalonia.UI.Controls;
@@ -375,11 +374,7 @@ public partial class NumberBox
     /// </summary>
     public event TypedEventHandler<NumberBox, NumberBoxValueChangedEventArgs> ValueChanged;
 
-
-    private double _minimum = double.MinValue;
-    private double _maxmimum = double.MaxValue;
     public string _text = null;
-    private double _value = double.NaN;
 
     private const string s_tpDownSpinButton = "DownSpinButton";
     private const string s_tpPopupDownSpinButton = "PopupDownSpinButton";

--- a/src/FluentAvalonia/UI/Data/CollectionView/RefreshDeferer.cs
+++ b/src/FluentAvalonia/UI/Data/CollectionView/RefreshDeferer.cs
@@ -17,6 +17,5 @@ internal class RefreshDeferer : IDisposable
     }
 
     private readonly Action<object> _releaseAction;
-    private readonly ICollectionView _acvs;
     private readonly object _currentItem;
 }

--- a/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
+++ b/src/FluentAvalonia/UI/Windowing/AppWindow/AppWindow.cs
@@ -233,7 +233,7 @@ public partial class AppWindow : Window, IStyleable
 
             // What we know is that the default title bar will always be [0,0,WindowWidth,TitleBar.Height]
             // Therefore, we only need to do check the Y coordinate
-            var hgt = _titleBar.Height * GetScaling();
+            var hgt = _titleBar.Height * RenderScaling;
             if (p.Y < hgt)
             {
                 if (TitleBar.TitleBarHitTestType == TitleBarHitTestType.Complex &&
@@ -345,13 +345,7 @@ public partial class AppWindow : Window, IStyleable
             OnExtendsContentIntoTitleBarChanged(_titleBar.ExtendsContentIntoTitleBar);
         }
     }
-
-    private double GetScaling()
-    {
-        // This is stupid
-        return Screens.ScreenFromWindow(PlatformImpl).Scaling;
-    }
-
+    
     private void SetTitleBarColors()
     {
         if (_templateRoot == null)

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
@@ -145,11 +145,9 @@ internal unsafe class Win32WindowManager
         return CallWindowProcW(_oldWndProc, hWnd, msg, wParam, lParam);
     }
 
-    private double GetScaling()
-    {
-        // This is stupid
-        return _window.Screens.ScreenFromWindow(_window.PlatformImpl).Scaling;
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private double GetScaling() =>
+        _window.RenderScaling;
 
     private int GetResizeHandleHeight() =>
         GetSystemMetricsForDpi(SM_CXPADDEDBORDER, (uint)(96 * GetScaling())) +


### PR DESCRIPTION
Some changes and fixes, mostly styling related:
- Switched to FABorder or FAContentPresenter in DatePicker, TimePicker, DropDownButton, and SplitButton and all "Overlay" controls (flyouts, popups, ContentDialog, and TaskDialog when in overlay mode)
  - NOTE: This only applies to the root border that has the BorderBrush/Thickness applied. To reiterate from the preview7 PR, the changes to FAContentPresenter require no changes on your part. The change to FABorder only requires and update if you have custom styles for one of these controls (just have to update from Border to ui|FABorder, where ui is your xmlns prefix)
- Removed the foreground setter on the Header ContentPresenter for `NumberBox`. 
- Fixed an issue where a NavigationViewItem without an Icon should show the content aligned as if an Icon was present. Issue was caused by `{Binding}` in a ControlTemplate is still being applied with LocalValue
- Added the new Scroll-related properties to ListBox/TreeView
- Removed the obsolete APIs from `FluentAvaloniaTheme`
  - `RequestedTheme`, `RequestedThemeChanged`, and `InvalidateThemingFromSystemThemeChanged` are now removed
  - Also removed the two constructors that required parameters as they're no longer necessary
- Cut down on a couple warnings
- Fixed issue with NumberBox caused by switch from DirectProperty -> StyledProperty

Known issues caused by things upstream:
- ComboBox won't display its last item (will be fixed by 11127)
- CommandBarButtons Label text is left aligned (if label is displayed on bottom) - related to 11125 and will be fixed by 11066

Note: branch is not yet on a CI build, I'm going to wait for at least 11127 before merging and releasing a preview7.1