### PR TITLE
Preview8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0.999-cibuild0034035-beta</AvaloniaVersion>
+    <AvaloniaVersion>11.0-preview8</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.0.0-preview7.1</Version>
+    <Version>2.0.0-preview8</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ProgressBarStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ProgressBarStyles.axaml
@@ -81,13 +81,13 @@
                     <Style.Animations>
                         <Animation Duration="0:0:2" IterationCount="Infinite">
                             <KeyFrame KeyTime="0:0:0" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerAnimationStartPosition}" />
+                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerAnimationStartPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:1.5" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerAnimationEndPosition}" />
+                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerAnimationEndPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:2" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerAnimationEndPosition}" />
+                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerAnimationEndPosition}" />
                             </KeyFrame>
                         </Animation>
                     </Style.Animations>
@@ -96,13 +96,13 @@
                     <Style.Animations>
                         <Animation Duration="0:0:2" IterationCount="Infinite">
                             <KeyFrame KeyTime="0:0:0" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2AnimationStartPosition}" />
+                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2AnimationStartPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:0.75" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2AnimationStartPosition}" />
+                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2AnimationStartPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:2" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2AnimationEndPosition}" />
+                                <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2AnimationEndPosition}" />
                             </KeyFrame>
                         </Animation>
                     </Style.Animations>
@@ -110,11 +110,11 @@
             </Style>
 
             <Style Selector="^ /template/ Border#IndeterminateProgressBarIndicator">
-                <Setter Property="Width" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerWidth}" />
+                <Setter Property="Width" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerWidth}" />
                 <Setter Property="Height" Value="NaN" />
             </Style>
             <Style Selector="^ /template/ Border#IndeterminateProgressBarIndicator2">
-                <Setter Property="Width" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2Width}" />
+                <Setter Property="Width" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2Width}" />
                 <Setter Property="Height" Value="NaN" />
             </Style>
         </Style>
@@ -139,13 +139,13 @@
                     <Style.Animations>
                         <Animation Duration="0:0:2" IterationCount="Infinite">
                             <KeyFrame KeyTime="0:0:0" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerAnimationStartPosition}" />
+                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerAnimationStartPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:1.5" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerAnimationEndPosition}" />
+                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerAnimationEndPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:2" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerAnimationEndPosition}" />
+                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerAnimationEndPosition}" />
                             </KeyFrame>
                         </Animation>
                     </Style.Animations>
@@ -154,13 +154,13 @@
                     <Style.Animations>
                         <Animation Duration="0:0:2" IterationCount="Infinite">
                             <KeyFrame KeyTime="0:0:0" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2AnimationStartPosition}" />
+                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2AnimationStartPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:0.75" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2AnimationStartPosition}" />
+                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2AnimationStartPosition}" />
                             </KeyFrame>
                             <KeyFrame KeyTime="0:0:2" KeySpline="0.4,0,0.6,1">
-                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2AnimationEndPosition}" />
+                                <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2AnimationEndPosition}" />
                             </KeyFrame>
                         </Animation>
                     </Style.Animations>
@@ -168,11 +168,11 @@
             </Style>
 
             <Style Selector="^ /template/ Border#IndeterminateProgressBarIndicator">
-                <Setter Property="Height" Value="{Binding $parent[ProgressBar].TemplateProperties.ContainerWidth}" />
+                <Setter Property="Height" Value="{Binding $parent[ProgressBar].TemplateSettings.ContainerWidth}" />
                 <Setter Property="Width" Value="NaN" />
             </Style>
             <Style Selector="^ /template/ Border#IndeterminateProgressBarIndicator2">
-                <Setter Property="Height" Value="{Binding $parent[ProgressBar].TemplateProperties.Container2Width}" />
+                <Setter Property="Height" Value="{Binding $parent[ProgressBar].TemplateSettings.Container2Width}" />
                 <Setter Property="Width" Value="NaN" />
             </Style>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/FAComboBox/FAComboBoxStyles.axaml
@@ -38,6 +38,7 @@
                 <VirtualizingStackPanel />
             </ItemsPanelTemplate>
         </Setter>
