### PR TITLE
Control Fixes

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CalendarDatePickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CalendarDatePickerStyles.axaml
@@ -92,10 +92,8 @@
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^">
-            <Style Selector="^ /template/ Button#PART_Button">
-                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerCalendarGlyphForeground}" />
-            </Style>
+        <Style Selector="^ /template/ Button#PART_Button">
+            <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerCalendarGlyphForeground}" />
         </Style>
 
         <Style Selector="^:pointerover">

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CalendarDatePickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/CalendarDatePickerStyles.axaml
@@ -58,7 +58,6 @@
                                     Grid.Column="1"
                                     Width="32"
                                     Theme="{StaticResource CalendarDropDownButton}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     Background="Transparent"
                                     BorderThickness="0"
                                     Margin="2,0,2,0"
@@ -92,5 +91,45 @@
                 </Grid>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^">
+            <Style Selector="^ /template/ Button#PART_Button">
+                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerCalendarGlyphForeground}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ TextBox#PART_TextBox">
+                <Setter Property="Background" Value="{DynamicResource CalendarDatePickerBackgroundPointerOver}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CalendarDatePickerBorderBrushPointerOver}" />
+                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerTextForegroundPointerOver}" />
+            </Style>
+            <Style Selector="^ /template/ Button#PART_Button">
+                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerCalendarGlyphForegroundPointerOver}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ TextBox#PART_TextBox">
+                <Setter Property="Background" Value="{DynamicResource CalendarDatePickerBackgroundPressed}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CalendarDatePickerBorderBrushPressed}" />
+                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerTextForegroundPressed}" />
+            </Style>
+            <Style Selector="^ /template/ Button#PART_Button">
+                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerCalendarGlyphForegroundPressed}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ TextBox#PART_TextBox">
+                <Setter Property="Background" Value="{DynamicResource CalendarDatePickerBackgroundDisabled}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CalendarDatePickerBorderBrushDisabled}" />
+                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerTextForegroundDisabled}" />
+            </Style>
+            <Style Selector="^ /template/ Button#PART_Button">
+                <Setter Property="Foreground" Value="{DynamicResource CalendarDatePickerCalendarGlyphForegroundDisabled}" />
+            </Style>
+        </Style>
+
     </ControlTheme>
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
@@ -134,14 +134,14 @@
                                    Foreground="{TemplateBinding PlaceholderForeground}"
                                    IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
 
-                        <ContentControl x:Name="ContentPresenter"
-                                        Content="{TemplateBinding SelectionBoxItem}"
-                                        ContentTemplate="{TemplateBinding ItemTemplate}"
-                                        Grid.Row="1"
-                                        Grid.Column="0"
-                                        Margin="{TemplateBinding Padding}"
-                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding ItemTemplate}"
+                                          Grid.Row="1"
+                                          Grid.Column="0"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
 
                         <Border x:Name="DropDownOverlay"
                                 Grid.Row="1"


### PR DESCRIPTION
 1. Use ContentPresenter instead of ContentControl in ComboBox
     * This is what the style selectors are using and is also the correct control to use here.
 1. Update CalendarDatePicker theme
     * The calendar glyph is currently always black in dark theme -- not light. I fixed this by setting the Foreground from a style selector rather than hardcoded in the control theme. That said, I'm not sure why it wasn't being inherited correctly as it looks like it should have worked. This might be an upstream bug.
     * The CalendarDatePicker had no styles for pointerover, disabled, etc. relying entirely on the TextBox itself to provide this. This completely ignores the CalendarDatePicker resources apps might be using. Therefore, I added support for this based on upstream WinUI.
     * https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/1.5-stable/controls/dev/CommonStyles/CalendarDatePicker_themeresources.xaml