### PR TITLE
FluentAvalonia v2.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ NOTE: The 1.x version of FluentAvalonia (0.10.x Avalonia) is now deprecated. Ple
 
 Note: Windows 7, 8/8.1 are not supported by FluentAvalonia. It may still be possible to run on these versions of Windows, but no support for issues will be given.
 
+## Avalonia minimum requirements
+(current) v2.0.4 - Avalonia 11.0.4
+All previous - Avalonia 11.0
+
 ## Documentation & Sample App
 
 Documentation and how to get started using FluentAvalonia is available [here](https://amwx.github.io/FluentAvaloniaDocs). Please note, these doc pages are still under development.

--- a/samples/FASandbox/MainWindow.axaml
+++ b/samples/FASandbox/MainWindow.axaml
@@ -11,4 +11,6 @@
         x:Class="FASandbox.MainWindow"
         Title="FASandbox">
 
+    <ToggleSwitch IsChecked="True"/>
+    
 </Window>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,8 +4,8 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.0.1</Version>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <Version>2.0.4</Version>
+    <AssemblyVersion>2.0.4.0</AssemblyVersion>
   </PropertyGroup>
 
   <!-- Add Package Icon -->

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleSwitchStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleSwitchStyles.axaml
@@ -25,6 +25,13 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="KnobTransitions">
+            <Transitions>
+                <DoubleTransition Easing="0,0,0,1"
+                                  Property="Canvas.Left"
+                                  Duration="0:0:0.2" />
+            </Transitions>
+        </Setter>
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid Background="{TemplateBinding Background}"
@@ -145,14 +152,6 @@
                 </Grid>
             </ControlTemplate>
         </Setter>
-
-        <Style Selector="^:not(:dragging) /template/ Grid#MovingKnobs">
-            <Setter Property="Transitions">
-                <Transitions>
-                    <DoubleTransition Property="Canvas.Left" Duration="0:0:0.2" Easing="CubicEaseOut"/>
-                </Transitions>
-            </Setter>
-        </Style>
 
 
         <Style Selector="^:pointerover">


### PR DESCRIPTION
Finally, an update!
Note: this boosts the Avalonia requirement to 11.0.4.

PR includes an update to ToggleSwitch which closes #410

Includes the RangeSlider control and the following PR fixes:
- #478
- #476 
- #467 
- #459 
- #457 
- #456