### PR TITLE
FA v2.0.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,8 +4,8 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.0.0</Version>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <Version>2.0.1</Version>
+    <AssemblyVersion>2.0.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <!-- Add Package Icon -->

--- a/src/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
+++ b/src/FluentAvalonia/UI/Controls/MenuFlyout/FAMenuFlyoutPresenter.cs
@@ -152,7 +152,6 @@ public class FAMenuFlyoutPresenter : ItemsControl
 
     protected override void OnKeyDown(KeyEventArgs args)
     {
-        base.OnKeyDown(args);
         if (args.Handled)
             return;
 
@@ -284,6 +283,8 @@ public class FAMenuFlyoutPresenter : ItemsControl
                 }
                 break;
         }
+
+        base.OnKeyDown(args);
     }
 
     protected override void OnPointerReleased(PointerReleasedEventArgs args)

--- a/src/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
+++ b/src/FluentAvalonia/UI/Controls/MenuFlyout/MenuFlyoutItemBase.cs
@@ -34,7 +34,9 @@ public class MenuFlyoutItemBase : TemplatedControl
     {
         base.OnPointerCaptureLost(e);
 
-        InternalParent.PointerExitedItem(this);
+        // Don't do this, for some reason this is getting called on a simple click of the menu item
+        // and if its done on a subitem during the open timer, it prevents the item from opening
+        //InternalParent.PointerExitedItem(this);
     }
 }
 


### PR DESCRIPTION
- Technically fixes an issue in FAMenuFlyout where clicking on a MenuFlyoutSubItem during the hover open timer would stop the item from opening
  - This seems to be a bug in Avalonia where PointerCaptureLost is raised on pointer released. So MenuFlyoutItem no longer handle this event
- Moves the base.OnKeyDown call in FAMenuFlyoutPresenter after our logic. This allows custom keyboard navigation now as previously it was being handled by the ItemsPanel logic and the logic here was never called because the args were already handled

The package will also include previous PRs since 2.0 released