### PR TITLE
CommandBarFlyout fix SecondaryCommands not showing

### DIFF
--- a/src/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyoutCommandBar.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBarFlyout/CommandBarFlyoutCommandBar.cs
@@ -82,7 +82,7 @@ public class CommandBarFlyoutCommandBar : CommandBar
 
         Closing += (_, __) =>
         {
-            if (_owningFlyout != null)
+            if (_owningFlyout != null && _owningFlyout.IsOpen)
             {
                 if (_owningFlyout.AlwaysExpanded)
                 {


### PR DESCRIPTION
Small fix to address an issue where the SecondaryCommands in a CommandBarFlyout weren't showing if the flyout was shown, hidden, and then re-shown when `AlwaysExpanded` was set to `true`.

Fixes #477