### PR TITLE
Fix NRE in TaskDialog.ShowAsync() when there is no focused control

### DIFF
--- a/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -272,7 +272,7 @@ public partial class TaskDialog : ContentControl
         OnClosed();
         _host = null;
 
-        _previousFocus.Focus();
+        _previousFocus?.Focus();
 
         return result ?? TaskDialogStandardResult.None;
     }


### PR DESCRIPTION
![image](https://github.com/amwx/FluentAvalonia/assets/1139118/1d88672c-1a77-48e3-9beb-6922dd30a200)
