### PR TITLE
Add Inner[Left/Right]Content to AutoCompleteBox & NumericUpDown

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/AutoCompleteBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/AutoCompleteBoxStyles.axaml
@@ -22,7 +22,6 @@
     <!--<x:Double x:Key="AutoSuggestBoxLeftButtonMargin">3</x:Double>
         <x:Double x:Key="AutoSuggestBoxRightButtonMargin">4</x:Double>-->
 
-
     <ControlTheme TargetType="AutoCompleteBox" x:Key="{x:Type AutoCompleteBox}">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
@@ -43,13 +42,18 @@
                              Background="{TemplateBinding Background}"
                              BorderBrush="{TemplateBinding BorderBrush}"
                              BorderThickness="{TemplateBinding BorderThickness}"
+                             CornerRadius="{TemplateBinding CornerRadius}"
+                             CaretIndex="{TemplateBinding CaretIndex, Mode=TwoWay}"
                              FontSize="{TemplateBinding FontSize}"
                              FontFamily="{TemplateBinding FontFamily}"
                              FontWeight="{TemplateBinding FontWeight}"
                              Padding="{TemplateBinding Padding}"
                              Margin="0"
                              DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}"
-                             CornerRadius="{TemplateBinding CornerRadius}"/>
+                             MaxLength="{TemplateBinding MaxLength}"
+                             InnerLeftContent="{TemplateBinding InnerLeftContent}"
+                             InnerRightContent="{TemplateBinding InnerRightContent}"
+                             />
 
                     <Popup Name="PART_Popup"
                            WindowManagerAddShadowHint="False"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/NumericUpDownStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/NumericUpDownStyles.axaml
@@ -119,6 +119,9 @@
 
                         <Border Margin="{TemplateBinding BorderThickness}">
                             <Grid ColumnDefinitions="Auto,*,Auto" >
+                                <ContentPresenter Grid.Column="0"
+                                                  Grid.ColumnSpan="1"
+                                                  Content="{TemplateBinding InnerLeftContent}"/>
                                 <DockPanel x:Name="PART_InnerDockPanel"
                                            Grid.Column="1"
                                            Grid.ColumnSpan="1"
@@ -161,6 +164,9 @@
                                         </Panel>
                                     </ScrollViewer>
                                 </DockPanel>
+                                <ContentPresenter Grid.Column="2"
+                                                  Grid.ColumnSpan="1"
+                                                  Content="{TemplateBinding InnerRightContent}"/>
                             </Grid>
                         </Border>
                     </Panel>
@@ -220,6 +226,8 @@
                              TextWrapping="NoWrap"
                              Theme="{StaticResource NumericUpDownTextBoxTheme}"
                              TextAlignment="{TemplateBinding TextAlignment}"
+                             InnerLeftContent="{TemplateBinding InnerLeftContent}"
+                             InnerRightContent="{TemplateBinding InnerRightContent}"
                              Classes.spinRight="{TemplateBinding ButtonSpinnerLocation, Converter={StaticResource NUDSpinLocationConverter}}"
                              Classes.noSpin="{Binding !$parent[NumericUpDown].ShowButtonSpinner}" />
                 </ButtonSpinner>

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TextBoxStyles.axaml
@@ -211,7 +211,9 @@
                                         </Panel>
                                     </ScrollViewer>
                                 </DockPanel>
-                                <ContentPresenter Grid.Column="2" Grid.ColumnSpan="1" Content="{TemplateBinding InnerRightContent}"/>
+                                <ContentPresenter Grid.Column="2"
+                                                  Grid.ColumnSpan="1"
+                                                  Content="{TemplateBinding InnerRightContent}"/>
                             </Grid>
                         </Border>
                     </Panel>


### PR DESCRIPTION

 1. Add InnerLeftContent and InnerRightContent to AutoCompleteBox
    * Port of upstream https://github.com/AvaloniaUI/Avalonia/pull/14610

    ![image](https://github.com/amwx/FluentAvalonia/assets/17993847/766ad166-3b62-433f-b260-44079c27594d)

 2. Add InnerLeftContent and InnerRightContent to NumericUpDown
    * Port of upstream https://github.com/AvaloniaUI/Avalonia/pull/14575 


