### PR TITLE
Try fix Android trimming issue

### DIFF
--- a/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.properties.cs
@@ -68,12 +68,14 @@ public partial class SettingsExpander
     public static readonly StyledProperty<object> CommandParameterProperty = 
         Button.CommandParameterProperty.AddOwner<SettingsExpander>();
 
+    // NOTE: Don't use Button.Click event here - when SettingsExpanderItem is in the top-level SettingsExpander
+    // there is a ToggleButton that is used to raise this event. If we use Button.Click here, and someone is 
+    // listening to Button.Click event with handledEventsToo = true, they'll get 2 click events as a result
     /// <summary>
     /// Defines the <see cref="Click"/> event
     /// </summary>
     public static readonly RoutedEvent<RoutedEventArgs> ClickEvent =
-        SettingsExpanderItem.ClickEvent;
-
+        RoutedEvent.Register<SettingsExpander, RoutedEventArgs>(nameof(Click), RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
     /// <summary>
     /// Gets or sets the description text

--- a/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.properties.cs
@@ -69,14 +69,11 @@ public partial class SettingsExpanderItem : ContentControl
     public static readonly StyledProperty<SettingsExpanderTemplateSettings> TemplateSettingsProperty =
         AvaloniaProperty.Register<SettingsExpanderItem, SettingsExpanderTemplateSettings>(nameof(TemplateSettings));
 
-    // NOTE: Don't use Button.Click event here - when SettingsExpanderItem is in the top-level SettingsExpander
-    // there is a ToggleButton that is used to raise this event. If we use Button.Click here, and someone is 
-    // listening to Button.Click event with handledEventsToo = true, they'll get 2 click events as a result
     /// <summary>
     /// Defines the <see cref="Click"/> event
     /// </summary>
     public static readonly RoutedEvent<RoutedEventArgs> ClickEvent =
-        RoutedEvent.Register<SettingsExpanderItem, RoutedEventArgs>(nameof(Click), RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        SettingsExpander.ClickEvent;
 
     /// <summary>
     /// Gets or sets the description text


### PR DESCRIPTION
#326 describes an issue where the NavigationView, when used on Android in release mode was leading to issues. #326 says the NavView showed up blank, but I was getting a full crash. 

A NullRef exception was being thrown from inside SettingsExpanderItem while trying to initialize the AvaloniaProperties. NavigationViewItem AddOwners the IconSource property from SettingsExpander, and SettingsExpanderItem AddOwners all its properties from SettingsExpander. (SettingsExpander has an instance variable of the inner SettingsExpander which is why its type had to be loaded too). 

Truthfully AOT/trimming isn't something I particularly care about, so my knowledge on this is very, very small. However, what I think was happening was, SettingsExpander type was loaded because of the AddOwner in NavigationViewItem, which resulted in SettingsExpanderItem type getting loaded too (because of the instance field). For some reason, I guess SettingsExpander wasn't fully initialized when SettingsExpanderItem was loaded leading to the exception. 

All of the AvaloniaProperties are declared in SettingsExpander, but I had the Click event declared in SettingsExpanderItem, which appears to be the source of the issue. So this PR swaps that so that the Click event is owned by SettingsExpander and "add ownered" by SettingsExpanderItem, which seems to fix the issue. Still feels like an issue in the runtime though, but as I said this is way outside my understanding.

Preview7.2 on nuget has this fix already (this is the only change from 7.1, so its the same CI Avalonia build here: 11.0.999-cibuild0034035-beta.