### PR TITLE
ContentDialog improvements

### DIFF
--- a/src/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -39,9 +39,6 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         _secondaryButton.Click += OnButtonClick;
         _closeButton = e.NameScope.Get<Button>(s_tpCloseButton);
         _closeButton.Click += OnButtonClick;
-
-        // v2- Removed this as I don't think its necessary anymore (called from ShowAsync)
-        //SetupDialog();
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -62,9 +59,31 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         return base.RegisterContentPresenter(presenter);
     }
 
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+
+        // See OnKeyUp for reasoning
+        if (!e.Handled && e.Key == Key.Enter)
+        {
+            _enterKeyDownVisual = e.Source as Visual;
+        }
+    }
+
     protected override void OnKeyUp(KeyEventArgs e)
     {
         if (e.Handled)
+        {
+            base.OnKeyUp(e);
+            return;
+        }
+
+        // HACK: If a default button is set, and the content dialog is opened by enter key press on a button
+        // the KeyUp event is raised on the focused item within the dialog, instead of the original button
+        // (Avalonia related issue #9626) and will immediately close the dialog
+        // We store the source of the key down and if it doesn't match, or hasn't been set yet, we ignore
+        // this key up event so we don't inadvertantly close the dialog
+        if (e.Key == Key.Enter && (_enterKeyDownVisual == null || _enterKeyDownVisual != (Visual)e.Source))
         {
             base.OnKeyUp(e);
             return;
@@ -110,12 +129,20 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     /// <summary>
     /// Begins an asynchronous operation to show the dialog.
     /// </summary>
-    public async Task<ContentDialogResult> ShowAsync() => await ShowAsyncCore(null);
+    public Task<ContentDialogResult> ShowAsync() => ShowAsyncCoreForTopLevel(null);
 
     /// <summary>
     /// Begins an asynchronous operation to show the dialog using the specified window
     /// </summary>
-    public async Task<ContentDialogResult> ShowAsync(Window w) => await ShowAsyncCore(w);
+    public Task<ContentDialogResult> ShowAsync(Window w) => ShowAsyncCoreForTopLevel(w);
+
+    /// <summary>
+    /// Begins an asynchronous operation to show the dialog using the specified top level
+    /// </summary>
+    /// <remarks>
+    /// Use this when an ApplicationLifetime is unavailable (such as in headless unit tests)
+    /// </remarks>
+    public Task<ContentDialogResult> ShowAsync(TopLevel tl) => ShowAsyncCoreForTopLevel(tl);
 
     /// <summary>
     /// Shows the content dialog on the specified window asynchronously.
@@ -123,10 +150,11 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     /// <remarks>
     /// Note that the placement parameter is not implemented and only accepts <see cref="ContentDialogPlacement.Popup"/>
     /// </remarks>
-    private async Task<ContentDialogResult> ShowAsyncCore(Window window, ContentDialogPlacement placement = ContentDialogPlacement.Popup)
+    private Task<ContentDialogResult> ShowAsyncCore(Window window, ContentDialogPlacement placement = ContentDialogPlacement.Popup) =>
+        ShowAsyncCoreForTopLevel((TopLevel)window);
+
+    private async Task<ContentDialogResult> ShowAsyncCoreForTopLevel(TopLevel topLevel)
     {
-        if (placement == ContentDialogPlacement.InPlace)
-            throw new NotImplementedException("InPlace not implemented yet");
         _tcs = new TaskCompletionSource<ContentDialogResult>();
 
         OnOpening();
@@ -158,55 +186,62 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
 
         OverlayLayer ol = null;
 
-        if (window != null)
+        if (topLevel != null)
         {
-            ol = OverlayLayer.GetOverlayLayer(window);
-            _lastFocus = window.FocusManager.GetFocusedElement();
+            ol = OverlayLayer.GetOverlayLayer(topLevel);
         }
         else
         {
             if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime al)
             {
-                foreach (var item in al.Windows)
+                var windows = al.Windows;
+                for (int i = 0; i < windows.Count; i++)
                 {
-                    if (item.IsActive)
+                    if (windows[i].IsActive)
                     {
-                        window = item;
+                        topLevel = windows[i];
                         break;
                     }
                 }
 
-                //Fallback, just in case
-                window ??= al.MainWindow;
+                if (topLevel == null)
+                {
+                    if (al.MainWindow == null)
+                        throw new NotSupportedException("No TopLevel root found to parent ContentDialog");
 
-                _lastFocus = window.FocusManager.GetFocusedElement();
-                ol = OverlayLayer.GetOverlayLayer(window);
+                    topLevel = al.MainWindow;
+                }
+
+                ol = OverlayLayer.GetOverlayLayer(topLevel);
             }
             else if (Application.Current.ApplicationLifetime is ISingleViewApplicationLifetime sl)
             {
-                _lastFocus = TopLevel.GetTopLevel(sl.MainView).FocusManager.GetFocusedElement();
                 ol = OverlayLayer.GetOverlayLayer(sl.MainView);
+            }
+            else
+            {
+                throw new InvalidOperationException("No TopLevel found for ContentDialog and no ApplicationLifetime is set. " +
+                    "Please either supply a valid ApplicationLifetime or TopLevel to ShowAsync()");
             }
         }
 
-        
-
         if (ol == null)
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("Unable to find OverlayLayer from given TopLevel");
+
+        _lastFocus = topLevel.FocusManager.GetFocusedElement();
 
         ol.Children.Add(_host);
 
-        // v2 - Added this so dialog materializes in the Visual Tree now since for some reason
-        //      items in the OverlayLayer materialize at the absolute last moment making init
-        //      a very difficult task to do
-        // v2-preview6: This doesn't appear necessary anymore...will preserve this for now
-        // but has to be removed to solve GH#315
-        //(ol.GetVisualRoot() as ILayoutRoot).LayoutManager.ExecuteInitialLayoutPass();
-
+        // Make the dialog visible
         IsVisible = true;
-        ol.UpdateLayout();
-        ShowCore();
-        SetupDialog();
+        PseudoClasses.Set(SharedPseudoclasses.s_pcHidden, false);
+        PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, true);
+
+        // Delay futher initializing until after the dialog has loaded. We sub here and unsbu in DialogLoaded
+        // because ContentDialog can be declared in Xaml prior to showing, and we don't want Loaded to trigger
+        // initialization if we're not actually showing the dialog
+        Loaded += DialogLoaded;
+
         return await _tcs.Task;
     }
 
