### PR TITLE
TaskDialog style changes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TaskDialog/TaskDialogStyles.axaml
@@ -5,14 +5,15 @@
                     xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
                     x:CompileBindings="True">
     <Design.PreviewWith>
-        <Border Padding="20">
+        <Border Padding="20" Background="#CDCDCD" Height="530" Width="600">
             <Border BorderBrush="#35EFEFEF" BorderThickness="1">
                 <ui:TaskDialog IconSource="SaveFilled" IsVisible="True"
                                Header="Dialog Heading"
+                               SubHeader="Dialog SubHeader"
                                Content="Dialog Content goes here"
                                FooterVisibility="Auto"
                                ShowProgressBar="True" 
-                               core:VisualStateHelper.ForcedClassesProperty=":open,:progressSuspend">
+                               core:VisualStateHelper.ForcedClassesProperty=":open,:progressSuspend:hosted">
                     <ui:TaskDialog.Buttons>
                         <ui:TaskDialogButton Text="OK" IconSource="Checkmark" IsDefault="True" />
                         <ui:TaskDialogButton Text="Cancel" IconSource="Dismiss" IsEnabled="False"/>
@@ -42,8 +43,10 @@
     <x:String x:Key="TaskDialogFooterButtonNormalText">More Details</x:String>
     <x:String x:Key="TaskDialogFooterButtonExpandedText">Less Details</x:String>
 
-    <Thickness x:Key="TaskDialogHeaderPadding">18 9</Thickness>
-    <Thickness x:Key="TaskDialogSubHeaderPadding">18 9</Thickness>
+    <Thickness x:Key="TaskDialogIconMargin">12</Thickness>
+    <Thickness x:Key="TaskDialogHeaderPadding">60 9 12 9</Thickness>
+    <Thickness x:Key="TaskDialogHeaderPaddingNoIcon">18 9 12 9</Thickness>
+    <Thickness x:Key="TaskDialogSubHeaderPadding">18 4</Thickness>
     <x:Double x:Key="TaskDialogIconSize">36</x:Double>
     <Thickness x:Key="TaskDialogContentMargin">18 9</Thickness>
     <Thickness x:Key="TaskDialogButtonHostMargin">18</Thickness>
@@ -86,38 +89,43 @@
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch">
                         <Grid RowDefinitions="Auto,Auto,*,Auto">
-                            <Border Background="{DynamicResource TaskDialogHeaderBackground}"
-                                    Padding="{DynamicResource TaskDialogHeaderPadding}"
-                                    Name="HeaderRoot"
-                                    IsVisible="False">
+                            <Panel Grid.Row="0"
+                                   Name="HeaderHost"
+                                   Background="{TemplateBinding HeaderBackground}"
+                                   IsVisible="False">
+                                <Viewbox Name="IconHost"
+                                         Width="{StaticResource TaskDialogIconSize}"
+                                         Height="{StaticResource TaskDialogIconSize}"
+                                         VerticalAlignment="Center"
+                                         HorizontalAlignment="Left"
+                                         Margin="{DynamicResource TaskDialogIconMargin}"
+                                         IsVisible="False">
+                                    <ui:IconSourceElement IconSource="{TemplateBinding IconSource}"
+                                                          Name="IconElement"/>
+                                </Viewbox>
                                 <TextBlock Text="{TemplateBinding Header}"
                                            TextWrapping="Wrap"
                                            FontSize="{DynamicResource TaskDialogHeaderFontSize}"
-                                           FontWeight="{StaticResource TaskDialogHeaderFontWeight}" />
-                            </Border>
-
-                            <DockPanel Grid.Row="1"
-                                       Name="SubHeaderRoot"
-                                       Margin="{DynamicResource TaskDialogSubHeaderPadding}"
-                                       IsVisible="False">
-                                <Viewbox Name="IconHost"
-                                         DockPanel.Dock="Left"
-                                         Width="{StaticResource TaskDialogIconSize}"
-                                         Height="{StaticResource TaskDialogIconSize}"
-                                         Margin="0 0 12 0"
-                                         IsVisible="False">
-                                    <ui:IconSourceElement IconSource="{TemplateBinding IconSource}" />
-                                </Viewbox>
-
-                                <TextBlock Name="SubHeaderHost"
-                                           Text="{TemplateBinding SubHeader}"
-                                           FontWeight="{StaticResource TaskDialogSubHeaderFontWeight}"
-                                           HorizontalAlignment="Left"
+                                           FontWeight="{StaticResource TaskDialogHeaderFontWeight}"
                                            VerticalAlignment="Center"
