### PR TITLE
Upgrade Avalonia to 11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0-rc1.1</AvaloniaVersion>
+    <AvaloniaVersion>11.0-rc2.2</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0-rc2.2</AvaloniaVersion>
+    <AvaloniaVersion>11.0</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/samples/FAControlsGallery/Controls/ControlExample.cs
+++ b/samples/FAControlsGallery/Controls/ControlExample.cs
@@ -117,9 +117,9 @@ public class ControlExample : HeaderedContentControl
         PseudoClasses.Set(":usagenotes", hasNotes);
     }
 
-    protected override void OnLoaded()
+    protected override void OnLoaded(RoutedEventArgs e)
     {
-        base.OnLoaded();
+        base.OnLoaded(e);
 
         // Do this here rather than OnApplyTemplate, otherwise this will animate
         // on load and that isn't desired

--- a/samples/FAControlsGallery/Pages/ControlsPageBase.cs
+++ b/samples/FAControlsGallery/Pages/ControlsPageBase.cs
@@ -224,16 +224,16 @@ public class ControlsPageBase : UserControl
         }
     }
 
-    protected override void OnLoaded()
+    protected override void OnLoaded(RoutedEventArgs e)
     {
-        base.OnLoaded();
+        base.OnLoaded(e);
         _hasLoaded = true;
         SetDetailsAnimation();
     }
 
-    protected override void OnUnloaded()
+    protected override void OnUnloaded(RoutedEventArgs e)
     {
-        base.OnUnloaded();
+        base.OnUnloaded(e);
         _hasLoaded = false;
     }
 

--- a/samples/FAControlsGallery/Pages/DesignPage.axaml.cs
+++ b/samples/FAControlsGallery/Pages/DesignPage.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using FAControlsGallery.Pages.DesignPages;
 using FAControlsGallery.ViewModels.DesignPages;
 using FluentAvalonia.UI.Media.Animation;
@@ -14,9 +15,9 @@ public partial class DesignPage : UserControl
         TabStrip1.SelectionChanged += TabStrip1SelectionChanged;
     }
 
-    protected override void OnLoaded()
+    protected override void OnLoaded(RoutedEventArgs e)
     {
-        base.OnLoaded();
+        base.OnLoaded(e);
 
         TabStrip1SelectionChanged(null, null);
     }

--- a/samples/FAControlsGallery/Pages/FAControlsOverviewPage.axaml
+++ b/samples/FAControlsGallery/Pages/FAControlsOverviewPage.axaml
@@ -65,9 +65,7 @@
                             BorderThickness="{TemplateBinding BorderThickness}">
                         <ItemsPresenter Name="PART_ItemsPresenter"
                                         ItemsPanel="{TemplateBinding ItemsPanel}"
-                                        Margin="{TemplateBinding Padding}"
-                                        AreVerticalSnapPointsRegular="{TemplateBinding AreVerticalSnapPointsRegular}"
-                                        AreHorizontalSnapPointsRegular="{TemplateBinding AreHorizontalSnapPointsRegular}"/>
+                                        Margin="{TemplateBinding Padding}"/>
                     </Border>
                 </ControlTemplate>
             </Setter>

--- a/samples/FAControlsGallery/Pages/SettingsPage.axaml.cs
+++ b/samples/FAControlsGallery/Pages/SettingsPage.axaml.cs
@@ -18,9 +18,9 @@ public partial class SettingsPage : UserControl
         LaunchRepoLinkItem.Click += LaunchRepoLinkItemClick;
     }
 
-    protected override void OnLoaded()
+    protected override void OnLoaded(RoutedEventArgs e)
     {
-        base.OnLoaded();
+        base.OnLoaded(e);
 
         var dc = DataContext as SettingsPageViewModel;
         dc.CurrentAppTheme = Application.Current.ActualThemeVariant;

--- a/samples/FAControlsGallery/Views/MainAppSplashContent.axaml.cs
+++ b/samples/FAControlsGallery/Views/MainAppSplashContent.axaml.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Rendering.Composition;
 using Avalonia.Rendering.Composition.Animations;
 using Avalonia.Threading;
@@ -13,9 +14,9 @@ public partial class MainAppSplashContent : UserControl
         InitializeComponent();
     }
 
