### PR TITLE
.NET 8 support, AOT and json source generator fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="MicroCom.Runtime" Version="0.11.0" />
     <PackageVersion Include="System.Text.Json" Version="7.0.3" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0.5" />
-    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0.5" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0" />
     
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0.5</AvaloniaVersion>
+    <AvaloniaVersion>11.0.4</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="MicroCom.Runtime" Version="0.11.0" />
     <PackageVersion Include="System.Text.Json" Version="7.0.3" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0.1" />
-    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0.1" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0.5" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0.5" />
     
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
@@ -32,9 +32,6 @@
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageVersion Include="coverlet.collector" Version="3.0.2" />
-
-    <PackageVersion Include="TextMateSharp" Version="1.0.56" />
-    <PackageVersion Include="TextMateSharp.Grammars" Version="1.0.56" />
     
     <!-- Begin Android -->
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.0.4</AvaloniaVersion>
+    <AvaloniaVersion>11.0.5</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
@@ -18,11 +18,10 @@
     
     <PackageVersion Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.0" />
     <PackageVersion Include="MicroCom.Runtime" Version="0.11.0" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0" />
-    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.0.1" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.0.1" />
     
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
@@ -33,6 +32,9 @@
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageVersion Include="coverlet.collector" Version="3.0.2" />
+
+    <PackageVersion Include="TextMateSharp" Version="1.0.56" />
+    <PackageVersion Include="TextMateSharp.Grammars" Version="1.0.56" />
     
     <!-- Begin Android -->
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1" />

--- a/samples/FAControlsGallery.Desktop/Roots.xml
+++ b/samples/FAControlsGallery.Desktop/Roots.xml
@@ -1,5 +1,6 @@
 ﻿<linker>
   <!-- Can be removed if CompiledBinding and no reflection are used -->
+  <assembly fullname="FAControlsGallery" preserve="All" />
   <assembly fullname="FAControlsGallery.Desktop" preserve="All" />
   <assembly fullname="Avalonia.Themes.Fluent" preserve="All" />
 </linker>

--- a/samples/FAControlsGallery/FAControlsGallery.csproj
+++ b/samples/FAControlsGallery/FAControlsGallery.csproj
@@ -16,9 +16,6 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="AvaloniaEdit.TextMate" />
-    <!-- Workaround for AvaloniaEdit AOT -->
-    <PackageReference Include="TextMateSharp" />
-    <PackageReference Include="TextMateSharp.Grammars" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
   </ItemGroup>
   <ItemGroup>    

--- a/samples/FAControlsGallery/FAControlsGallery.csproj
+++ b/samples/FAControlsGallery/FAControlsGallery.csproj
@@ -16,6 +16,9 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="AvaloniaEdit.TextMate" />
+    <!-- Workaround for AvaloniaEdit AOT -->
+    <PackageReference Include="TextMateSharp" />
+    <PackageReference Include="TextMateSharp.Grammars" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
   </ItemGroup>
   <ItemGroup>    

--- a/samples/FAControlsGallery/ViewModels/CoreControlsPageViewModel.cs
+++ b/samples/FAControlsGallery/ViewModels/CoreControlsPageViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json;
-using FAControlsGallery.Services;
 
 namespace FAControlsGallery.ViewModels;
 
@@ -10,7 +9,7 @@ public class CoreControlsPageViewModel : MainPageViewModelBase
         NoteText = "Fluent v2 styling on Avalonia controls. Only controls that have styling changes " +
             "are shown here for demo purposes, though all controls (except ContextMenu) are supported.";
 
