### PR TITLE
Windows chrome glyphs icons changes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/AppWindowStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/AppWindowStyles.axaml
@@ -22,8 +22,7 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Background="{TemplateBinding Background}">
-                    <Viewbox Width="14"
-                             Height="14">
+                    <Viewbox Width="{TemplateBinding FontSize}" Height="{TemplateBinding FontSize}">
                         <ui:FontIcon Name="ButtonIcon"
                                      FontFamily="{StaticResource SymbolThemeFontFamily}"
                                      Glyph="{TemplateBinding Content}" />
@@ -85,13 +84,14 @@
                 <StackPanel Orientation="Horizontal">
                     <Button Name="MinimizeButton"
                             Theme="{StaticResource FA_SystemCaptionButton}"
-                            Content="&#xE921;"/>
+                            Content="&#xE738;"/>
                     <Button Name="MaxRestoreButton"
                             Theme="{StaticResource FA_SystemCaptionButton}"
-                            Content="&#xE922;" />
+                            Content="&#xE739;" />
                     <Button Name="CloseButton"
                             Theme="{StaticResource FA_SystemCaptionButton}"
-                            Content="&#xE8BB;"
+                            Content="&#xE711;"
+                            FontSize="16"
                             Classes="Close"  />
                 </StackPanel>
             </ControlTemplate>
@@ -99,6 +99,7 @@
 
         <Style Selector="^:maximized /template/ Button#MaxRestoreButton">
             <Setter Property="Content" Value="&#xE923;" />
+            <Setter Property="FontSize" Value="16" />
         </Style>
     </ControlTheme>
 


### PR DESCRIPTION
This would close https://github.com/amwx/FluentAvalonia/issues/458 if this solution is appropriate.

I noticed that the system chrome icons in AppWindow were slightly larger than the ones seen in other windows apps, and it seems like windows is not using the glyphs they explicitly call "ChromeMaximize" etc.. on their own apps. I am wondering if they should be more of a copy of other fluent apps?

I dug through the [glyphs](https://learn.microsoft.com/en-us/windows/apps/design/style/segoe-fluent-icons-font) and I wondering if these match slightly more in your opinion, if not this can be closed.

Current chrome icons:
![image](https://github.com/amwx/FluentAvalonia/assets/15821271/305eabb2-6c54-4906-8ae9-65b909402445)
Fullscreen:
![image](https://github.com/amwx/FluentAvalonia/assets/15821271/a25fe3e6-3a5d-406b-b106-4333e5f5ed73)


PR version of chrome icons changes:
![image](https://github.com/amwx/FluentAvalonia/assets/15821271/ca2fc4f7-e340-470d-a451-d10035c4d068)
Fullscreen:
![image](https://github.com/amwx/FluentAvalonia/assets/15821271/18895546-2680-4969-a7fd-0a402cd86fdf)


Comparison with a few other apps on win11 with the change:
![Screenshot 2023-08-12 105848](https://github.com/amwx/FluentAvalonia/assets/15821271/cff495ac-e26b-44d2-9f5e-7718232a8815)

This uses the already defined FontSize of 14 and allows updating it to 16px for the "X" symbol.