-    protected override void OnLoaded()
+    protected override void OnLoaded(RoutedEventArgs e)
     {
-        base.OnLoaded();
+        base.OnLoaded(e);
 
         if (!Design.IsDesignMode)
         {
@@ -39,16 +40,16 @@ public partial class MainAppSplashContent : UserControl
         grad4.Opacity = 0;
 
         // GRADIENT BAR ANIMATION
-        grad1.CenterPoint = new Vector3(grad1.Size.X / 2f, grad1.Size.Y / 2f, grad1.CenterPoint.Z);
+        grad1.CenterPoint = new Vector3((float) (grad1.Size.X / 2f), (float) (grad1.Size.Y / 2f), (float) grad1.CenterPoint.Z);
         grad1.StartAnimationGroup(GetGradientBarAnimation(comp, 1));
 
-        grad2.CenterPoint = new Vector3(grad2.Size.X / 2f, grad2.Size.Y / 2f, grad2.CenterPoint.Z);
+        grad2.CenterPoint = new Vector3((float) grad2.Size.X / 2f, (float) grad2.Size.Y / 2f, (float) grad2.CenterPoint.Z);
         grad2.StartAnimationGroup(GetGradientBarAnimation(comp, 2));
 
-        grad3.CenterPoint = new Vector3(grad3.Size.X / 2f, grad3.Size.Y / 2f, grad3.CenterPoint.Z);
+        grad3.CenterPoint = new Vector3((float) grad3.Size.X / 2f, (float) grad3.Size.Y / 2f, (float) grad3.CenterPoint.Z);
         grad3.StartAnimationGroup(GetGradientBarAnimation(comp, 3));
 
-        grad4.CenterPoint = new Vector3(grad4.Size.X / 2f, grad4.Size.Y / 2f, grad4.CenterPoint.Z);
+        grad4.CenterPoint = new Vector3((float) grad4.Size.X / 2f, (float) grad4.Size.Y / 2f, (float) grad4.CenterPoint.Z);
         grad4.StartAnimationGroup(GetGradientBarAnimation(comp, 4));
 
         // BLOCKS
@@ -70,7 +71,7 @@ public partial class MainAppSplashContent : UserControl
         // FA
         var fa = ElementComposition.GetElementVisual(FA);
         fa.Opacity = 0;
-        fa.CenterPoint = new Vector3(fa.Size.X / 2f, fa.Size.Y / 2f - (fa.Size.Y * 0.1f), fa.CenterPoint.Z);
+        fa.CenterPoint = new Vector3((float) fa.Size.X / 2f,(float)  (fa.Size.Y / 2f - (fa.Size.Y * 0.1f)), (float) fa.CenterPoint.Z);
         fa.StartAnimationGroup(GetFAAnimation(comp));
     }
 

--- a/samples/FAControlsGallery/Views/MainView.axaml.cs
+++ b/samples/FAControlsGallery/Views/MainView.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.Threading;
@@ -85,9 +86,9 @@ public partial class MainView : UserControl
         NavView.BackRequested += OnNavigationViewBackRequested;        
     }
 
-    protected override void OnLoaded()
+    protected override void OnLoaded(RoutedEventArgs e)
     {
-        base.OnLoaded();
+        base.OnLoaded(e);
 
         if (VisualRoot is AppWindow aw)
         {

--- a/src/FluentAvalonia/UI/Controls/Experimental/ConnectedAnimation.cs
+++ b/src/FluentAvalonia/UI/Controls/Experimental/ConnectedAnimation.cs
@@ -110,9 +110,10 @@ public class ConnectedAnimation
         var offsetAnim = comp.CreateVector3KeyFrameAnimation();
         offsetAnim.Target = "Offset";
         offsetAnim.Duration = duration;
-
-        offsetAnim.SetVector3Parameter("StartValue", destVis.Offset + delta);
-        offsetAnim.SetVector3Parameter("FinalValue", destVis.Offset);
+        
+        var offset = new Vector3((float)destVis.Offset.X, (float)destVis.Offset.Y, (float)destVis.Offset.Z);
+        offsetAnim.SetVector3Parameter("StartValue", offset + delta);
+        offsetAnim.SetVector3Parameter("FinalValue", offset);
         offsetAnim.InsertExpressionKeyFrame(0, "StartValue");
 
         if (Configuration is GravityConnectedAnimationConfiguration)
@@ -188,10 +189,12 @@ public class ConnectedAnimation
         group.Add(opacAnim);
 
         var offsetAnim = comp.CreateVector3KeyFrameAnimation();
+        var offset = new Vector3((float)destVis.Offset.X, (float)destVis.Offset.Y, (float)destVis.Offset.Z);
+        
         offsetAnim.Target = "Offset";
         offsetAnim.Duration = duration;
-        offsetAnim.SetVector3Parameter("StartValue", destVis.Offset + delta);
-        offsetAnim.SetVector3Parameter("FinalValue", destVis.Offset);
+        offsetAnim.SetVector3Parameter("StartValue", offset + delta);
+        offsetAnim.SetVector3Parameter("FinalValue", offset);
         offsetAnim.InsertExpressionKeyFrame(0, "StartValue");
         offsetAnim.InsertExpressionKeyFrame(1, "FinalValue", easing);
         group.Add(offsetAnim);

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -131,7 +131,7 @@ public partial class TabView : TemplatedControl
 
         UpdateListViewItemContainerTransitions();
 
-        OnLoaded();
+        OnLoaded(e);
     }
 
     protected override Size MeasureOverride(Size availableSize)

--- a/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/TaskDialog/TaskDialog.cs
@@ -101,9 +101,9 @@ public partial class TaskDialog : ContentControl
         return base.RegisterContentPresenter(presenter);
     }
 
-    protected override void OnLoaded()
+    protected override void OnLoaded(RoutedEventArgs e)
     {
-        base.OnLoaded();
+        base.OnLoaded(e);
 
         SetButtons();
         SetCommands();


### PR DESCRIPTION
Not much changed this build, but my client application did fail to open so I took a quick look.
All I did was remove `AreVerticalSnapPointsRegular` and added `RoutedEventArgs e` to `OnLoaded` and `OnUnloaded` overrides.
I didn't spend too much time on the vectors since they're in experimental code.

Related PRs:
https://github.com/AvaloniaUI/Avalonia/pull/11752
https://github.com/AvaloniaUI/Avalonia/pull/11768
https://github.com/AvaloniaUI/Avalonia/pull/11828