-        CoreControlGroups = JsonSerializer.Deserialize<List<PageBaseViewModel>>(coreControlsJson);
+        CoreControlGroups = JsonSerializer.Deserialize(coreControlsJson, FAControlsJsonSerializerContext.Default.ListPageBaseViewModel);
 
         for (int i = 0, ct = CoreControlGroups.Count; i < ct; i++)
         {

--- a/samples/FAControlsGallery/ViewModels/DesignPages/DesignIconsPageViewModel.cs
+++ b/samples/FAControlsGallery/ViewModels/DesignPages/DesignIconsPageViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
-using Avalonia;
 using Avalonia.Platform;
 
 namespace FAControlsGallery.ViewModels.DesignPages;
@@ -41,7 +40,7 @@ public class DesignIconsPageViewModel : ViewModelBase
         return await Task.Run(() =>
         {
             using var s = AssetLoader.Open(new Uri("avares://FAControlsGallery/Assets/FASymbolFontList.json"));
-            var icons = JsonSerializer.Deserialize<List<FontIconInfo>>(s);
+            var icons = JsonSerializer.Deserialize(s, FAControlsJsonSerializerContext.Default.ListFontIconInfo);
 
             return icons;
         });

--- a/samples/FAControlsGallery/ViewModels/FAControlsJsonSerializerContext.cs
+++ b/samples/FAControlsGallery/ViewModels/FAControlsJsonSerializerContext.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+using FAControlsGallery.ViewModels.DesignPages;
+
+namespace FAControlsGallery.ViewModels;
+
+[JsonSerializable(typeof(List<PageBaseViewModel>))]
+[JsonSerializable(typeof(List<FontIconInfo>))]
+[JsonSerializable(typeof(List<FAControlsGroupItem>))]
+internal partial class FAControlsJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/samples/FAControlsGallery/ViewModels/FAControlsOverviewPageViewModel.cs
+++ b/samples/FAControlsGallery/ViewModels/FAControlsOverviewPageViewModel.cs
@@ -6,7 +6,7 @@ public class FAControlsOverviewPageViewModel : MainPageViewModelBase
 {
     public FAControlsOverviewPageViewModel(string controlsJson)
     {
-        ControlGroups = JsonSerializer.Deserialize<List<FAControlsGroupItem>>(controlsJson);
+        ControlGroups = JsonSerializer.Deserialize(controlsJson, FAControlsJsonSerializerContext.Default.ListFAControlsGroupItem);
 
         for (int i = 0; i < ControlGroups.Count; i++)
         {

--- a/src/FluentAvalonia/UI/FALocalizationHelper.cs
+++ b/src/FluentAvalonia/UI/FALocalizationHelper.cs
@@ -1,7 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.Json;
-using Avalonia;
+using System.Text.Json.Serialization;
 using Avalonia.Platform;
 
 namespace FluentAvalonia.UI;
@@ -13,21 +12,12 @@ namespace FluentAvalonia.UI;
 /// The string resources are taken from the WinUI repo. Not all resources in WinUI
 /// may be available here, only those that are known to be used in a control
 /// </remarks>
-public class FALocalizationHelper
+public partial class FALocalizationHelper
 {
     private FALocalizationHelper()
     {
         using var al = AssetLoader.Open(new Uri("avares://FluentAvalonia/Assets/ControlStrings.json"));
-
-        KeepType<LocalizationMap>();
-        KeepType<LocalizationEntry>();
-        _mappings = JsonSerializer.Deserialize<LocalizationMap>(al);
-
-        static void KeepType<
-#if NET5_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-#endif
-            T>() { }
+        _mappings = JsonSerializer.Deserialize(al, FALocalizationJsonSerializerContext.Default.LocalizationMap);
     }
 
     static FALocalizationHelper()
@@ -94,5 +84,10 @@ public class FALocalizationHelper
         {
 
         }
+    }
+
+    [JsonSerializable(typeof(LocalizationMap))]
+    private partial class FALocalizationJsonSerializerContext : JsonSerializerContext
+    {
     }
 }


### PR DESCRIPTION
- Use json source generator to avoid trimming/AOT issue as well as the incompatibility on .NET 8
- Bump AvaloniaEdit to 11.0.5 to fix AOT issue

Fixes #481
Fixes #492