### PR TITLE
FluentAvalonia v2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,8 @@
     <PackageVersion Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0-rc1.1" />
-    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0-rc1.1" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0" />
     
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.0.0-rc1</Version>
+    <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewItemPresenterStyles.axaml
@@ -20,12 +20,13 @@
         <Setter Property="BorderThickness" Value="{DynamicResource NavigationViewItemBorderThickness}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="LayoutRoot"
                         MinHeight="{DynamicResource NavigationViewItemOnLeftMinHeight}"
                         Background="{TemplateBinding Background}"
-                        CornerRadius="{DynamicResource OverlayCornerRadius}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
                         Margin="4,2,4,2"
                         TemplatedControl.IsTemplateFocusTarget="True">
 

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewStyles.axaml
@@ -227,7 +227,7 @@
                                         <!--x:Name="PaneContentGridToggleButtonRow"
                                              Removed & set only in TogglePaneButtonVisible VisualState...TODO
                                              MinHeight="{StaticResource NavigationViewPaneHeaderRowMinHeight}"-->
-                                        <RowDefinition Height="Auto"  />
+                                        <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="0" />
@@ -281,6 +281,12 @@
                                                     VerticalContentAlignment="Stretch"
                                                     HorizontalContentAlignment="Stretch"
                                                     Grid.Row="4" />
+                                    
+                                    <Rectangle IsHitTestVisible="False"
+                                               Height="{DynamicResource NavigationViewPaneHeaderRowMinHeight}"
+                                               Grid.Row="2"
+                                               Name="PaneContentGridToggleButtonRowHack"
+                                               IsVisible="{Binding #TogglePaneButton.IsVisible}"/>
 
                                     <!--"Non header" content-->
                                     <Grid Name="ItemsContainerGrid" Grid.Row="6"

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -9,7 +9,6 @@ using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Logging;
-using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls.Primitives;
@@ -130,8 +129,6 @@ public partial class TabView : TemplatedControl
         // Ignore ThemeShadow
 
         UpdateListViewItemContainerTransitions();
-
-        OnLoaded(e);
     }
 
     protected override Size MeasureOverride(Size availableSize)


### PR DESCRIPTION
Updates FA to v2.0, fully compatible with Avalonia 11.0 - a long time in the making.

See previous PRs for fixes here, a couple extra included here:
- Fixed issue where NavView items & pane toggle button were too close together (fixes #412)
- Corrected NavViewItem corner radius (fixes #413)
- Removed redundant OnLoaded from TabView