@@ -282,15 +317,6 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         Closed?.Invoke(this, args);
     }
 
-    private void ShowCore()
-    {
-        IsVisible = true;
-        PseudoClasses.Set(SharedPseudoclasses.s_pcHidden, false);
-        PseudoClasses.Set(SharedPseudoclasses.s_pcOpen, true);
-
-        OnOpened();
-    }
-
     private void HideCore()
     {
         // v2 - No longer disabling the dialog during a deferral so we need to make sure that if
@@ -325,27 +351,33 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     internal void SetupDialog()
     {
         if (_primaryButton == null)
-            ApplyTemplate();
+            throw new InvalidOperationException("Attempted to setup ContentDialog but the template has not been applied yet.");
 
         PseudoClasses.Set(s_pcPrimary, !string.IsNullOrEmpty(PrimaryButtonText));
         PseudoClasses.Set(s_pcSecondary, !string.IsNullOrEmpty(SecondaryButtonText));
         PseudoClasses.Set(s_pcClose, !string.IsNullOrEmpty(CloseButtonText));
 
-        var curFocus = TopLevel.GetTopLevel(this).FocusManager.GetFocusedElement() as Control;
-        bool setFocus = false;
-        if (curFocus.FindAncestorOfType<ContentDialog>() == null)
-        {
-            // Only set the focus if user didn't handle doing that in Opened handler,
-            // since this is called after
-            setFocus = true;
-        }
+        //var curFocus = TopLevel.GetTopLevel(this).FocusManager.GetFocusedElement() as Control;
+        bool setFocus = true;
+        //if (curFocus.FindAncestorOfType<ContentDialog>() == null)
+        //{
+        //    // Only set the focus if user didn't handle doing that in Opened handler,
+        //    // since this is called after
+        //    setFocus = true;
+        //}
 
         var p = Presenter;
         switch (DefaultButton)
         {
             case ContentDialogButton.Primary:
                 if (!_primaryButton.IsVisible)
+                {
+#if DEBUG
+                    Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", 
+                        "DefaultButton was set to Primary, but PrimaryButton is not enabled");
+#endif
                     break;
+                }
 
                 _primaryButton.Classes.Add(SharedPseudoclasses.s_cAccent);
                 _secondaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
@@ -363,7 +395,13 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
 
             case ContentDialogButton.Secondary:
                 if (!_secondaryButton.IsVisible)
+                {
+#if DEBUG
+                    Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog",
+                        "DefaultButton was set to Secondary, but SecondaryButton is not enabled");
+#endif
                     break;
+                }
 
                 _secondaryButton.Classes.Add(SharedPseudoclasses.s_cAccent);
                 _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
@@ -381,7 +419,13 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
 
             case ContentDialogButton.Close:
                 if (!_closeButton.IsVisible)
+                {
+#if DEBUG
+                    Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog",
+                        "DefaultButton was set to Close, but CloseButton is not enabled");
+#endif
                     break;
+                }
 
                 _closeButton.Classes.Add(SharedPseudoclasses.s_cAccent);
                 _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
@@ -404,15 +448,12 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
 
                 if (setFocus)
                 {
-                    var next = KeyboardNavigationHandler.GetNext(this, NavigationDirection.Next);
-                    if (next != null)
-                    {
-                        next.Focus();
-                    }
-                    else
-                    {
-                        this.Focus();
-                    }
+                    // If no default button is set, try to find a suitable first focus item. If none exist, focus the
+                    // ContentDialog itself to pull focus away from the main visual tree so weird things don't happen
+                    // The latter shouldn't happen in 99% of cases as either something in the user content will be able
+                    // to take focus OR there should always be at least one button which can take focus
+                    var next = KeyboardNavigationHandler.GetNext(this, NavigationDirection.Next) ?? this;
+                    next.Focus();
 
 #if DEBUG
                     Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to {next}", next);
@@ -483,6 +524,8 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 cp.Content = this;
             }
         }
+
+        _enterKeyDownVisual = null;
 
         _tcs.TrySetResult(_result);
     }
@@ -608,6 +651,19 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         return (false, null);
     }
 
+    private void DialogLoaded(object sender, RoutedEventArgs args)
+    {
+        Loaded -= DialogLoaded;
+
+        // Run setup, this will set up the buttons and attempt to set initial focus into the dialog
+        SetupDialog();
+
+        // Now force a new layout pass so everything in SetupDialog takes effect
+        UpdateLayout();
+
+        // Now that we've fully initialized here, raise the Opened event
+        OnOpened();
+    }
 
     // Store the last element focused before showing the dialog, so we can
     // restore it when it closes
@@ -621,4 +677,5 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
     private Button _secondaryButton;
     private Button _closeButton;
     private bool _hasDeferralActive;
+    private Visual _enterKeyDownVisual;
 }

--- a/src/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.cs
@@ -357,15 +357,6 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
         PseudoClasses.Set(s_pcSecondary, !string.IsNullOrEmpty(SecondaryButtonText));
         PseudoClasses.Set(s_pcClose, !string.IsNullOrEmpty(CloseButtonText));
 