+        <Setter Property="PlaceholderForeground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid Name="LayoutRoot"
@@ -103,7 +104,7 @@
 							   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 							   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 							   Text="{TemplateBinding PlaceholderText}"
-							   Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForeground}}" />
+                               IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
 
                     <TextBox Name="EditableText"
 							 Grid.Row="1"
@@ -116,7 +117,7 @@
 							 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 							 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 							 Watermark="{TemplateBinding PlaceholderText}"
-							 Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={DynamicResource ComboBoxPlaceHolderForeground}}"
+							 Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}"
 							 Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Text, Mode=TwoWay}"
 							 IsVisible="False"
 							 AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
@@ -178,6 +179,13 @@
                 </Grid>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+            <Setter Property="Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}" />
+        </Style>
+        <Style Selector="^ /template/ TextBox#EditableText">
+            <Setter Property="Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}" />
+        </Style>
 
         <Style Selector="^:pointerover">
             <Style Selector="^ /template/ Border#Background">
@@ -285,6 +293,11 @@
 				             ^:dropdownopen /template/ TextBox#EditableText">
                 <Setter Property="IsVisible" Value="True" />
                 <Setter Property="Width" Value="NaN" />
+            </Style>
+
+            <Style Selector="^:focus-within /template/ TextBlock#PlaceholderTextBlock
+                             ^:dropdownopen /template/ TextBlock#PlaceholderTextBlock">
+                <Setter Property="IsVisible" Value="False" />
             </Style>
 
             <Style Selector="^:dropdownopen /template/ ContentPresenter#ContentPresenter,

--- a/src/FluentAvalonia/UI/Controls/ColorPicker/ColorSpectrum.cs
+++ b/src/FluentAvalonia/UI/Controls/ColorPicker/ColorSpectrum.cs
@@ -29,6 +29,8 @@ public partial class ColorSpectrum : ColorPickerComponent
         MinHeight = 150;
         MaxWidth = 500;
         MaxHeight = 500;
+
+        RenderOptions.SetBitmapInterpolationMode(this, BitmapInterpolationMode.HighQuality);
     }
 
     static ColorSpectrum()
@@ -47,7 +49,7 @@ public partial class ColorSpectrum : ColorPickerComponent
         {
             if (Shape == ColorSpectrumShape.Spectrum)
             {
-                context.DrawImage(_tempBitmap, new Rect(_tempBitmap.Size), rect, BitmapInterpolationMode.HighQuality);
+                context.DrawImage(_tempBitmap, new Rect(_tempBitmap.Size), rect);
 
                 RenderSelectorRects(context, rect.Width, rect.Height);
 
@@ -70,7 +72,7 @@ public partial class ColorSpectrum : ColorPickerComponent
                 // Value by drawing a Black ellipse behind the image and the using the Value as the opacity
                 // to draw the bitmap
                 using (context.PushOpacity(Color.Valuef, rect))
-                    context.DrawImage(_tempBitmap, new Rect(_tempBitmap.Size), _lastWheelRect, BitmapInterpolationMode.HighQuality);
+                    context.DrawImage(_tempBitmap, new Rect(_tempBitmap.Size), _lastWheelRect);
             }
             else if (Shape == ColorSpectrumShape.Triangle)
             {
@@ -82,7 +84,7 @@ public partial class ColorSpectrum : ColorPickerComponent
                     CreateBitmap();
                 }
 
-                context.DrawImage(_tempBitmap, new Rect(_tempBitmap.Size), _lastWheelRect, BitmapInterpolationMode.HighQuality);
+                context.DrawImage(_tempBitmap, new Rect(_tempBitmap.Size), _lastWheelRect);
 
                 RenderTriangleSelector(context);
             }

--- a/src/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBar/CommandBarOverflowPresenter.cs
@@ -35,8 +35,11 @@ public class CommandBarOverflowPresenter : ItemsControl, IStyleable
         }
     }
 
-    protected override bool IsItemItsOwnContainerOverride(Control item) =>
-        item is ICommandBarElement;
+    protected override bool NeedsContainerOverride(object item, int index, out object recycleKey)
+    {
+        recycleKey = null;
+        return !(item is ICommandBarElement);
+    }
 
     private void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {

--- a/src/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
+++ b/src/FluentAvalonia/UI/Controls/FAComboBox/FAComboBox.cs
@@ -131,10 +131,16 @@ public partial class FAComboBox : HeaderedSelectingItemsControl
         }
     }
 