-                                           TextWrapping="Wrap"
-                                           FontSize="{StaticResource TaskDialogSubHeaderFontSize}" />
-                            </DockPanel>
+                                           HorizontalAlignment="Left"
+                                           Margin="{DynamicResource TaskDialogHeaderPadding}"
+                                           IsVisible="False"
+                                           Name="HeaderText"/>
 
+                            </Panel>
+
+                            <TextBlock Name="SubHeaderText"
+                                       Text="{TemplateBinding SubHeader}"
+                                       FontWeight="{StaticResource TaskDialogSubHeaderFontWeight}"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       FontSize="{StaticResource TaskDialogSubHeaderFontSize}"
+                                       Margin="{DynamicResource TaskDialogSubHeaderPadding}"
+                                       Grid.Row="1"
+                                       IsVisible="False"/>
+                            
                             <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                                           VerticalScrollBarVisibility="Auto"
                                           Grid.Row="2"
@@ -197,11 +205,19 @@
             <Setter Property="IsVisible" Value="True" />
         </Style>
 
-        <Style Selector="^:header /template/ Border#HeaderRoot">
-            <Setter Property="IsVisible" Value="True" />
+        <Style Selector="^:header">
+            <Style Selector="^ /template/ Panel#HeaderHost">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#HeaderText">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+            <Style Selector="^:not(:icon) /template/ TextBlock#HeaderText">
+                <Setter Property="Margin" Value="{DynamicResource TaskDialogHeaderPaddingNoIcon}" />
+            </Style>
         </Style>
-
-        <Style Selector="^:subheader /template/ DockPanel#SubHeaderRoot">
+        
+        <Style Selector="^:subheader /template/ TextBlock#SubHeaderText">
             <Setter Property="IsVisible" Value="True" />
         </Style>
 
@@ -213,6 +229,9 @@
             <Style Selector="^ /template/ Viewbox#IconHost">
                 <Setter Property="IsVisible" Value="True" />
             </Style>
+            <Style Selector="^ /template/ Panel#HeaderHost">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>            
         </Style>
 
         <Style Selector="^:footerAuto">
@@ -246,6 +265,14 @@
         <Style Selector="^:progressSuspend /template/ ProgressBar#ProgressBar">
             <Setter Property="Foreground" Value="{DynamicResource TaskDialogProgressBarSuspendColor}" />
             <Setter Property="Background" Value="{DynamicResource TaskDialogProgressBarSuspendBackgroundColor}" />
+        </Style>
+
+        <Style Selector="^:headerForeground /template/ TextBlock#HeaderText">
+            <Setter Property="Foreground" Value="{Binding $parent[ui:TaskDialog].HeaderForeground}" />
+        </Style>
+
+        <Style Selector="^:iconForeground /template/ ui|IconSourceElement#IconElement">
+            <Setter Property="Foreground" Value="{Binding $parent[ui:TaskDialog].IconForeground}" />
         </Style>
         
         

--- a/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -507,6 +507,8 @@ public partial class TaskDialog : ContentControl
         List<Control> commands = new List<Control>();
 
         bool foundDefault = _defaultButton != null;
+        int iconCount = 0;
+        int normalCommandCount = 0;
         for (int i = 0; i < _commands.Count; i++)
         {
             if (_commands[i] is TaskDialogCheckBox tdcb)
@@ -521,7 +523,7 @@ public partial class TaskDialog : ContentControl
 
                 com.Classes.Add(s_cFATDCom);
 
-                commands.Add(com);
+                commands.Add(com);                
             }
             else if (_commands[i] is TaskDialogRadioButton tdrb)
             {
@@ -560,6 +562,21 @@ public partial class TaskDialog : ContentControl
                 }
 
                 commands.Add(com);
+
+                // Icons are only supported on "normal" TaskDialogCommands
+                if (tdc.IconSource != null)
+                    iconCount++;
+                normalCommandCount++;
+            }
+        }
+
+        if (iconCount != normalCommandCount)
+        {
+            // We have an item with no icon - force it to display as if one
+            // was present so that its aligned with the others
+            for (int i = 0; i < commands.Count; i++)
+            {
+                (commands[i].Classes as IPseudoClasses).Set(SharedPseudoclasses.s_pcIcon, true);
             }
         }
 

--- a/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -88,6 +88,14 @@ public partial class TaskDialog : ContentControl
         {
             PseudoClasses.Set(s_pcSubheader, change.NewValue != null);
         }
+        else if (change.Property == HeaderForegroundProperty)
+        {
+            PseudoClasses.Set(s_pcHeaderForeground, change.NewValue != null);
+        }
+        else if (change.Property == IconForegroundProperty)
+        {
+            PseudoClasses.Set(s_pcIconForeground, change.NewValue != null);
+        }
     }
     
     protected override bool RegisterContentPresenter(IContentPresenter presenter)

