### PR TITLE
SettingsExpander fixes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderItemStyles.axaml
@@ -158,10 +158,16 @@
             </Style>           
         </Style>
         
-        <Style Selector="^:disabled /template/ ui|FABorder#Root">
-            <Setter Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
-            <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+        <Style Selector="^:disabled">            
+            <Style Selector="^ /template/ ui|FABorder#Root">
+                <Setter Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+            </Style>
+
+            <Style Selector="^ /template/ TextBlock#DescriptionText">
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+            </Style>
         </Style>
     </ControlTheme>    
 </ResourceDictionary>

--- a/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.cs
+++ b/src/FluentAvalonia/UI/Controls/SettingsExpander/SettingsExpander.cs
@@ -178,8 +178,9 @@ public partial class SettingsExpander : HeaderedItemsControl, ICommandSource
 
     protected override Size MeasureOverride(Size availableSize)
     {
+        var sz = base.MeasureOverride(availableSize);
         SetIcons();
-        return base.MeasureOverride(availableSize);
+        return sz;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes two issues with SettingsExpander:
- Fixes #370. Foreground setters are using `TextElement.Foreground` so that all elements are affected and multiple Selectors aren't needed, but Description has it's own Foreground set in the template which has higher priority than the inherited value. Fixed by adding a separate Selector for description text
- Fixes #369. Not sure whether this slipped through or regressed, but fixed by ensuring the measure pass completes on SettingsExpander and then adjusting icons on child items as necessary. Previously, it was adjusting icons and then measuring, which didn't account for new generated containers.