### PR TITLE
Improve RangeSlider

### DIFF
--- a/samples/FASandbox/MainWindow.axaml
+++ b/samples/FASandbox/MainWindow.axaml
@@ -1,16 +1,10 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:ui="using:FluentAvalonia.UI.Controls"
-        xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
-        xmlns:core="using:FluentAvalonia.Core"
-        xmlns:sys="using:System"
-        xmlns:local="using:FASandbox"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="FASandbox.MainWindow"
-        Title="FASandbox">
+<Window x:Class="FASandbox.MainWindow" xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:core="using:FluentAvalonia.Core" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:local="using:FASandbox" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:sys="using:System" xmlns:ui="using:FluentAvalonia.UI.Controls" xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives" Title="FASandbox" d:DesignHeight="450" d:DesignWidth="800" x:DataType="local:MainWindowViewModel" mc:Ignorable="d">
 
-    <ToggleSwitch IsChecked="True"/>
-    
+    <StackPanel>
+        <ui:NumberBox Value="{Binding Min}" />
+        <ui:NumberBox Value="{Binding Max}" />
+
+        <ui:RangeSlider RangeEnd="{Binding Max}" RangeStart="{Binding Min}" />
+    </StackPanel>
+
 </Window>

--- a/samples/FASandbox/MainWindowViewModel.cs
+++ b/samples/FASandbox/MainWindowViewModel.cs
@@ -7,6 +7,9 @@ namespace FASandbox;
 
 public class MainWindowViewModel : INotifyPropertyChanged
 {
+    private double _min;
+    private double _max;
+
     public MainWindowViewModel()
     {
         
@@ -32,6 +35,16 @@ public class MainWindowViewModel : INotifyPropertyChanged
         }
 
         return false;
+    }
+
+    public double Min
+    {
+        get => _min;
+        set => RaiseAndSetIfChanged(ref _min, value);
+    }public double Max
+    {
+        get => _max;
+        set => RaiseAndSetIfChanged(ref _max, value);
     }
 }
 

--- a/src/FluentAvalonia/UI/Controls/RangeSlider/RangeSlider.cs
+++ b/src/FluentAvalonia/UI/Controls/RangeSlider/RangeSlider.cs
@@ -1,16 +1,11 @@
 ﻿using System.Collections.Concurrent;
-using System.Diagnostics;
 using Avalonia;
