### PR TITLE
Fix TextBoxDeleteButtonStyle

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBoxStyles.axaml
@@ -31,7 +31,7 @@
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Background="Transparent"
                         CornerRadius="{TemplateBinding CornerRadius}">
-                    <ui:SymbolIcon Foreground="{StaticResource TextControlButtonForeground}"
+                    <ui:SymbolIcon Foreground="{DynamicResource TextControlButtonForeground}"
                                    VerticalAlignment="Center"
                                    HorizontalAlignment="Center"
                                    FontSize="{StaticResource TextBoxIconFontSize}"


### PR DESCRIPTION
The TextBox's InnerRightContent clear/delete button has an issue with Foreground color in dark mode. This is set using a control theme (shared several places) and currently appears as below:

**TextBox**

![image](https://github.com/amwx/FluentAvalonia/assets/17993847/c0ef0c6f-1a74-4632-bf29-589e2bb9953a)

**NumberBox**

![image](https://github.com/amwx/FluentAvalonia/assets/17993847/cbb1e1b2-bfa5-4890-9278-2003c5c5dfe9)

As can be seen above this should be white instead of black in dark mode. This PR fixes that so the foreground of the SymbolIcon is correct on initial load into dark theme and then stays correct across theme variant changes.

![image](https://github.com/amwx/FluentAvalonia/assets/17993847/df296eea-e8ea-46aa-bdc3-4a23cd138bd3)
