### PR TITLE
Update TabViewItemScrollButtonFontSize Size

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
@@ -22,7 +22,7 @@
         <Setter Property="Background" Value="{DynamicResource TabViewScrollButtonBackground}"/>
         <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonForeground}"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}"/>
-        <Setter Property="FontSize" Value="{DynamicResource TabViewItemScrollButonFontSize}"/>
+        <Setter Property="FontSize" Value="{DynamicResource TabViewItemScrollButtonFontSize}"/>
         <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}"/>
         <Setter Property="Width" Value="{DynamicResource TabViewItemScrollButtonWidth}"/>
         <Setter Property="Height" Value="{DynamicResource TabViewItemScrollButtonHeight}"/>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
@@ -25,7 +25,7 @@
     <Thickness x:Key="TabViewItemHeaderCloseMargin">4,0,0,0</Thickness>
     <x:Double x:Key="TabViewItemScrollButtonWidth">32</x:Double>
     <x:Double x:Key="TabViewItemScrollButtonHeight">24</x:Double>
-    <x:Double x:Key="TabViewItemScrollButonFontSize">8</x:Double>
+    <x:Double x:Key="TabViewItemScrollButtonFontSize">14</x:Double>
     <Thickness x:Key="TabViewItemScrollButtonPadding">7,3,7,3</Thickness>
     <Thickness x:Key="TabViewItemLeftScrollButtonContainerPadding">8,0,3,3</Thickness>
     <Thickness x:Key="TabViewItemRightScrollButtonContainerPadding">3,0,8,3</Thickness>


### PR DESCRIPTION
I noticed a few differences between the FA tabview scroll button font size and that of WinUI, I could not find the exact size of the font from WinUI but it seems to be closer to 14pt. This also fixed a typo.


FluentAvalonia Before:
![font8](https://github.com/amwx/FluentAvalonia/assets/15821271/2b07b6a8-1e45-4f29-9841-44f0a649a4eb)

WinUI tab scroll button font:
![pwsh_tab](https://github.com/amwx/FluentAvalonia/assets/15821271/037f8d0b-3b2c-4dae-b73c-2348093734ab)


After:
![image](https://github.com/amwx/FluentAvalonia/assets/15821271/1732cfaa-77dc-4f5d-a239-f7beee6335db)

Button focused after (unchanged):
![image](https://github.com/amwx/FluentAvalonia/assets/15821271/0d8f4875-0184-45cf-a958-247ad0ec3858)


This is a super small change and if it's not appropriate, please close. 

Thanks