-using Avalonia.Automation;
-using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.Utilities;
-using Avalonia.VisualTree;
-using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -19,103 +14,51 @@ public partial class RangeSlider : TemplatedControl
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-
+        
         if (change.Property == RangeStartProperty)
         {
-            _minSet = true;
-
-            if (!_valuesAssigned)
-                return;
-
-            var newV = change.GetNewValue<double>();
-            RangeMinToStepFrequency();
-
-            if (_valuesAssigned)
-            {
-                if (newV < Minimum)
-                    RangeStart = Minimum;
-                else if (newV > Maximum)
-                    RangeStart = Maximum;
-
-                SyncActiveRectangle();
-
-                if (newV > RangeEnd)
-                    RangeEnd = newV;
-            }
+            var direction = change.GetNewValue<double>() - change.GetOldValue<double>(); 
+            CoerceValue(RangeStartProperty);
 
             SyncThumbs();
 
             if (!_isDraggingEnd && !_isDraggingStart)
             {
-                OnValueChanged(new RangeChangedEventArgs(change.GetOldValue<double>(), newV, RangeSelectorProperty.RangeStartValue));
+                OnValueChanged(new RangeChangedEventArgs(change.GetOldValue<double>(), RangeStart, RangeSelectorProperty.RangeStartValue));
             }
         }
         else if (change.Property == RangeEndProperty)
         {
-            _maxSet = true;
-
-            if (!_valuesAssigned)
-                return;
-
-            var newV = change.GetNewValue<double>();
-            RangeMaxToStepFrequency();
-
-            if (_valuesAssigned)
-            {
-                if (newV < Minimum)
-                    RangeEnd = Minimum;
-                else if (newV > Maximum)
-                    RangeEnd = Maximum;
-
-                SyncActiveRectangle();
-
-                if (newV < RangeStart)
-                    RangeStart = newV;
-            }
+            var direction = change.GetNewValue<double>() - change.GetOldValue<double>();
+            CoerceValue(RangeEndProperty);
 
             SyncThumbs();
 
             if (!_isDraggingEnd && !_isDraggingStart)
             {
-                OnValueChanged(new RangeChangedEventArgs(change.GetOldValue<double>(), newV, RangeSelectorProperty.RangeEndValue));
+                OnValueChanged(new RangeChangedEventArgs(change.GetOldValue<double>(), RangeEnd, RangeSelectorProperty.RangeEndValue));
             }
         }
         else if (change.Property == MinimumProperty)
         {
-            if (!_valuesAssigned)
-                return;
-
             var (oldV, newV) = change.GetOldAndNewValue<double>();
 
-            if (Maximum < newV)
-                Maximum = newV + Epsilon;
+            CoerceValue(MaximumProperty);
+            CoerceValue(RangeStartProperty);
+            CoerceValue(RangeEndProperty);
 
-            if (RangeStart < newV)
-                RangeStart = newV;
-
-            if (RangeEnd < newV)
-                RangeEnd = newV;
-
-            if (newV != oldV)
+            if (Math.Abs(newV - oldV) > Epsilon)
                 SyncThumbs();
         }
         else if (change.Property == MaximumProperty)
         {
-            if (!_valuesAssigned)
-                return;
-
             var (oldV, newV) = change.GetOldAndNewValue<double>();
+            
+            CoerceValue(MinimumProperty);
+            CoerceValue(RangeEndProperty);
+            CoerceValue(RangeStartProperty);
 
-            if (Minimum > newV)
-                Maximum = newV + Epsilon;
-
-            if (RangeEnd > newV)
-                RangeEnd = newV;
-
-            if (RangeStart > newV)
-                RangeStart = newV;
-
-            if (newV != oldV)
+            if (Math.Abs(newV - oldV) > Epsilon)
                 SyncThumbs();
         }
     }
@@ -144,9 +87,6 @@ public partial class RangeSlider : TemplatedControl
         }
 
         base.OnApplyTemplate(e);
-
-        VerifyValues();
-        _valuesAssigned = true;
 
         _activeRectangle = e.NameScope.Get<Rectangle>(s_tpActiveRectangle);
         _minThumb = e.NameScope.Get<Thumb>(s_tpMinThumb);
@@ -205,13 +145,12 @@ public partial class RangeSlider : TemplatedControl
         var limit = RangeEnd - MinimumRange;
         if (newStart > limit)
         {
-            RangeEnd += newStart - oldStart;
-            newStart -= newStart - limit;
-            RangeStart = newStart;
+            RangeMaxToStepFrequency(newStart - oldStart);
+            RangeMinToStepFrequency(limit - newStart);
         }
         else
         {
-            RangeStart = newStart;
+            RangeMinToStepFrequency(newStart - oldStart);
         }
 
         if (_toolTipText != null)
@@ -230,13 +169,12 @@ public partial class RangeSlider : TemplatedControl
         var limit = RangeStart + MinimumRange;
         if (newEnd < limit)
         {
-            RangeStart -= oldEnd - newEnd;
-            newEnd -= newEnd - limit;
-            RangeEnd = newEnd;
+            RangeMinToStepFrequency(newEnd - oldEnd);
+            RangeMaxToStepFrequency(limit - newEnd);
         }
         else
         {
-            RangeEnd = newEnd;
+            RangeMaxToStepFrequency(newEnd - oldEnd);
         }
 
         if (_toolTipText != null)