-    protected override Control CreateContainerForItemOverride() => new FAComboBoxItem();
+    protected override Control CreateContainerForItemOverride(object item, int index, object recycleKey)
+    {
+        return new FAComboBoxItem();
+    }
 
-    protected override bool IsItemItsOwnContainerOverride(Control item) =>
-        item is FAComboBoxItem;
+    protected override bool NeedsContainerOverride(object item, int index, out object recycleKey)
+    {
+        recycleKey = nameof(FAComboBoxItem);
+        return item is FAComboBoxItem;
+    }
 
     public override void InvalidateMirrorTransform()
     {

--- a/src/FluentAvalonia/UI/Controls/IconElement/BitmapIcon.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/BitmapIcon.cs
@@ -10,6 +10,11 @@ namespace FluentAvalonia.UI.Controls;
 
 public partial class BitmapIcon : FAIconElement
 {
+    public BitmapIcon()
+    {
+        RenderOptions.SetBitmapInterpolationMode(this, BitmapInterpolationMode.HighQuality);
+    }
+
     ~BitmapIcon()
     {
         Dispose();
@@ -95,7 +100,7 @@ public partial class BitmapIcon : FAIconElement
 
             using (context.PushClip(dst))
             {
-                context.DrawImage(bmp, new Rect(bmp.Size), dst, BitmapInterpolationMode.HighQuality);
+                context.DrawImage(bmp, new Rect(bmp.Size), dst);
             }
         }
     }

--- a/src/FluentAvalonia/UI/Controls/IconElement/ImageIcon.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/ImageIcon.cs
@@ -10,6 +10,11 @@ namespace FluentAvalonia.UI.Controls;
 /// </summary>
 public class ImageIcon : FAIconElement
 {
+    public ImageIcon()
+    {
+        RenderOptions.SetBitmapInterpolationMode(this, BitmapInterpolationMode.HighQuality);
+    }
+
     /// <summary>
     /// Defines the <see cref="Source"/> property
     /// </summary>
@@ -58,7 +63,7 @@ public class ImageIcon : FAIconElement
             Rect srcRect = new Rect(src.Size)
                 .CenterRect(new Rect(destRect.Size / scale));
 
-            context.DrawImage(src, srcRect, destRect, BitmapInterpolationMode.HighQuality);
+            context.DrawImage(src, srcRect, destRect);
         }
     }
 }

--- a/src/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
+++ b/src/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
@@ -64,14 +65,31 @@ public class FAMenuFlyoutPresenter : MenuBase, IStyleable
         throw new NotSupportedException("Use MenuFlyout.ShowAt(Control) instead");
     }
 
-    protected override bool IsItemItsOwnContainerOverride(Control item) => true;
+    protected override bool NeedsContainerOverride(object item, int index, out object recycleKey)
+    {
+        recycleKey = typeof(MenuFlyoutItem);
+        return !(item is MenuFlyoutItemBase);
+    }
 
-    protected override Control CreateContainerForItemOverride() =>
-        new MenuFlyoutItem();
+    protected override Control CreateContainerForItemOverride(object item, int index, object recycleKey)
+    {
+        var cont = this.FindDataTemplate(item, ItemTemplate)?.Build(item);
+
+        if (cont is MenuFlyoutItemBase mfib)
+        {
+            mfib.IsContainerFromTemplate = true;
+            return mfib;
+        }
+
+        return new MenuFlyoutItem();
+    }
 
     protected override void PrepareContainerForItemOverride(Control element, object item, int index)
     {
-        base.PrepareContainerForItemOverride(element, item, index);
+        var mfib = element as MenuFlyoutItemBase;
+
+        if (!mfib.IsContainerFromTemplate)
+            base.PrepareContainerForItemOverride(element, item, index);
 
         var iconCount = _iconCount;
         var toggleCount = _toggleCount;

--- a/src/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
+++ b/src/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
@@ -12,6 +12,8 @@ public class MenuFlyoutItemBase : TemplatedControl
         FocusableProperty.OverrideDefaultValue<MenuFlyoutItemBase>(true);
     }
 
