### PR TITLE
Fix default value of Maximum and Minimum

### DIFF
--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
@@ -63,6 +63,7 @@ public partial class NumberBox
     public static readonly StyledProperty<double> MinimumProperty =
         RangeBase.MinimumProperty.AddOwner<NumberBox>(
             new StyledPropertyMetadata<double>(
+                defaultValue: double.MinValue,
                 coerce: (ao, d1) =>
                 {
                     var nb = ao as NumberBox;
@@ -79,6 +80,7 @@ public partial class NumberBox
     public static readonly StyledProperty<double> MaximumProperty =
         RangeBase.MaximumProperty.AddOwner<NumberBox>(
             new StyledPropertyMetadata<double>(
+                defaultValue: double.MaxValue,
                 coerce: (ao, d1) =>
                 {
                     var nb = ao as NumberBox;


### PR DESCRIPTION
Fixes #374. When NumberBox was switched from Direct->Styled properties, the default value of Maximum and Minimum were changed to the inherited values from RangeBase. Updates the values to be `double.MinValue` and `double.MaxValue` to match WinUI