### PR TITLE
Add XML Namespace Definitions

### DIFF
--- a/src/FluentAvalonia/Properties/AssemblyInfo.cs
+++ b/src/FluentAvalonia/Properties/AssemblyInfo.cs
@@ -1,3 +1,11 @@
 ﻿using System.Runtime.CompilerServices;
 
+using Avalonia.Metadata;
+
 [assembly: InternalsVisibleTo("FluentAvaloniaTests")]
+
+[assembly: XmlnsDefinition("https://github.com/fluent-avalonia", "FluentAvalonia.UI")]
+[assembly: XmlnsDefinition("https://github.com/fluent-avalonia", "FluentAvalonia.UI.Controls")]
+[assembly: XmlnsDefinition("https://github.com/fluent-avalonia", "FluentAvalonia.UI.Controls.Primitives")]
+[assembly: XmlnsDefinition("https://github.com/fluent-avalonia", "FluentAvalonia.UI.Windowing")]
+[assembly: XmlnsDefinition("https://github.com/fluent-avalonia", "FluentAvalonia.Styling")]


### PR DESCRIPTION
When we add a reference to this library in an Avalonia UI XAML file, we can use the URL identification format. For example: 
`
xmlns:fluent="https://github.com/fluent-avalonia"
`