### PR TITLE
Fix ColorPicker Theme Variant Brushes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
@@ -58,10 +58,22 @@
               <Grid RowDefinitions="Auto,Auto">
 
                 <Grid.Resources>
-                  <StaticResource x:Key="ColorViewContentBackgroundBrush" ResourceKey="LayerFillColorAltBrush" />
-                  <StaticResource x:Key="ColorViewContentBorderBrush" ResourceKey="DividerStrokeColorDefaultBrush" />
-                  <SolidColorBrush x:Key="ColorViewTabBackgroundBrush" Color="Transparent" />
-                  <SolidColorBrush x:Key="ColorViewTabBorderBrush" Color="Transparent" />
+                  <ResourceDictionary>
+                    <ResourceDictionary.ThemeDictionaries>
+                      <ResourceDictionary x:Key="Default">
+                        <StaticResource x:Key="ColorViewContentBackgroundBrush" ResourceKey="LayerFillColorAltBrush" />
+                        <StaticResource x:Key="ColorViewContentBorderBrush" ResourceKey="DividerStrokeColorDefaultBrush" />
+                        <SolidColorBrush x:Key="ColorViewTabBackgroundBrush" Color="Transparent" />
+                        <SolidColorBrush x:Key="ColorViewTabBorderBrush" Color="Transparent" />
+                      </ResourceDictionary>
+                      <ResourceDictionary x:Key="Dark">
+                        <StaticResource x:Key="ColorViewContentBackgroundBrush" ResourceKey="LayerFillColorAltBrush" />
+                        <StaticResource x:Key="ColorViewContentBorderBrush" ResourceKey="DividerStrokeColorDefaultBrush" />
+                        <SolidColorBrush x:Key="ColorViewTabBackgroundBrush" Color="Transparent" />
+                        <SolidColorBrush x:Key="ColorViewTabBorderBrush" Color="Transparent" />
+                      </ResourceDictionary>
+                    </ResourceDictionary.ThemeDictionaries>
+                  </ResourceDictionary>
                   <!-- This radius must follow OverlayCornerRadius -->
                   <CornerRadius x:Key="ColorViewTabBackgroundCornerRadius">8,8,0,0</CornerRadius>
                 </Grid.Resources>


### PR DESCRIPTION
Fixes https://github.com/amwx/FluentAvalonia/issues/314 as discussed here: https://github.com/AvaloniaUI/Avalonia/issues/10502#issuecomment-1522670851.

**Before**
![](https://user-images.githubusercontent.com/17993847/221744601-8689ba62-8349-4fe3-aa40-a643c11e5eaf.png)

**After**
![image](https://user-images.githubusercontent.com/17993847/234855029-38779e13-a525-4e68-8503-9410b7c8508c.png)

@amwx Would be great to get this in for the 7.1 package.