### PR TITLE
Fix the disabled color always applying to the tab strip items

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TabStripStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TabStripStyles.axaml
@@ -101,7 +101,7 @@
             <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
         </Style>
 
-        <Style Selector="^ /template/ Border#PART_LayoutRoot">
+        <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
         </Style>


### PR DESCRIPTION
There was a small mistake in the TabStrip style, the disabled style was missing it's `:disabled` selector, causing it to always apply.

## Before
![rider64_U1Fs2vZDiD](https://github.com/amwx/FluentAvalonia/assets/8858506/c6b76928-6a4e-42d5-8ade-43a69fc90e80)

## After
![rider64_1Fh8D4y9rD](https://github.com/amwx/FluentAvalonia/assets/8858506/7027d313-ab66-4568-9bbf-b1382f7738ac)