+    internal bool IsContainerFromTemplate { get; set; }
+
     protected override void OnPointerEntered(PointerEventArgs e)
     {
         base.OnPointerEntered(e);

--- a/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpanderItem.properties.cs
@@ -172,6 +172,8 @@ public partial class SettingsExpanderItem : ContentControl
         remove => RemoveHandler(ClickEvent, value);
     }
 
+    internal bool IsContainerFromTemplate { get; set; }
+
     private const string s_pcDescription = ":description";
     private const string s_pcContent = ":content";
     private const string s_pcActionIcon = ":actionIcon";

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
@@ -97,6 +97,9 @@ public partial class TabViewItem
     /// </summary>
     public event TypedEventHandler<TabViewItem, TabViewTabCloseRequestedEventArgs> CloseRequested;
 
+    internal bool IsContainerFromTemplate { get; set; }
+
+
     private const string s_pcForeground = ":foreground";
     private const string s_pcCloseCollapsed = ":closecollapsed";
 

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -120,11 +120,26 @@ public class TabViewListView : ListBox
         }
     }
 
-    protected override bool IsItemItsOwnContainerOverride(Control item) =>
-        item is TabViewItem;
+    protected override bool NeedsContainerOverride(object item, int index, out object recycleKey)
+    {
+        bool isItem = item is TabViewItem;
+        recycleKey = isItem ? null : nameof(TabViewItem);
+        return !isItem;
+    }
 
-    protected override Control CreateContainerForItemOverride() => new TabViewItem();
-        
+    protected override Control CreateContainerForItemOverride(object item, int index, object recycleKey)
+    {
+        var cont = this.FindDataTemplate(item, ItemTemplate)?.Build(item);
+
+        if (cont is TabViewItem tvi)
+        {
+            tvi.IsContainerFromTemplate = true;
+            return tvi;
+        }
+
+        return new TabViewItem();
+    }
+
     protected override void PrepareContainerForItemOverride(Control element, object item, int index)
     {
         var tvi = element as TabViewItem;
@@ -147,7 +162,7 @@ public class TabViewListView : ListBox
 
         // Special b/c we use the header and not Content. Somehow this *just works* in
         // WinUI b/c they don't have to do this.
-        if (element == item)
+        if (element == item || tvi.IsContainerFromTemplate)
             return;
 
         tvi.Header = item;


### PR DESCRIPTION
Updates to Avalonia 11.0-preview 8 along with these fixes:

- Fixed issue with `FAComboBox` textbox foreground. This was caused by `TargetNullValue` not respecting DynamicResource and `PlaceholderForeground` not being set by default (following WinUI). Fixed by including a Setter for `PlaceholderForeground` (fixes #360)
- Fixed issue with `FAComboBox` where Placeholder text (watermark) was visible when it wasn't supposed to be
- Made adjustments to `FAMenuFlyoutPresenter`, `TabView`, and `SettingsExpander` to align with new ItemsControl API for heterogeneous containers, see below

From 7.2- fixed issue with SettingsExpander when trimming is enabled

BONUS!
In preview5, the ability to use a DataTemplate to create a container for some controls was lost with the new ItemsControl. The most recent changes that allowed different container types made it once again possible to do this. For `TabView` and `SettingsExpander`, it is now (again) possible to do this (same applies to SettingsExpander):

```xaml
<ui:TabView>
    <ui:TabView.ItemTemplate>
        <DataTemplate DataType="myType">
            <ui:TabViewItem Header="{Binding MyHeader}" Content="{Binding MyContent}" ... />
        </DataTemplate>
    </ui:TabView.ItemTemplate>
</ui:TabView>
```

I hacked around that limitation in FAMenuFlyoutPresenter by force creating all containers on the flyout and then passing them to the presenter when the flyout opened (as this was a more complicated scenario), so technically this isn't as affected. I haven't undone that hack yet, will do that in a future PR.

Note that you don't have to do this, and can use the DataTemplate only for the content, the item generator will still create a container for you and use your data template for the Content only. DataTemplates can also be supplied in `DataTemplates` for implicit lookup and not just on `ItemTemplate` property of the ItemsControl.



