### PR TITLE
Minor fixes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ButtonStyles.axaml
@@ -25,9 +25,6 @@
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -138,9 +135,6 @@
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CheckBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CheckBoxStyles.axaml
@@ -33,8 +33,6 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="MinHeight" Value="{DynamicResource CheckBoxHeight}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
@@ -82,8 +82,6 @@
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Top" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
         <Setter Property="Template">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
@@ -57,7 +57,6 @@
         <Setter Property="Background" Value="{DynamicResource MenuBarItemBackground}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MenuBarItemBorderBrush}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource MenuBarItemBorderThickness}"/>
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <!-- Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
         <Setter Property="Padding" Value="{DynamicResource MenuFlyoutItemThemePaddingNarrow}" />

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuStyles.axaml
@@ -59,7 +59,6 @@
         <Setter Property="Background" Value="{DynamicResource MenuBarItemBackground}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MenuBarItemBorderBrush}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource MenuBarItemBorderThickness}"/>
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <!-- Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
         <!--<Setter Property="Padding" Value="{DynamicResource MenuFlyoutItemThemePaddingNarrow}" />-->

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/NumericUpDownStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/NumericUpDownStyles.axaml
@@ -52,7 +52,6 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
         <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Focusable" Value="True"/>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/RadioButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/RadioButtonStyles.axaml
@@ -27,8 +27,6 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Top" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Template">
             <ControlTemplate>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/RepeatButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/RepeatButtonStyles.axaml
@@ -26,9 +26,7 @@
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
-        <Setter Property="HorizontalContentAlignment" Value="Center" />
+         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="RenderTransform" Value="none" />
         <Setter Property="Template">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/SliderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/SliderStyles.axaml
@@ -77,7 +77,6 @@
         <Setter Property="Background" Value="{DynamicResource SliderTrackFill}" />
         <Setter Property="BorderThickness" Value="{DynamicResource SliderBorderThemeThickness}" />
         <Setter Property="Foreground" Value="{DynamicResource SliderTrackValueFill}" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="ClipToBounds" Value="False" />
 
         <Style Selector="^:horizontal">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBlockStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBlockStyles.axaml
@@ -20,7 +20,6 @@
     <x:Double x:Key="DisplayTextBlockFontSize">68</x:Double>
 
     <ControlTheme TargetType="TextBlock" x:Key="BaseTextBlockStyle">
-        <Setter Property="FontFamily" Value="XamlAutoFontFamily" />
         <Setter Property="FontSize" Value="{StaticResource BodyTextBlockFontSize}" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="TextTrimming" Value="CharacterEllipsis" />

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
@@ -171,8 +171,6 @@
         <Setter Property="Width" Value="242" />
         <Setter Property="MinWidth" Value="242" />
         <Setter Property="MaxHeight" Value="398" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="Background" Value="{DynamicResource TimePickerFlyoutPresenterBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TimePickerFlyoutPresenterBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource DateTimeFlyoutBorderThickness}" />

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleButtonStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleButtonStyles.axaml
@@ -6,7 +6,7 @@
         <Border Padding="50">
             <StackPanel Spacing="10">
                 <ToggleButton Content="Toggle" />
-                <ToggleButton Content="Toggle" IsEnabled="Tr" IsChecked="False"
+                <ToggleButton Content="Toggle" IsChecked="False"
                               Theme="{DynamicResource TransparentToggleButton}"/>
             </StackPanel>
         </Border>
@@ -20,9 +20,6 @@
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -173,9 +170,6 @@
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleSwitchStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToggleSwitchStyles.axaml
@@ -23,7 +23,6 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="KnobTransitions">
             <Transitions>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToolTipStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ToolTipStyles.axaml
@@ -51,7 +51,6 @@
         <Setter Property="Padding" Value="{DynamicResource ToolTipBorderPadding}" />
         <Setter Property="MaxWidth" Value="{DynamicResource ToolTipMaxWidth}" />
         <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
         <Setter Property="Transitions">
             <Transitions>
                 <DoubleTransition Property="Opacity" Duration="0:0:0.15" />

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewSharedStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NavigationView/NavigationViewSharedStyles.axaml
@@ -310,7 +310,6 @@
                   BasedOn="{StaticResource {x:Type ContentControl}}">
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="FontSize" Value="28" />
-        <Setter Property="FontFamily" Value="XamlAutoFontFamily" />
         <Setter Property="Margin" Value="{DynamicResource NavigationViewHeaderMargin}"/>
         <Setter Property="VerticalAlignment" Value="Stretch"/>
     </ControlTheme>

