### PR TITLE
Breaking change updates

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CaptionButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CaptionButtonStyles.axaml
@@ -47,7 +47,7 @@
                           </Viewbox>
                       </Button>
                       
-                      <Button x:Name="PART_MinimiseButton"
+                      <Button x:Name="PART_MinimizeButton"
                               Theme="{StaticResource FluentCaptionButton}">
                           <Viewbox Width="11" Margin="2">
                               <Path Stretch="UniformToFill"
@@ -92,7 +92,7 @@
         <Style Selector="^:fullscreen /template/ Panel#PART_RestoreButton">
             <Setter Property="IsVisible" Value="False" />
         </Style>
-        <Style Selector="^:fullscreen /template/ Panel#PART_MinimiseButton">
+        <Style Selector="^:fullscreen /template/ Panel#PART_MinimizeButton">
             <Setter Property="IsVisible" Value="False" />
         </Style>
     </ControlTheme>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPicker.axaml
@@ -134,8 +134,8 @@
                       <primitives:ColorSlider x:Name="ColorSpectrumThirdComponentSlider"
                                               AutomationProperties.Name="Third Component"
                                               Grid.Column="0"
-                                              IsAlphaMaxForced="True"
-                                              IsSaturationValueMaxForced="False"
+                                              IsAlphaVisible="False"
+                                              IsPerceptive="True"
                                               Orientation="Vertical"
                                               ColorModel="Hsva"
                                               ColorComponent="{Binding ThirdComponent, ElementName=ColorSpectrum}"
@@ -513,11 +513,11 @@
                   </TabItem>
                 </TabControl>
                 <!-- Previewer -->
-                <!-- Note that top/bottom margins have -5 to remove for drop shadow padding -->
+                <!-- Note that the drop shadow is allowed to extend past the control bounds -->
                 <primitives:ColorPreviewer Grid.Row="1"
                                            HsvColor="{Binding HsvColor, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                            IsAccentColorsVisible="{TemplateBinding IsAccentColorsVisible}"
-                                           Margin="12,-5,12,7"
+                                           Margin="12,0,12,12"
                                            IsVisible="{TemplateBinding IsColorPreviewVisible}" />
               </Grid>
             </Flyout>
@@ -525,6 +525,23 @@
         </DropDownButton>
       </ControlTemplate>
     </Setter>
+
+    <!--
+    <Style Selector="^ /template/ primitives|ColorSlider#ColorSpectrumThirdComponentSlider[ColorComponent=Component1]">
+      <Setter Property="IsPerceptive" Value="True" />
+    </Style>
+
+    <Style Selector="^ /template/ primitives|ColorSlider#Component1Slider[ColorModel=Rgba]">
+      <Setter Property="IsPerceptive" Value="False" />
+    </Style>
+    <Style Selector="^ /template/ primitives|ColorSlider#Component2Slider[ColorModel=Rgba]">
+      <Setter Property="IsPerceptive" Value="False" />
+    </Style>
+    <Style Selector="^ /template/ primitives|ColorSlider#Component3Slider[ColorModel=Rgba]">
+      <Setter Property="IsPerceptive" Value="False" />
+    </Style>
+    -->
+
   </ControlTheme>
 
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPreviewer.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorPreviewer.axaml
@@ -9,7 +9,9 @@
 
   <ControlTheme x:Key="{x:Type ColorPreviewer}"
                 TargetType="ColorPreviewer">
-    <Setter Property="Height" Value="70" />
+    <Setter Property="Height" Value="50" />
+    <!-- The preview color drop shadow is allowed to extend outside the control bounds -->
+    <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Template">
       <ControlTemplate TargetType="{x:Type ColorPreviewer}">
@@ -22,7 +24,6 @@
                   Height="{StaticResource ColorPreviewerAccentSectionHeight}"
                   Width="{StaticResource ColorPreviewerAccentSectionWidth}"
                   ColumnDefinitions="*,*"
