### PR TITLE
Fix for #475

### DIFF
--- a/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
+++ b/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs
@@ -756,7 +756,7 @@ public partial class NavigationView : HeaderedContentControl
     private static readonly string SR_SettingsButtonName = "SettingsButtonName";
     private static readonly string SR_NavigationOverflowButtonToolTip = "NavigationOverflowButtonToolTip";
     private static readonly string SR_NavigationViewSearchButtonName = "NavigationViewSearchButtonName";
-    private static readonly string SR_NavigationBackButtonToolTip = "NavigationViewBackButtonToolTip";
+    private static readonly string SR_NavigationBackButtonToolTip = "NavigationBackButtonToolTip";
     private static readonly string SR_NavigationButtonOpenName = "NavigationButtonOpenName";
     private static readonly string SR_NavigationButtonClosedName = "NavigationButtonClosedName";
 }


### PR DESCRIPTION
This fixes #475. I have just updated the key used by SR_NavigationBackButtonToolTip in [NavigationView.members.cs](https://github.com/amwx/FluentAvalonia/blob/4d847a8403b914d558baa79351a7866a02ec0b3e/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.members.cs#L759) to match the one declared in [ControlStrings.json](https://github.com/amwx/FluentAvalonia/blob/4d847a8403b914d558baa79351a7866a02ec0b3e/src/FluentAvalonia/Assets/ControlStrings.json#L442C20-L442C20).