@@ -307,7 +245,7 @@ public partial class RangeSlider : TemplatedControl
         switch (e.Key)
         {
             case Key.Left:
-                RangeStart -= StepFrequency;
+                RangeMinToStepFrequency(-StepFrequency);
                 SyncThumbs(fromMinKeyDown: true);
 
                 SetToolTipAt(_minThumb, true);
@@ -316,7 +254,7 @@ public partial class RangeSlider : TemplatedControl
                 break;
 
             case Key.Right:
-                RangeStart += StepFrequency;
+                RangeMinToStepFrequency(+StepFrequency);
                 SyncThumbs(fromMinKeyDown: true);
 
                 SetToolTipAt(_minThumb, true);
@@ -331,7 +269,7 @@ public partial class RangeSlider : TemplatedControl
         switch (e.Key)
         {
             case Key.Left:
-                RangeEnd -= StepFrequency;
+                RangeMaxToStepFrequency(-StepFrequency);
                 SyncThumbs(fromMaxKeyDown: true);
 
                 if (!ToolTip.GetIsOpen(_maxThumb))
@@ -346,7 +284,7 @@ public partial class RangeSlider : TemplatedControl
                 e.Handled = true;
                 break;
             case Key.Right:
-                RangeEnd += StepFrequency;
+                RangeMaxToStepFrequency(+StepFrequency);
                 SyncThumbs(fromMaxKeyDown: true);
 
                 if (!ToolTip.GetIsOpen(_maxThumb))
@@ -467,10 +405,9 @@ public partial class RangeSlider : TemplatedControl
                 if (rs + delta < min)
                     delta = min - rs;
             }
-
             
-            RangeStart += delta;
-            RangeEnd += delta;
+            RangeMinToStepFrequency(delta);
+            RangeMaxToStepFrequency(delta);
             _absolutePosition = position;
             return;
         }
@@ -532,69 +469,43 @@ public partial class RangeSlider : TemplatedControl
             _toolTipText.Text = newValue.ToString(format);
         }
     }
-
-    private void VerifyValues()
+    
+    private void RangeMinToStepFrequency(double direction)
     {
-        if (Minimum > Maximum)
+        if (_isProgramaticChange)
         {
-            Minimum = Maximum;
-            Maximum = Maximum;
+            return;
         }
 
-        if (Minimum == Maximum)
-        {
-            Maximum += Epsilon;
-        }
-
-        if (!_maxSet)
-        {
-            RangeEnd = Maximum;
-        }
-
-        if (!_minSet)
-        {
-            RangeStart = Minimum;
-        }
-
-        if (RangeStart < Minimum)
-        {
-            RangeStart = Minimum;
-        }
-
-        if (RangeEnd < Minimum)
-        {
-            RangeEnd = Minimum;
-        }
-
-        if (RangeStart > Maximum)
-        {
-            RangeStart = Maximum;
-        }
-
-        if (RangeEnd > Maximum)
-        {
-            RangeEnd = Maximum;
-        }
-
-        if (RangeEnd < RangeStart)
-        {
-            RangeStart = RangeEnd;
-        }
+        _isProgramaticChange = true;
+        SetCurrentValue(RangeStartProperty, MoveToStepFrequency(RangeStart, direction));
+        _isProgramaticChange = false;
     }
 
-    private void RangeMinToStepFrequency()
+    private void RangeMaxToStepFrequency(double direction)
     {
-        RangeStart = MoveToStepFrequency(RangeStart);
+        var newValue = MoveToStepFrequency(RangeEnd, direction); 
+        
+        if (_isProgramaticChange || Math.Abs(RangeEnd - newValue) < Epsilon)
+        {
+            return;
+        }
+
+        _isProgramaticChange = true;
+        SetCurrentValue(RangeEndProperty, newValue);
+        _isProgramaticChange = false;
     }
 