--- a/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.properties.cs
@@ -7,12 +7,14 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
+using Avalonia.Media;
 
 namespace FluentAvalonia.UI.Controls;
 
 [PseudoClasses(s_pcHosted, s_pcHidden, SharedPseudoclasses.s_pcOpen)]
 [PseudoClasses(SharedPseudoclasses.s_pcHeader, s_pcSubheader, SharedPseudoclasses.s_pcIcon, s_pcFooter, s_pcFooterAuto, s_pcExpanded)]
 [PseudoClasses(s_pcProgress, s_pcProgressError, s_pcProgressSuspend)]
+[PseudoClasses(s_pcHeaderForeground, s_pcIconForeground)]
 [TemplatePart(s_tpButtonsHost, typeof(ItemsPresenter))]
 [TemplatePart(s_tpCommandsHost, typeof(ItemsPresenter))]
 [TemplatePart(s_tpMoreDetailsButton, typeof(Button))]
@@ -86,6 +88,24 @@ public partial class TaskDialog
     /// </summary>
     public static readonly StyledProperty<bool> ShowProgressBarProperty =
         AvaloniaProperty.Register<TaskDialog, bool>(nameof(ShowProgressBar));
+
+    /// <summary>
+    /// Defines the <see cref="HeaderBackground"/> property
+    /// </summary>
+    public static readonly StyledProperty<IBrush> HeaderBackgroundProperty =
+        AvaloniaProperty.Register<TaskDialog, IBrush>(nameof(HeaderBackground));
+
+    /// <summary>
+    /// Defines the <see cref="HeaderForeground"/> property
+    /// </summary>
+    public static readonly StyledProperty<IBrush> HeaderForegroundProperty =
+        AvaloniaProperty.Register<TaskDialog, IBrush>(nameof(HeaderForeground));
+
+    /// <summary>
+    /// Defines the <see cref="IconForeground"/> property
+    /// </summary>
+    public static readonly StyledProperty<IBrush> IconForegroundProperty =
+        AvaloniaProperty.Register<TaskDialog, IBrush>(nameof(IconForeground));
 
     /// <summary>
     /// Gets or sets the title of the dialog
@@ -191,6 +211,33 @@ public partial class TaskDialog
     }
 
     /// <summary>
+    /// Gets or sets the background of the header region of the task dialog
+    /// </summary>
+    public IBrush HeaderBackground
+    {
+        get => GetValue(HeaderBackgroundProperty);
+        set => SetValue(HeaderBackgroundProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground of the header text for the TaskDialog
+    /// </summary>
+    public IBrush HeaderForeground
+    {
+        get => GetValue(HeaderForegroundProperty);
+        set => SetValue(HeaderForegroundProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground of the <see cref="IconSource"/> for the TaskDialog
+    /// </summary>
+    public IBrush IconForeground
+    {
+        get => GetValue(IconForegroundProperty);
+        set => SetValue(IconForegroundProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the root visual that should host this dialog
     /// </summary>
     /// <remarks>
@@ -238,6 +285,8 @@ public partial class TaskDialog
     private const string s_pcProgress = ":progress";
     private const string s_pcProgressError = ":progressError";
     private const string s_pcProgressSuspend = ":progressSuspend";
+    private const string s_pcHeaderForeground = ":headerForeground";
+    private const string s_pcIconForeground = ":iconForeground";
 
     private const string s_cFATDCom = "FA_TaskDialogCommand";
 }


### PR DESCRIPTION
A couple of style changes for the `TaskDialog`:
- Moved the `Header` text to be inline with the Icon rather than `SubHeader`
  - Subheader is now below the header region. Honestly, I'm thinking about removing this property as it feels unnecessary with both header and content, but that's a future decision
  - If you have a header but no Icon, the header will fully left align to be inline with the content below it
- Adjusted some of the margins for these elements
- Added 3 new properties
  - `HeaderBackground`: specifies the background color of the header region - this is the area behind the Icon and the header text
  - `HeaderForeground`: specifies the foreground of the header text. Generally should only be set if HeaderBackground is supplied
  - `IconForeground`: specifies the foreground of the icon. Generally should only be set if HeaderBackground is supplied
- Adjusted TaskDialogCommands to always be indented if at least one item has an Icon. (CheckBoxes and RadioButtons don't support icons, so they'll always be fully left aligned)

New style:
(note: this is in the designer, you can ignore the unrounded corners)
![image](https://user-images.githubusercontent.com/40413319/235257488-f1a69dcf-e971-47f3-82db-ab1507031b45.png)

Addition of the Header properties allows you to customize the dialog a little more to indicate results:
![image](https://user-images.githubusercontent.com/40413319/235257223-166254d8-d358-4cdc-82b0-d2d7fe7cfca1.png)