-        //var curFocus = TopLevel.GetTopLevel(this).FocusManager.GetFocusedElement() as Control;
-        bool setFocus = true;
-        //if (curFocus.FindAncestorOfType<ContentDialog>() == null)
-        //{
-        //    // Only set the focus if user didn't handle doing that in Opened handler,
-        //    // since this is called after
-        //    setFocus = true;
-        //}
-
         var p = Presenter;
         switch (DefaultButton)
         {
@@ -382,14 +373,12 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 _primaryButton.Classes.Add(SharedPseudoclasses.s_cAccent);
                 _secondaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
                 _closeButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
-               
-                if (setFocus)
-                {
-                    _primaryButton.Focus();
+
+                _primaryButton.Focus();
 #if DEBUG
-                    Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to PrimaryButton");
+                Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to PrimaryButton");
 #endif
-                }
+
 
                 break;
 
@@ -407,13 +396,10 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
                 _closeButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
 
-                if (setFocus)
-                {
-                    _secondaryButton.Focus();
+                _secondaryButton.Focus();
 #if DEBUG
-                    Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to SecondaryButton");
+                Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to SecondaryButton");
 #endif
-                }
 
                 break;
 
@@ -431,13 +417,10 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
                 _secondaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
 
-                if (setFocus)
-                {
-                    _closeButton.Focus();
+                _closeButton.Focus();
 #if DEBUG
-                    Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to CloseButton");
+                Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to CloseButton");
 #endif
-                }
 
                 break;
 
@@ -446,20 +429,16 @@ public partial class ContentDialog : ContentControl, ICustomKeyboardNavigation
                 _primaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
                 _secondaryButton.Classes.Remove(SharedPseudoclasses.s_cAccent);
 
-                if (setFocus)
-                {
-                    // If no default button is set, try to find a suitable first focus item. If none exist, focus the
-                    // ContentDialog itself to pull focus away from the main visual tree so weird things don't happen
-                    // The latter shouldn't happen in 99% of cases as either something in the user content will be able
-                    // to take focus OR there should always be at least one button which can take focus
-                    var next = KeyboardNavigationHandler.GetNext(this, NavigationDirection.Next) ?? this;
-                    next.Focus();
+                // If no default button is set, try to find a suitable first focus item. If none exist, focus the
+                // ContentDialog itself to pull focus away from the main visual tree so weird things don't happen
+                // The latter shouldn't happen in 99% of cases as either something in the user content will be able
+                // to take focus OR there should always be at least one button which can take focus
+                var next = KeyboardNavigationHandler.GetNext(this, NavigationDirection.Next) ?? this;
+                next.Focus();
 
 #if DEBUG
-                    Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to {next}", next);
+                Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to {next}", next);
 #endif
-                }
-
                 break;
         }
     }

--- a/src/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/ContentDialog/ContentDialog.properties.cs
@@ -110,14 +110,8 @@ public partial class ContentDialog
     /// </summary>
     public ICommand CloseButtonCommand
     {
-        get
-        {
-            return GetValue(CloseButtonCommandProperty);
-        }
-        set
-        {
-            SetValue(CloseButtonCommandProperty, value);
-        }
+        get => GetValue(CloseButtonCommandProperty);
+        set => SetValue(CloseButtonCommandProperty, value);
     }
 
     /// <summary>
