### PR TITLE
Corner Radius and DynamicResource Changes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
@@ -258,6 +258,7 @@
     </ControlTheme>
 
     <ControlTheme TargetType="ComboBoxItem" x:Key="{x:Type ComboBoxItem}">
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForeground}" />
         <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackground}" />
         <Setter Property="Padding" Value="{DynamicResource ComboBoxItemThemePadding}" />
@@ -279,7 +280,7 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Margin="5,2,5,2"
-                        CornerRadius="{DynamicResource ControlCornerRadius}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
                         TemplatedControl.IsTemplateFocusTarget="True">
                     <Panel>
                         <Rectangle Name="Pill"
@@ -295,6 +296,7 @@
                                           Margin="{TemplateBinding Padding}"
                                           Background="{x:Null}"
                                           BorderBrush="{x:Null}"
+                                          CornerRadius="{TemplateBinding CornerRadius}"
                                           BorderThickness="0"/>
                     </Panel>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ListBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ListBoxStyles.axaml
@@ -57,6 +57,7 @@
         <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="Background" Value="{DynamicResource ListViewItemBackground}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
         <Setter Property="Padding" Value="16,0,12,0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -75,7 +76,7 @@
                                       Padding="{TemplateBinding Padding}"
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                      CornerRadius="{DynamicResource ControlCornerRadius}"
+                                      CornerRadius="{TemplateBinding CornerRadius}"
 									  Margin="2"/>
 
                     <!-- added 1px left margin, otherwise we can get strange artifacts while

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewBackButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewBackButtonStyles.axaml
@@ -18,6 +18,7 @@
 
     <ControlTheme x:Key="NavigationBackButtonNormalStyle" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource NavigationViewBackButtonBackground}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Foreground" Value="{DynamicResource NavigationViewItemForeground}" />
         <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
         <Setter Property="FontSize" Value="16" />
@@ -31,7 +32,7 @@
             <ControlTemplate>
                 <Border Name="Root"
                         Background="{TemplateBinding Background}"
-                        CornerRadius="{DynamicResource ControlCornerRadius}">
+                        CornerRadius="{TemplateBinding CornerRadius}">
                     <ui:FontIcon Name="Content"
                                  FontSize="{TemplateBinding FontSize}"
                                  FontFamily="{TemplateBinding FontFamily}"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemStyles.axaml
@@ -33,10 +33,10 @@
                             <Setter Property="Theme" Value="{StaticResource NavViewFlyoutStyle}" />
                         </Style>
                     </Grid.Styles>
-                    
+
                     <uip:NavigationViewItemPresenter Name="NVIPresenter"
                                                      IconSource="{TemplateBinding IconSource}"
-													 InfoBadge="{TemplateBinding InfoBadge}"
+                                                     InfoBadge="{TemplateBinding InfoBadge}"
                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
                                                      Padding="{TemplateBinding Padding}"
                                                      Foreground="{TemplateBinding Foreground}"
@@ -73,12 +73,12 @@
         </Style>
 
         <Style Selector="^:topnav /template/ uip|NavigationViewItemPresenter">
-            <Setter Property="Theme" Value="{StaticResource NavigationViewItemPresenterWhenOnTopPane}" />
+            <Setter Property="Theme" Value="{DynamicResource NavigationViewItemPresenterWhenOnTopPane}" />
         </Style>
 
         <Style Selector="^:topoverflow /template/ uip|NavigationViewItemPresenter">
-            <Setter Property="Theme" Value="{StaticResource NavigationViewItemPresenterWhenOnTopPaneOverflow}" />
+            <Setter Property="Theme" Value="{DynamicResource NavigationViewItemPresenterWhenOnTopPaneOverflow}" />
         </Style>
     </ControlTheme>
-    
+
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderItemStyles.axaml
@@ -9,7 +9,7 @@
                 <ui:SettingsExpander.Footer>
                     <Button Content="FooterButton" />
                 </ui:SettingsExpander.Footer>
-                
+
                 <ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
                 <ui:SettingsExpanderItem Content="Content Here">
                     <ui:SettingsExpanderItem.Footer>
@@ -62,7 +62,7 @@
                         </Viewbox>
 
                         <StackPanel HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"                                    
+                                    VerticalAlignment="Center"
                                     Name="HeaderRegion">
                             <ContentPresenter Content="{TemplateBinding Content}"
                                               ContentTemplate="{TemplateBinding ContentTemplate}"


### PR DESCRIPTION
 1. Use TemplateBinding for CornerRadius in more control themes. This allows apps to more easily customize the radius because it isn't hardcoded within the template
 2. Switch some StaticResource to DynamicResource to allow apps to customize NavigationViewItemPresenterWhenOnTop.