### PR TITLE
SelectableTextBlock Fixes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBlockStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBlockStyles.axaml
@@ -5,6 +5,8 @@
 
     <ControlTheme TargetType="SelectableTextBlock"
                   x:Key="{x:Type SelectableTextBlock}">
+        <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+
         <Style Selector="^[IsEnabled=true]">
             <Setter Property="Cursor" Value="IBeam" />
             <!-- Defined in TextBoxStyles -->

--- a/src/FluentAvalonia/UI/Controls/CommandBarFlyout/TextCommandBarFlyout.cs
+++ b/src/FluentAvalonia/UI/Controls/CommandBarFlyout/TextCommandBarFlyout.cs
@@ -167,12 +167,21 @@ public class TextCommandBarFlyout : CommandBarFlyout
         // TextBlocks aren't as robust as WinUI, but we should still be able 
         // to make Copy work. SelectAll won't though
 
-        var buttonsToAdd = TextControlButtons.Copy;
+        var buttonsToAdd = TextControlButtons.None;
 
         if (tb is SelectableTextBlock stb)
         {
+            var selLength = Math.Abs(stb.SelectionEnd - stb.SelectionStart);
+            if (selLength > 0)
+            {
+                buttonsToAdd |= TextControlButtons.Copy;
+            }
             if (!string.IsNullOrEmpty(stb.Text) && stb.Text.Length > 0)
                 buttonsToAdd |= TextControlButtons.SelectAll;
+        }
+        else
+        {
+            buttonsToAdd |= TextControlButtons.Copy;
         }
         
         return buttonsToAdd;
@@ -233,6 +242,10 @@ public class TextCommandBarFlyout : CommandBarFlyout
             if (target is TextBox tb)
             {
                 tb.Copy();
+            }
+            else if (target is SelectableTextBlock stb)
+            {
+                stb.Copy();
             }
             else if (target is TextBlock txtB)
             {


### PR DESCRIPTION
Fixes the `SelectableTextBlock` issues described in https://github.com/amwx/FluentAvalonia/issues/550:

1. The `SelectionBrush` property has been added to the `ControlTheme`.
2. The "Copy" button on the `ContextFlyout` is now only visible when text is selected.
3. Clicking the "Copy" button on the `ContextFlyout` now only copies the selected text.