@@ -125,14 +119,8 @@ public partial class ContentDialog
     /// </summary>
     public object CloseButtonCommandParameter
     {
-        get
-        {
-            return GetValue(CloseButtonCommandParameterProperty);
-        }
-        set
-        {
-            SetValue(CloseButtonCommandParameterProperty, value);
-        }
+        get => GetValue(CloseButtonCommandParameterProperty);
+        set => SetValue(CloseButtonCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -140,14 +128,8 @@ public partial class ContentDialog
     /// </summary>
     public string CloseButtonText
     {
-        get
-        {
-            return GetValue(CloseButtonTextProperty);
-        }
-        set
-        {
-            SetValue(CloseButtonTextProperty, value);
-        }
+        get => GetValue(CloseButtonTextProperty);
+        set => SetValue(CloseButtonTextProperty, value);
     }
 
     /// <summary>
@@ -155,14 +137,8 @@ public partial class ContentDialog
     /// </summary>
     public ContentDialogButton DefaultButton
     {
-        get
-        {
-            return GetValue(DefaultButtonProperty);
-        }
-        set
-        {
-            SetValue(DefaultButtonProperty, value);
-        }
+        get => GetValue(DefaultButtonProperty);
+        set => SetValue(DefaultButtonProperty, value);
     }
 
     /// <summary>
@@ -170,14 +146,8 @@ public partial class ContentDialog
     /// </summary>
     public bool IsPrimaryButtonEnabled
     {
-        get
-        {
-            return GetValue(IsPrimaryButtonEnabledProperty);
-        }
-        set
-        {
-            SetValue(IsPrimaryButtonEnabledProperty, value);
-        }
+        get => GetValue(IsPrimaryButtonEnabledProperty);
+        set => SetValue(IsPrimaryButtonEnabledProperty, value);
     }
 
     /// <summary>
@@ -185,14 +155,8 @@ public partial class ContentDialog
     /// </summary>
     public bool IsSecondaryButtonEnabled
     {
-        get
-        {
-            return GetValue(IsSecondaryButtonEnabledProperty);
-        }
-        set
-        {
-            SetValue(IsSecondaryButtonEnabledProperty, value);
-        }
+        get => GetValue(IsSecondaryButtonEnabledProperty);
+        set => SetValue(IsSecondaryButtonEnabledProperty, value);
     }
 
     /// <summary>
@@ -200,14 +164,8 @@ public partial class ContentDialog
     /// </summary>
     public ICommand PrimaryButtonCommand
     {
-        get
-        {
-            return GetValue(PrimaryButtonCommandProperty);
-        }
-        set
-        {
-            SetValue(PrimaryButtonCommandProperty, value);
-        }
+        get => GetValue(PrimaryButtonCommandProperty);
+        set => SetValue(PrimaryButtonCommandProperty, value);
     }
 
     /// <summary>
@@ -215,14 +173,8 @@ public partial class ContentDialog
     /// </summary>
     public object PrimaryButtonCommandParameter
     {
-        get
-        {
-            return GetValue(PrimaryButtonCommandParameterProperty);
-        }
-        set
-        {
-            SetValue(PrimaryButtonCommandParameterProperty, value);
-        }
+        get => GetValue(PrimaryButtonCommandParameterProperty);
+        set => SetValue(PrimaryButtonCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -230,14 +182,8 @@ public partial class ContentDialog
     /// </summary>
     public string PrimaryButtonText
     {
-        get
-        {
-            return GetValue(PrimaryButtonTextProperty);
-        }
-        set
-        {
-            SetValue(PrimaryButtonTextProperty, value);
-        }
+        get => GetValue(PrimaryButtonTextProperty);
+        set => SetValue(PrimaryButtonTextProperty, value);
     }
 
     /// <summary>
@@ -245,14 +191,8 @@ public partial class ContentDialog
     /// </summary>
     public ICommand SecondaryButtonCommand
     {
-        get
-        {
-            return GetValue(SecondaryButtonCommandProperty);
-        }
-        set
-        {
-            SetValue(SecondaryButtonCommandProperty, value);
-        }
+        get => GetValue(SecondaryButtonCommandProperty);
+        set => SetValue(SecondaryButtonCommandProperty, value);
     }
 
     /// <summary>
@@ -260,14 +200,8 @@ public partial class ContentDialog
     /// </summary>
     public object SecondaryButtonCommandParameter
     {
-        get
-        {
-            return GetValue(SecondaryButtonCommandParameterProperty);
-        }
-        set
-        {
-            SetValue(SecondaryButtonCommandParameterProperty, value);
-        }
+        get => GetValue(SecondaryButtonCommandParameterProperty);
+        set => SetValue(SecondaryButtonCommandParameterProperty, value);
     }
 
     /// <summary>
@@ -275,14 +209,8 @@ public partial class ContentDialog
     /// </summary>
     public string SecondaryButtonText
     {
-        get
-        {
-            return GetValue(SecondaryButtonTextProperty);
-        }
-        set
-        {
-            SetValue(SecondaryButtonTextProperty, value);
-        }
+        get => GetValue(SecondaryButtonTextProperty);
+        set => SetValue(SecondaryButtonTextProperty, value);
     }
 
     /// <summary>
@@ -290,14 +218,8 @@ public partial class ContentDialog
     /// </summary>
     public object Title
     {
-        get
-        {
-            return GetValue(TitleProperty);
-        }
-        set
-        {
-            SetValue(TitleProperty, value);
-        }
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
     }
 
     /// <summary>
@@ -305,14 +227,8 @@ public partial class ContentDialog
     /// </summary>
     public IDataTemplate TitleTemplate
     {
-        get
-        {
-            return GetValue(TitleTemplateProperty);
-        }
-        set
-        {
-            SetValue(TitleTemplateProperty, value);
-        }
+        get => GetValue(TitleTemplateProperty);
+        set => SetValue(TitleTemplateProperty, value);
     }
 
     /// <summary>

--- a/tests/FluentAvaloniaTests/ControlTests/ContentDialogTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/ContentDialogTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
@@ -93,7 +94,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void ContentDialogInCodeShows()
+    public async Task ContentDialogInCodeShows()
     {
         var dlg = new ContentDialog();
         _window.Content = dlg;
@@ -113,7 +114,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void AlreadyParentedContentDialogShows()
+    public async Task AlreadyParentedContentDialogShows()
     {
         var dlg = new ContentDialog();
         _window.Content = dlg;
@@ -131,7 +132,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void ContentDialogShowsAtCorrectWindow()
+    public async Task ContentDialogShowsAtCorrectWindow()
     {
         var dlg = new ContentDialog();
         _window.Content = dlg;
@@ -151,7 +152,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void PrimaryButtonInvokesEventAndCommand()
+    public async Task PrimaryButtonInvokesEventAndCommand()
     {
         var window = new Window();
         var dlg = new ContentDialog();
@@ -194,7 +195,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void SecondaryButtonInvokesEventAndCommand()
+    public async Task SecondaryButtonInvokesEventAndCommand()
     {
         var window = new Window();
         var dlg = new ContentDialog();
@@ -237,7 +238,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void CloseButtonInvokesEventAndCommand()
+    public async Task CloseButtonInvokesEventAndCommand()
     {
         var window = new Window();
         var dlg = new ContentDialog();
@@ -280,7 +281,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void FocusIsMovedIntoContentDialogUponOpening()
+    public async Task FocusIsMovedIntoContentDialogUponOpening()
     {
         var dlg = new ContentDialog
         {
@@ -304,7 +305,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void OldFocusIsPreservedThroughContentDialog()
+    public async Task OldFocusIsPreservedThroughContentDialog()
     {
         var dlg = new ContentDialog
         {
@@ -341,7 +342,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void PrimaryDefaultButtonGetsInitialFocus()
+    public async Task PrimaryDefaultButtonGetsInitialFocus()
     {
         var dlg = new ContentDialog
         {
@@ -366,7 +367,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void SecondaryDefaultButtonGetsInitialFocus()
+    public async Task SecondaryDefaultButtonGetsInitialFocus()
     {
         var dlg = new ContentDialog
         {
@@ -391,7 +392,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void CloseDefaultButtonGetsInitialFocus()
+    public async Task CloseDefaultButtonGetsInitialFocus()
     {
         var dlg = new ContentDialog
         {
@@ -416,7 +417,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void UserCanOverrideInitialFocus()
+    public async Task UserCanOverrideInitialFocus()
     {
         var tb = new TextBox();
         var dlg = new ContentDialog
@@ -447,7 +448,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void EnterKeyInvokesDefaultButtonIfSet()
+    public async Task EnterKeyInvokesDefaultButtonIfSet()
     {
         var dlg = new ContentDialog
         {
@@ -469,7 +470,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void EscapeKeyClosesDialogWithNoResult()
+    public async Task EscapeKeyClosesDialogWithNoResult()
     {
         var dlg = new ContentDialog
         {
@@ -491,7 +492,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void UnhandledEnterKeyInUserContentInvokesDefaultButton()
+    public async Task UnhandledEnterKeyInUserContentInvokesDefaultButton()
     {
         var tb = new TextBox();
         var dlg = new ContentDialog
@@ -517,7 +518,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void HandledEnterKeyInUserContentDoesNotInvokesDefaultButton()
+    public async Task HandledEnterKeyInUserContentDoesNotInvokesDefaultButton()
     {
         var tb = new TextBox();
         var dlg = new ContentDialog
@@ -589,7 +590,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void CancellingClosingInButtonClickCancelsDialogClosing()
+    public async Task CancellingClosingInButtonClickCancelsDialogClosing()
     {
         var window = new Window();
         var dlg = new ContentDialog();
@@ -624,7 +625,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void ButtonDeferralWorks()
+    public async Task ButtonDeferralWorks()
     {
         var window = new Window();
         var dlg = new ContentDialog();
@@ -663,7 +664,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void CanCancelWithButtonDeferral()
+    public async Task CanCancelWithButtonDeferral()
     {
         var window = new Window();
         var dlg = new ContentDialog();
@@ -711,7 +712,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void ClosingDeferralWorks()
+    public async Task ClosingDeferralWorks()
     {
         var window = new Window();
         var dlg = new ContentDialog();
@@ -741,7 +742,7 @@ public class ContentDialogTests : IDisposable
     }
 
     [AvaloniaFact(Timeout = 5000)]
-    public async void CanCancelWithClosingDeferral()
+    public async Task CanCancelWithClosingDeferral()
     {
         var window = new Window();
         var dlg = new ContentDialog();

--- a/tests/FluentAvaloniaTests/ControlTests/ContentDialogTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/ContentDialogTests.cs
@@ -1,134 +1,791 @@
-﻿//using System;
-//using System.Linq;
-//using Avalonia.Controls;
-//using Avalonia.Markup.Xaml;
-//using Avalonia.Styling;
-//using Avalonia.VisualTree;
-//using FluentAvalonia.UI.Controls;
-//using FluentAvaloniaTests.Helpers;
-//using Xunit;
+﻿using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAvalonia.UI.Controls;
+using FluentAvaloniaTests.Helpers;
+using Xunit;
 
-//namespace FluentAvaloniaTests.ControlTests;
+namespace FluentAvaloniaTests.ControlTests;
 
-//public class ContentDialogTestContext : IDisposable
-//{
-//    public ContentDialogTestContext()
-//    {
-//        _appDisposable = UnitTestApplication.Start();
+public class ContentDialogTests : IDisposable
+{
+    public ContentDialogTests()
+    {
+        _window = new Window();
+        _window.Show();
+    }
 
-//        Dialog = CreateDialog();
-//        Root.LayoutManager.ExecuteInitialLayoutPass();
-//        Root.LayoutManager.ExecuteLayoutPass();
-//    }
+    [AvaloniaFact]
+    public void NotSettingButtonTextShowsNoButtons()
+    {
+        var dlg = new ContentDialog();
+        _window.Content = dlg;
+        dlg.ApplyTemplate();
+        dlg.SetupDialog();
 
-//    public ContentDialog Dialog { get; }
+        var items = dlg.GetVisualDescendants().OfType<Button>();
 
-//    public TestRoot Root { get; private set; }
+        foreach (var item in items)
+        {
+            Assert.False(item.IsVisible);
+        }
+        _window.Content = null;
+    }
 
-//    public ContentDialog CreateDialog()
-//    {
-//        Root = new TestRoot(new Avalonia.Size(1280, 720));
-//        Root.StylingParent = UnitTestApplication.Current;
+    [AvaloniaFact]
+    public void SettingPrimaryButtonTextShowsPrimaryButton()
+    {
+        var dlg = new ContentDialog();
+        _window.Content = dlg;
 
-//        ////UnitTestApplication.Current.Styles.Add(
-//        ////   (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/ContentControl.axaml")));
-//        //UnitTestApplication.Current.Styles.Add(
-//        //   (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/Controls/ContentDialogStyles.axaml")));
-//        //UnitTestApplication.Current.Styles.Add(
-//        //    (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/ScrollBarStyles.axaml")));
-//        //UnitTestApplication.Current.Styles.Add(
-//        //    (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/ScrollViewerStyles.axaml")));
-//        //UnitTestApplication.Current.Styles.Add(
-//        //   (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/BasicControls/ButtonStyles.axaml")));
+        dlg.PrimaryButtonText = "Primary";
+        dlg.ApplyTemplate();
+        dlg.SetupDialog();
 
-//        // ContentDialog is an async process which is hard to unit test, so force create and add to tree here
-//        var cd = new ContentDialog();
-//        cd.Opacity = 1;
-//        cd.IsVisible = true;
-//        Root.Child = cd;
+        var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+        Assert.NotNull(button);
 
-//        return cd;
-//    }
+        Assert.True(button.IsVisible);
+        Assert.Equal("Primary", button.Content);
+        _window.Content = null;
+    }
 
-//    public void Dispose()
-//    {
-//        _appDisposable.Dispose();
-//    }
+    [AvaloniaFact]
+    public void SettingSecondaryButtonTextShowsSecondaryButton()
+    {
+        var dlg = new ContentDialog();
+        _window.Content = dlg;
 
-//    private IDisposable _appDisposable;
-//}
+        dlg.SecondaryButtonText = "Secondary";
+        dlg.ApplyTemplate();
+        dlg.SetupDialog();
 
-//public class ContentDialogTests : IClassFixture<ContentDialogTestContext>
-//{
-//    public ContentDialogTests(ContentDialogTestContext ctx)
-//    {
-//        Context = ctx;
-//    }
+        var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "SecondaryButton").FirstOrDefault();
+        Assert.NotNull(button);
 
-//    [Fact]
-//    public void NotSettingButtonTextShowsNoButtons()
-//    {
-//        ResetDialog();
-//        Context.Dialog.SetupDialog();
+        Assert.True(button.IsVisible);
+        Assert.Equal("Secondary", button.Content);
+        _window.Content = null;
+    }
 
-//        var items = Context.Dialog.GetVisualDescendants().OfType<Button>();
+    [AvaloniaFact]
+    public void SettingCloseButtonTextShowsCloseButton()
+    {
+        var dlg = new ContentDialog();
+        _window.Content = dlg;
 
-//        foreach(var item in items)
-//        {
-//            Assert.False(item.IsVisible);
-//        }
-//    }
+        dlg.CloseButtonText = "Close";
+        dlg.ApplyTemplate();
+        dlg.SetupDialog();
 
-//    [Fact]
-//    public void SettingPrimaryButtonTextShowsPrimaryButton()
-//    {
-//        ResetDialog();
-//        Context.Dialog.PrimaryButtonText = "Primary";
-//        Context.Dialog.SetupDialog();
+        var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "CloseButton").FirstOrDefault();
+        Assert.NotNull(button);
 
-//        var button = Context.Dialog.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
-//        Assert.NotNull(button);
-        
-//        Assert.True(button.IsVisible);
-//        Assert.Equal("Primary", button.Content);
-//    }
+        Assert.True(button.IsVisible);
+        Assert.Equal("Close", button.Content);
+        _window.Content = null;
+    }
 
-//    [Fact]
-//    public void SettingSecondaryButtonTextShowsSecondaryButton()
-//    {
-//        ResetDialog();
-//        Context.Dialog.SecondaryButtonText = "Secondary";
-//        Context.Dialog.SetupDialog();
+    [AvaloniaFact(Timeout = 5000)]
+    public async void ContentDialogInCodeShows()
+    {
+        var dlg = new ContentDialog();
+        _window.Content = dlg;
 
-//        var button = Context.Dialog.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "SecondaryButton").FirstOrDefault();
-//        Assert.NotNull(button);
+        bool shown = false;
+        dlg.Opened += (_, __) =>
+        {
+            shown = true;
+            Assert.Equal(_window, TopLevel.GetTopLevel(dlg));
+            dlg.Hide();
+        };
 
-//        Assert.True(button.IsVisible);
-//        Assert.Equal("Secondary", button.Content);
-//    }
+        var res = await dlg.ShowAsync(_window);
 
-//    [Fact]
-//    public void SettingCloseButtonTextShowsCloseButton()
-//    {
-//        ResetDialog();
-//        Context.Dialog.CloseButtonText = "Close";
-//        Context.Dialog.SetupDialog();
+        Assert.True(shown);
+        _window.Content = null;
+    }
 
-//        var button = Context.Dialog.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "CloseButton").FirstOrDefault();
-//        Assert.NotNull(button);
+    [AvaloniaFact(Timeout = 5000)]
+    public async void AlreadyParentedContentDialogShows()
+    {
+        var dlg = new ContentDialog();
+        _window.Content = dlg;
 
-//        Assert.True(button.IsVisible);
-//        Assert.Equal("Close", button.Content);
-//    }
+        bool shown = false;
+        dlg.Opened += (_, __) =>
+        {
+            shown = true;
+            dlg.Hide();
+        };
 
-//    private void ResetDialog()
-//    {
-//        Context.Dialog.PrimaryButtonText = null;
-//        Context.Dialog.SecondaryButtonText = null;
-//        Context.Dialog.CloseButtonText = null;
-//        Context.Dialog.Title = null;
-//        Context.Dialog.Content = null;
-//    }
+        var res = await dlg.ShowAsync(_window);
 
-//    public ContentDialogTestContext Context { get; }
-//}
+        Assert.True(shown);
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void ContentDialogShowsAtCorrectWindow()
+    {
+        var dlg = new ContentDialog();
+        _window.Content = dlg;
+        var wnd2 = new Window();
+        wnd2.Show();
+
+        TopLevel topLevel = null;
+        dlg.Opened += (_, __) =>
+        {
+            topLevel = TopLevel.GetTopLevel(dlg);
+            dlg.Hide();
+        };
+
+        var res = await dlg.ShowAsync(wnd2);
+
+        Assert.Equal(wnd2, topLevel);
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void PrimaryButtonInvokesEventAndCommand()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.PrimaryButtonText = "Primary";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            var transform = button.TransformToVisual(window).Value;
+            var bnds = new Rect(button.Bounds.Size).TransformToAABB(transform);
+            var pt = bnds.Center;
+
+            window.MouseDown(pt, MouseButton.Left);
+            window.MouseUp(pt, MouseButton.Left);
+        };
+
+        bool clicked = false;
+        bool commandInvoked = false;
+        dlg.PrimaryButtonClick += (s, e) =>
+        {
+            // Command should fire AFTER button event
+            Assert.False(commandInvoked);
+            clicked = true;
+        };
+
+        var com = new TestCommand(_ =>
+        {
+            commandInvoked = true;
+        });
+        dlg.PrimaryButtonCommand = com;
+
+        var res = await dlg.ShowAsync(window);
+
+        Assert.True(clicked);
+        Assert.True(commandInvoked);
+        window.Close();
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void SecondaryButtonInvokesEventAndCommand()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.SecondaryButtonText = "Secondary";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "SecondaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            var transform = button.TransformToVisual(window).Value;
+            var bnds = new Rect(button.Bounds.Size).TransformToAABB(transform);
+            var pt = bnds.Center;
+
+            window.MouseDown(pt, MouseButton.Left);
+            window.MouseUp(pt, MouseButton.Left);
+        };
+
+        bool clicked = false;
+        bool commandInvoked = false;
+        dlg.SecondaryButtonClick += (s, e) =>
+        {
+            // Command should fire AFTER button event
+            Assert.False(commandInvoked);
+            clicked = true;
+        };
+
+        var com = new TestCommand(_ =>
+        {
+            commandInvoked = true;
+        });
+        dlg.SecondaryButtonCommand = com;
+
+        var res = await dlg.ShowAsync(window);
+
+        Assert.True(clicked);
+        Assert.True(commandInvoked);
+        window.Close();
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void CloseButtonInvokesEventAndCommand()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.CloseButtonText = "Close";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "CloseButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            var transform = button.TransformToVisual(window).Value;
+            var bnds = new Rect(button.Bounds.Size).TransformToAABB(transform);
+            var pt = bnds.Center;
+
+            window.MouseDown(pt, MouseButton.Left);
+            window.MouseUp(pt, MouseButton.Left);
+        };
+
+        bool clicked = false;
+        bool commandInvoked = false;
+        dlg.CloseButtonClick += (s, e) =>
+        {
+            // Command should fire AFTER button event
+            Assert.False(commandInvoked);
+            clicked = true;
+        };
+
+        var com = new TestCommand(_ =>
+        {
+            commandInvoked = true;
+        });
+        dlg.CloseButtonCommand = com;
+
+        var res = await dlg.ShowAsync(window);
+
+        Assert.True(clicked);
+        Assert.True(commandInvoked);
+        window.Close();
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void FocusIsMovedIntoContentDialogUponOpening()
+    {
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary"
+        };
+        _window.Content = dlg;
+
+        dlg.Opened += (_, __) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            Assert.True(button.IsFocused);
+
+            dlg.Hide();
+        };
+
+        var res = await dlg.ShowAsync(_window);
+
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void OldFocusIsPreservedThroughContentDialog()
+    {
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary"
+        };
+
+        var mainButton = new Button { Content = "hello" };
+        _window.Content = new Panel
+        {
+            Children =
+            {
+                mainButton
+            }
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            Assert.True(button.IsFocused);
+
+            dlg.Hide();
+        };
+
+        mainButton.Focus();
+        Assert.True(mainButton.IsFocused);
+
+        var res = await dlg.ShowAsync(_window);
+
+        Assert.True(mainButton.IsFocused);
+
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void PrimaryDefaultButtonGetsInitialFocus()
+    {
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Primary
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            Assert.True(button.IsFocused);
+
+            dlg.Hide();
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void SecondaryDefaultButtonGetsInitialFocus()
+    {
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Secondary
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "SecondaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            Assert.True(button.IsFocused);
+
+            dlg.Hide();
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void CloseDefaultButtonGetsInitialFocus()
+    {
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "CloseButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            Assert.True(button.IsFocused);
+
+            dlg.Hide();
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void UserCanOverrideInitialFocus()
+    {
+        var tb = new TextBox();
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Primary,
+            Content = tb
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            Assert.True(button.IsFocused);
+
+            tb.Focus();
+
+            Assert.True(tb.IsFocused);
+
+            dlg.Hide();
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void EnterKeyInvokesDefaultButtonIfSet()
+    {
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Primary
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            _window.KeyPress(Key.Enter, RawInputModifiers.None);
+            _window.KeyRelease(Key.Enter, RawInputModifiers.None);
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        Assert.Equal(ContentDialogResult.Primary, res);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void EscapeKeyClosesDialogWithNoResult()
+    {
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Primary
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            _window.KeyPress(Key.Escape, RawInputModifiers.None);
+            _window.KeyRelease(Key.Escape, RawInputModifiers.None);
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        Assert.Equal(ContentDialogResult.None, res);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void UnhandledEnterKeyInUserContentInvokesDefaultButton()
+    {
+        var tb = new TextBox();
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Primary,
+            Content = tb
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            tb.Focus();
+
+            _window.KeyPress(Key.Enter, RawInputModifiers.None);
+            _window.KeyRelease(Key.Enter, RawInputModifiers.None);
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        Assert.Equal(ContentDialogResult.Primary, res);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void HandledEnterKeyInUserContentDoesNotInvokesDefaultButton()
+    {
+        var tb = new TextBox();
+        var dlg = new ContentDialog
+        {
+            PrimaryButtonText = "Primary",
+            SecondaryButtonText = "Secondary",
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Primary,
+            Content = tb
+        };
+
+        tb.KeyDown += (_, e) =>
+        {
+            e.Handled = true;
+        };
+
+        dlg.Opened += (_, __) =>
+        {
+            tb.Focus();
+
+            _window.KeyPress(Key.Enter, RawInputModifiers.None);
+            _window.KeyRelease(Key.Enter, RawInputModifiers.None);
+            dlg.Hide(ContentDialogResult.None);
+        };
+
+        var res = await dlg.ShowAsync(_window);
+        Assert.Equal(ContentDialogResult.None, res);
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public void UsingEnterKeyToLaunchDialogDoesNotImmediatelyCloseDialogIfDefaultButtonIsSet()
+    {
+
+        var mainButton = new Button { Content = "hello" };
+        _window.Content = new Panel
+        {
+            Children =
+            {
+                mainButton
+            }
+        };
+
+        mainButton.Click += async (s, e) =>
+        {
+            var dlg = new ContentDialog
+            {
+                PrimaryButtonText = "Primary",
+                SecondaryButtonText = "Secondary",
+                CloseButtonText = "Close",
+                DefaultButton = ContentDialogButton.Primary
+            };
+
+            dlg.Opened += (_, __) =>
+            {
+                dlg.Hide(ContentDialogResult.None);
+            };
+
+            var res = await dlg.ShowAsync(_window);
+            Assert.Equal(ContentDialogResult.None, res);
+        };
+
+        mainButton.Focus();
+
+        _window.KeyPress(Key.Enter, RawInputModifiers.None);
+        _window.KeyRelease(Key.Enter, RawInputModifiers.None);
+
+        _window.Content = null;
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void CancellingClosingInButtonClickCancelsDialogClosing()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.PrimaryButtonText = "Primary";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            var transform = button.TransformToVisual(window).Value;
+            var bnds = new Rect(button.Bounds.Size).TransformToAABB(transform);
+            var pt = bnds.Center;
+
+            window.MouseDown(pt, MouseButton.Left);
+            window.MouseUp(pt, MouseButton.Left);
+        };
+
+
+        dlg.PrimaryButtonClick += (s, e) =>
+        {
+            e.Cancel = true;
+
+            Dispatcher.UIThread.Post(() => dlg.Hide(), DispatcherPriority.Background);
+        };
+
+        var res = await dlg.ShowAsync(window);
+
+        Assert.Equal(ContentDialogResult.None, res);
+        window.Close();
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void ButtonDeferralWorks()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.PrimaryButtonText = "Primary";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            var transform = button.TransformToVisual(window).Value;
+            var bnds = new Rect(button.Bounds.Size).TransformToAABB(transform);
+            var pt = bnds.Center;
+
+            window.MouseDown(pt, MouseButton.Left);
+            window.MouseUp(pt, MouseButton.Left);
+        };
+
+        bool deferralRun = false;
+
+        dlg.PrimaryButtonClick += (s, e) =>
+        {
+            var def = e.GetDeferral();
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                deferralRun = true;
+                def.Complete();
+            }, DispatcherPriority.Background);
+        };
+
+        var res = await dlg.ShowAsync(window);
+        Assert.True(deferralRun);
+        window.Close();
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void CanCancelWithButtonDeferral()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.PrimaryButtonText = "Primary";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            var button = dlg.GetVisualDescendants().OfType<Button>().Where(x => x.Name == "PrimaryButton").FirstOrDefault();
+            Assert.NotNull(button);
+
+            var transform = button.TransformToVisual(window).Value;
+            var bnds = new Rect(button.Bounds.Size).TransformToAABB(transform);
+            var pt = bnds.Center;
+
+            window.MouseDown(pt, MouseButton.Left);
+            window.MouseUp(pt, MouseButton.Left);
+        };
+
+        bool deferralRun = false;
+
+        dlg.PrimaryButtonClick += (s, e) =>
+        {
+            var def = e.GetDeferral();
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                deferralRun = true;
+                def.Complete();
+
+                e.Cancel = true;
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    dlg.Hide();
+                }, DispatcherPriority.Background);
+            }, DispatcherPriority.Background);
+        };
+
+        var res = await dlg.ShowAsync(window);
+        Assert.True(deferralRun);
+        Assert.Equal(ContentDialogResult.None, res);
+
+        window.Close();
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void ClosingDeferralWorks()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.PrimaryButtonText = "Primary";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            dlg.Hide();
+        };
+
+        bool deferralRun = false;
+        dlg.Closing += (s, e) =>
+        {
+            var def = e.GetDeferral();
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                deferralRun = true;
+                def.Complete();
+            }, DispatcherPriority.Background);
+        };
+
+        var res = await dlg.ShowAsync(window);
+        Assert.True(deferralRun);
+        window.Close();
+    }
+
+    [AvaloniaFact(Timeout = 5000)]
+    public async void CanCancelWithClosingDeferral()
+    {
+        var window = new Window();
+        var dlg = new ContentDialog();
+        dlg.PrimaryButtonText = "Primary";
+        window.Show();
+
+        dlg.Opened += (s, e) =>
+        {
+            dlg.Hide();
+        };
+
+        bool ignore = false;
+        bool deferralRun = false;
+        dlg.Closing += (s, e) =>
+        {
+            if (ignore)
+                return;
+
+            ignore = true;
+            var def = e.GetDeferral();
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                deferralRun = true;
+                def.Complete();
+
+                e.Cancel = true;
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    dlg.Hide();
+                }, DispatcherPriority.Background);
+            }, DispatcherPriority.Background);
+        };
+
+        var res = await dlg.ShowAsync(window);
+        Assert.True(deferralRun);
+        window.Close();
+    }
+
+    public void Dispose()
+    {
+        _window.Close();
+    }
+
+    private Window _window;
+}

--- a/tests/FluentAvaloniaTests/Helpers/TestCommand.cs
+++ b/tests/FluentAvaloniaTests/Helpers/TestCommand.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace FluentAvaloniaTests.Helpers;
+
+internal class TestCommand : ICommand
+{
+    public TestCommand(Action<object> executeMethod, Func<object, bool> canExecuteMethod = null)
+    {
+        _executeMethod = executeMethod;
+        _canExecuteMethod = canExecuteMethod;
+    }
+
+    public event EventHandler CanExecuteChanged;
+
+    public bool CanExecute(object parameter) =>
+        _canExecuteMethod?.Invoke(parameter) ?? true;
+
+    public void Execute(object parameter) =>
+        _executeMethod.Invoke(parameter);
+
+    private Action<object> _executeMethod;
+    private Func<object, bool> _canExecuteMethod;
+}

--- a/tests/FluentAvaloniaTests/Helpers/UnitTestApplication.cs
+++ b/tests/FluentAvaloniaTests/Helpers/UnitTestApplication.cs
@@ -1,15 +1,26 @@
 ﻿using Avalonia;
 using FluentAvaloniaTests.Helpers;
-//using Avalonia.Headless.XUnit;
+using Avalonia.Headless;
+using FluentAvalonia.Styling;
+using Avalonia.Controls.ApplicationLifetimes;
 
-//[assembly: AvaloniaTestFramework(typeof(UnitTestApplication))]
+[assembly: AvaloniaTestApplication(typeof(UnitTestApplication))]
 
 namespace FluentAvaloniaTests.Helpers;
 
 public class UnitTestApplication : Application
 {
-    public UnitTestApplication()
-    {
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<UnitTestApplication>()
+        .UseSkia()
+        .UseHeadless(new AvaloniaHeadlessPlatformOptions
+        {
+            UseHeadlessDrawing = false
+        })
+        .AfterSetup(InitStyles);
 
+    private static void InitStyles(AppBuilder ab)
+    {
+        // FATheme requires Application.Current to be set, so we run this after Application setup has finished
+        Current.Styles.Add(new FluentAvaloniaTheme());
     }
 }


### PR DESCRIPTION
Several much needed improvements for ContentDialog:

- Initialization logic has been refactored to ensure ContentDialog initalizes in the correct order. Previously, `SetupDialog`, which is responsible for setting up all the buttons based on the properties was called AFTER the dialog said is was ready and raised the opened event. This was leading to the issue where the buttons were still invisible and initial focus was not being applied. Now, everything is run in the correct order and when the Opened event fires, you can be sure the entire dialog is ready to go. 
  - As a result, initial focus is now correctly applied (this is done automatically). You can still override that and focus whatever you want by handling the Opened event.
  - It is not required to post to the dispatcher to get focus to work correctly
  - Also, just as a reminder, if no focusable content is found in the ContentDialog (can happen with all disabled buttons or no buttons, combined with no focusable content), focus will NOT move into the dialog and will remain on whatever the previous focus is. This is by design and is how the FocusManager works (we can't focus any control that isn't focusable)
- Fixed an issue where if the dialog was launched via a Button invoked with the enter key with a DefaultButton set, the dialog would immediately close. This is hack fixed as I think this is an underlying issue in Avalonia where if focus changes in between key events, the KeyUp is routed to the new focused control rather than the old.
- Some adjustments to the ShowAsync method
  - Added `ShowAsync(TopLevel)` overload. This should be used in cases where no ApplicationLifetime is present (like in my unit tests), as ContentDialog won't know where to launch. 
  - As a result, `ShowAsync(Window)` remains for now but will be removed in 2.1 as this is breaking change
- Some minor cleanup of some code
- Added unit tests for ContentDialog, which includes tests for the above bugs to ensure they don't regress in the future.

fixes #419