-    private void RangeMaxToStepFrequency()
+    private double MoveToStepFrequency(double rangeValue, double direction)
     {
-        RangeEnd = MoveToStepFrequency(RangeEnd);
-    }
-
-    private double MoveToStepFrequency(double rangeValue)
-    {
-        double newValue = Minimum + (((int)Math.Round((rangeValue - Minimum) / StepFrequency)) * StepFrequency);
+        if (!IsSnapToStepFrequencyEnabled)
+        {
+            return rangeValue + direction;
+        }
+        
+        double newValue = direction > 0
+            ? Minimum + (((int)Math.Floor((rangeValue + direction - Minimum) / StepFrequency)) * StepFrequency)
+            : Minimum + (((int)Math.Ceiling((rangeValue +direction - Minimum) / StepFrequency)) * StepFrequency);
 
         if (newValue < Minimum)
         {
@@ -712,9 +623,6 @@ public partial class RangeSlider : TemplatedControl
     private Thumb _maxThumb;
     private Canvas _containerCanvas;
     private double _oldValue;
-    private bool _valuesAssigned;
-    private bool _minSet;
-    private bool _maxSet;
     private bool _pointerManipulatingMin;
     private bool _pointerManipulatingMax;
     private bool _pointerManipulatingBoth;
@@ -724,6 +632,7 @@ public partial class RangeSlider : TemplatedControl
     private const double Epsilon = 0.01;
     private bool _isDraggingStart;
     private bool _isDraggingEnd;
+    private bool _isProgramaticChange;
     private readonly DispatcherTimer _keyTimer = new DispatcherTimer();
 }
 

--- a/src/FluentAvalonia/UI/Controls/RangeSlider/RangeSlider.props.cs
+++ b/src/FluentAvalonia/UI/Controls/RangeSlider/RangeSlider.props.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Utilities;
 
 namespace FluentAvalonia.UI.Controls;
 
@@ -23,28 +24,28 @@ public partial class RangeSlider
     /// </summary>
     public static readonly StyledProperty<double> MinimumProperty = 
         RangeBase.MinimumProperty.AddOwner<RangeSlider>(
-            new StyledPropertyMetadata<double>(0d));
+            new StyledPropertyMetadata<double>(0d, coerce: CoerceMinimum));
 
     /// <summary>
     /// Defines the <see cref="Maximum"/> property
     /// </summary>
     public static readonly StyledProperty<double> MaximumProperty = 
         RangeBase.MaximumProperty.AddOwner<RangeSlider>(
-            new StyledPropertyMetadata<double>(100d));
+            new StyledPropertyMetadata<double>(100d, coerce: CoerceMaximum));
 
     /// <summary>
     /// Defines the <see cref="RangeStart"/> property
     /// </summary>
     public static readonly StyledProperty<double> RangeStartProperty = 
         AvaloniaProperty.Register<RangeSlider, double>(nameof(RangeStart),
-            defaultValue: 0, defaultBindingMode: BindingMode.TwoWay);
+            defaultValue: 0, defaultBindingMode: BindingMode.TwoWay, coerce: CoerceRangeStart);
 
     /// <summary>
     /// Defines the <see cref="RangeEnd"/> property
     /// </summary>
     public static readonly StyledProperty<double> RangeEndProperty = 
         AvaloniaProperty.Register<RangeSlider, double>(nameof(RangeEnd), 
-            defaultValue: 100, defaultBindingMode: BindingMode.TwoWay);
+            defaultValue: 100, defaultBindingMode: BindingMode.TwoWay, coerce: CoerceRangeEnd);
 
     /// <summary>
     /// Defines the <see cref="StepFrequency"/> property
@@ -52,6 +53,13 @@ public partial class RangeSlider
     public static readonly StyledProperty<double> StepFrequencyProperty = 
         AvaloniaProperty.Register<RangeSlider, double>(nameof(StepFrequency), 
             defaultValue: 1);
+    
+    /// <summary>
+    /// Defines the <see cref="IsSnapToStepFrequencyEnabled"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsSnapToStepFrequencyEnabledProperty =
+        AvaloniaProperty.Register<Slider, bool>(nameof(IsSnapToStepFrequencyEnabled), true);
+
 
     /// <summary>
     /// Defines the <see cref="ToolTipStringFormat"/> property
