### PR TITLE
fix: SettingsExpanderItem HorizontalContentAlignment handling

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderItemStyles.axaml
@@ -16,6 +16,8 @@
                         <Button Content="FooterButton" />
                     </ui:SettingsExpanderItem.Footer>
                 </ui:SettingsExpanderItem>
+                <ui:SettingsExpanderItem Content="Right Content Here" 
+                                         HorizontalContentAlignment="Right"/>
             </ui:SettingsExpander>
         </Border>
     </Design.PreviewWith>
@@ -61,7 +63,7 @@
                                               Content="{Binding TemplateSettings.Icon, RelativeSource={RelativeSource TemplatedParent}}" />
                         </Viewbox>
 
-                        <StackPanel HorizontalAlignment="Left"
+                        <StackPanel HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     VerticalAlignment="Center"
                                     Name="HeaderRegion">
                             <ContentPresenter Content="{TemplateBinding Content}"


### PR DESCRIPTION
SettingsExpanderItem HorizontalContentAlignment handling

SettingsExpanderItem ignore  HorizontalContentAlignment settings

```xaml
            <ui:SettingsExpander IconSource="Globe" Header="Test Header" IsExpanded="True"
                                 Description="This is a description for the SettingsExpander"
                                 ActionIconSource="Save" IsClickEnabled="False">
                <ui:SettingsExpander.Footer>
                    <Button Content="FooterButton" />
                </ui:SettingsExpander.Footer>

                <ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
                <ui:SettingsExpanderItem Content="Content Here">
                    <ui:SettingsExpanderItem.Footer>
                        <Button Content="FooterButton" />
                    </ui:SettingsExpanderItem.Footer>
                </ui:SettingsExpanderItem>
                <ui:SettingsExpanderItem Content="Right Content Here" 
                                         HorizontalContentAlignment="Right"/>
            </ui:SettingsExpander>
```

 ## Current
![immagine](https://github.com/amwx/FluentAvalonia/assets/12531229/c72aa8f7-52fe-434f-a8ef-e23024a69cfa)


## Expected
![Senza nome](https://github.com/amwx/FluentAvalonia/assets/12531229/df26aa26-6948-403b-9fbd-8c383a3753b6)

Fixes #438