-                  Margin="0,0,-10,0"
                   VerticalAlignment="Center">
               <Border Grid.Column="0"
                       Grid.ColumnSpan="2"
@@ -44,7 +45,6 @@
                   Height="{StaticResource ColorPreviewerAccentSectionHeight}"
                   Width="{StaticResource ColorPreviewerAccentSectionWidth}"
                   ColumnDefinitions="*,*"
-                  Margin="-10,0,0,0"
                   VerticalAlignment="Center">
               <Border Grid.Column="0"
                       Grid.ColumnSpan="2"
@@ -65,10 +65,8 @@
             <Border Grid.Column="1"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
-                    Background="Transparent"
                     BoxShadow="0 0 10 2 #BF000000"
-                    CornerRadius="{TemplateBinding CornerRadius}"
-                    Margin="10">
+                    CornerRadius="{TemplateBinding CornerRadius}">
               <Panel>
                 <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
                         CornerRadius="{TemplateBinding CornerRadius}" />
@@ -83,8 +81,7 @@
           <Border CornerRadius="{TemplateBinding CornerRadius}"
                   IsVisible="{TemplateBinding IsAccentColorsVisible, Converter={x:Static BoolConverters.Not}}"
                   HorizontalAlignment="Stretch"
-                  VerticalAlignment="Stretch"
-                  Margin="0,10,0,10">
+                  VerticalAlignment="Stretch">
             <Panel>
               <Border Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
                       CornerRadius="{TemplateBinding CornerRadius}" />

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ColorPicker/ColorView.axaml
@@ -292,8 +292,8 @@
                 <primitives:ColorSlider x:Name="ColorSpectrumThirdComponentSlider"
                                         AutomationProperties.Name="Third Component"
                                         Grid.Column="0"
-                                        IsAlphaMaxForced="True"
-                                        IsSaturationValueMaxForced="False"
+                                        IsAlphaVisible="False"
+                                        IsPerceptive="True"
                                         Orientation="Vertical"
                                         ColorModel="Hsva"
                                         ColorComponent="{Binding ThirdComponent, ElementName=ColorSpectrum}"
@@ -671,15 +671,32 @@
             </TabItem>
           </TabControl>
           <!-- Previewer -->
-          <!-- Note that top/bottom margins have -5 to remove for drop shadow padding -->
+          <!-- Note that the drop shadow is allowed to extend past the control bounds -->
           <primitives:ColorPreviewer Grid.Row="1"
                                      HsvColor="{Binding HsvColor, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                      IsAccentColorsVisible="{TemplateBinding IsAccentColorsVisible}"
-                                     Margin="12,-5,12,7"
+                                     Margin="12,0,12,12"
                                      IsVisible="{TemplateBinding IsColorPreviewVisible}" />
         </Grid>
       </ControlTemplate>
     </Setter>
+
+    <!--
+    <Style Selector="^ /template/ primitives|ColorSlider#ColorSpectrumThirdComponentSlider[ColorComponent=Component1]">
+      <Setter Property="IsPerceptive" Value="True" />
+    </Style>
+
+    <Style Selector="^ /template/ primitives|ColorSlider#Component1Slider[ColorModel=Rgba]">
+      <Setter Property="IsPerceptive" Value="False" />
+    </Style>
+    <Style Selector="^ /template/ primitives|ColorSlider#Component2Slider[ColorModel=Rgba]">
+      <Setter Property="IsPerceptive" Value="False" />
+    </Style>
+    <Style Selector="^ /template/ primitives|ColorSlider#Component3Slider[ColorModel=Rgba]">
+      <Setter Property="IsPerceptive" Value="False" />
+    </Style>
+    -->
+
   </ControlTheme>
 
 </ResourceDictionary>


### PR DESCRIPTION
Updates for some breaking changes I made upstream:

 * ColorPicker updates for ColorSlider and ColorPreviewer
 * CaptionButtons template part rename

**WARNING** This requires an update of the Avalonia reference to a current nightly build. This PR is not meant to be merged until FluentAvalonia itself updates to a newer version of Avalonia.