@@ -80,7 +88,13 @@ public partial class RangeSlider
         get => GetValue(MinimumProperty);
         set => SetValue(MinimumProperty, value);
     }
+    
+    private static double CoerceMinimum(AvaloniaObject sender, double value)
+    {
+        return ValidateDouble(value) ? value : sender.GetValue(MinimumProperty);
+    }
 
+    
     /// <summary>
     /// Gets or sets the maximum allowed value for the RangeSlider
     /// </summary>
@@ -89,6 +103,14 @@ public partial class RangeSlider
         get => GetValue(MaximumProperty);
         set => SetValue(MaximumProperty, value);
     }
+    
+    private static double CoerceMaximum(AvaloniaObject sender, double value)
+    {
+        return ValidateDouble(value)
+            ? Math.Max(value, sender.GetValue(MinimumProperty))
+            : sender.GetValue(MaximumProperty);
+    }
+
 
     /// <summary>
     /// Gets or sets the start of the selected range
@@ -97,6 +119,13 @@ public partial class RangeSlider
     {
         get => GetValue(RangeStartProperty);
         set => SetValue(RangeStartProperty, value);
+    }
+    
+    private static double CoerceRangeStart(AvaloniaObject sender, double value)
+    {
+        return ValidateDouble(value) 
+            ? MathUtilities.Clamp(value, sender.GetValue(MinimumProperty), Math.Min(sender.GetValue(RangeEndProperty), sender.GetValue(MaximumProperty))) // TODO: How to deal with MinRange here?
+            : sender.GetValue(RangeStartProperty);
     }
 
     /// <summary>
@@ -108,6 +137,13 @@ public partial class RangeSlider
         set => SetValue(RangeEndProperty, value);
     }
 
+    private static double CoerceRangeEnd(AvaloniaObject sender, double value)
+    {
+        return ValidateDouble(value) 
+            ? MathUtilities.Clamp(value, Math.Max(sender.GetValue(MinimumProperty), sender.GetValue(RangeStartProperty)), sender.GetValue(MaximumProperty)) // TODO: How to deal with MinRange here?
+            : sender.GetValue(RangeEndProperty);
+    }
+    
     /// <summary>
     /// Gets or sets the frequency of ticks when dragging the slider
     /// </summary>
@@ -115,6 +151,15 @@ public partial class RangeSlider
     {
         get => GetValue(StepFrequencyProperty);
         set => SetValue(StepFrequencyProperty, value);
+    }
+    
+    /// <summary>
+    /// Gets or sets a value that indicates whether the <see cref="Slider"/> automatically moves the <see cref="Thumb"/> to the closest step frequency.
+    /// </summary>
+    public bool IsSnapToStepFrequencyEnabled
+    {
+        get => GetValue(IsSnapToStepFrequencyEnabledProperty);
+        set => SetValue(IsSnapToStepFrequencyEnabledProperty, value);
     }
 
     /// <summary>
@@ -175,5 +220,14 @@ public partial class RangeSlider
     private const string s_tpMaxThumb = "MaxThumb";
     private const string s_tpContainerCanvas = "ContainerCanvas";
     private const string s_tpToolTipText = "ToolTipText";
+    
+    /// <summary>
+    /// Checks if the double value is not infinity nor NaN.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    private static bool ValidateDouble(double value)
+    {
+        return !double.IsInfinity(value) && !double.IsNaN(value);
+    }
 }
 


### PR DESCRIPTION
## Descrition of changes

- Use `CoerceValue` where possible (same as Slider in Avalonia uses)
- Add property to control snap behavior `IsSnapToStepFrequencyEnabled` (not everyone may like it, same as Slider in Avalonia)
- SnapToFrequency should be handled in input events, not in `PropertyChanged` (don't touch Values from the ViewModel sent)

## To test the RangeSlider

I added a minimum sample to SandBox. Can revert this change before merging if you want me to

## Tests
Well ... Need to think about useful tests later on, if that PR gets accepted. 

## Fixed issues
Fixes #568 