--- a/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
+++ b/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
@@ -5618,7 +5618,6 @@
     <x:Double x:Key="TabItemVerticalPipeHeight">24</x:Double>
     <x:Double x:Key="TabItemPipeThickness">2</x:Double>
     <Thickness x:Key="TabItemHeaderMargin">12,0,12,0</Thickness>
-    <FontFamily x:Key="TabItemHeaderItemFontFamily">XamlAutoFontFamily</FontFamily>
     <x:Double x:Key="TabItemHeaderFontSize">24</x:Double>
     <Thickness x:Key="TabItemMargin">12,0,12,0</Thickness>
     <FontWeight x:Key="TabItemHeaderThemeFontWeight">SemiLight</FontWeight>

--- a/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
@@ -264,6 +264,12 @@ public partial class CommandBar : ContentControl
         if (!_appliedTemplate)
             return;
 
+        if (_primaryItems == null)
+        { 
+            AttachItems();
+            goto SetState;
+        }
+
         if (IsDynamicOverflowEnabled)
         {
             // While not the most performant or best solution, we return all Overflowed items back
@@ -331,6 +337,7 @@ public partial class CommandBar : ContentControl
                 break;
         }
 
+SetState:
         PseudoClasses.Set(s_pcPrimaryOnly, _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
         PseudoClasses.Set(s_pcSecondaryOnly, _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
         InvalidateMeasure();
@@ -340,6 +347,12 @@ public partial class CommandBar : ContentControl
     {
         if (!_appliedTemplate)
             return;
+
+        if (_overflowItems == null)
+        {
+            AttachItems();
+            goto SetState;
+        }
 
         // TODO: Test that this works...
         int startIndex = _numInOverflow == 0 ? 0 : _numInOverflow + 1;
@@ -376,8 +389,15 @@ public partial class CommandBar : ContentControl
                 break;
         }
 
+SetState:
         PseudoClasses.Set(s_pcPrimaryOnly, _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
         PseudoClasses.Set(s_pcSecondaryOnly, _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
+
+        if (_primaryItems == null || _primaryItems.Count == 0)
+        {
+            InvalidateMeasure();
+            //_moreButton.IsVisible = true;
+        }
     }
 
     private void AttachItems()

--- a/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBar/CommandBar.cs
@@ -179,7 +179,13 @@ public partial class CommandBar : ContentControl
             }
 
             if (_overflowSeparator != null)
+            { 
                 _overflowSeparator.IsVisible = _numInOverflow > 0 && SecondaryCommands.Count > 0;
+
+                var idx = _numInOverflow;
+                var curIdx = _overflowItems.IndexOf(_overflowSeparator);
+                _overflowItems.Move(curIdx, idx);
+            }
         }
 
         var overflowVis = OverflowButtonVisibility;
@@ -393,11 +399,8 @@ SetState:
         PseudoClasses.Set(s_pcPrimaryOnly, _primaryCommands.Count > 0 && _secondaryCommands.Count == 0);
         PseudoClasses.Set(s_pcSecondaryOnly, _primaryCommands.Count == 0 && _secondaryCommands.Count > 0);
 
-        if (_primaryItems == null || _primaryItems.Count == 0)
-        {
-            InvalidateMeasure();
-            //_moreButton.IsVisible = true;
-        }
+        // Rerun measure to ensure the MoreButton has the correct visibility
+        InvalidateMeasure();
     }
 
     private void AttachItems()
@@ -425,7 +428,10 @@ SetState:
 
         if (_secondaryCommands.Count > 0 || IsDynamicOverflowEnabled)
         {
-            _overflowSeparator = new CommandBarSeparator();
+            _overflowSeparator = new CommandBarSeparator
+            {
+                IsVisible = false
+            };
 
             _overflowItems = new AvaloniaList<ICommandBarElement>();
             _overflowItems.Add(_overflowSeparator);


### PR DESCRIPTION
- Fixes issue #512 by ensuring we initialize the internal lists 
- Fixes an issue where the overflow separator in the overflow menu of a CommandBar was not showing in the correct place
- Removes any references to `XamlAutoFontFamily` in styles
- Removes font setters for core controls to allow font inheritance
  - This only removes font setters where FontSize was set to `ControlContentThemeFontSize`, FontFamily was set to `ContentControlThemeFontFamily`, or another font property was set to the default value. If a control had a set font value to something else, it remains.
  - NOTE: This ONLY applies to the core controls. No FA specific controls were touched as part of this