### PR TITLE
Fix VerticalTextAlignment Override not being set when initializing

### DIFF
--- a/src/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.axaml.cs
+++ b/src/FluentAvalonia/Styling/Core/FluentAvaloniaTheme.axaml.cs
@@ -1,14 +1,17 @@
 ﻿using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using FluentAvalonia.Interop;
 using FluentAvalonia.UI.Media;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -133,8 +136,20 @@ public partial class FluentAvaloniaTheme : Styles, IResourceProvider
     /// to get a consistent experience, at the (small) expense of breaking Fluent design principles. If your controls
     /// never use multi-line text, you'll never see the effect of this property.
     /// </remarks>
-    public TextVerticalAlignmentOverride TextVerticalAlignmentOverrideBehavior { get; set; } =
-        TextVerticalAlignmentOverride.EnabledNonWindows;
+    public TextVerticalAlignmentOverride TextVerticalAlignmentOverrideBehavior
+    {
+        get => _textAlignmentOverride;
+        set
+        {
+            if (_textAlignmentOverride != value)
+            {
+                // NOTE: Attempting to downgrade this after startup will not 
+                // remove the styles - this still requires an app restart
+                _textAlignmentOverride = value;
+                SetTextAlignmentOverrides();
+            }
+        }
+    }
 
     public AvaloniaList<IResourceDictionary> MergedDictionaries { get; }
       
@@ -393,7 +408,7 @@ public partial class FluentAvaloniaTheme : Styles, IResourceProvider
         // may get messed up b/c of the centered alignment
         var s3 = new Style(x =>
         {
-            return x.OfType<ComboBox>().Template().OfType<ContentControl>().Child().OfType<TextBlock>();
+            return x.OfType<ComboBox>().Template().OfType<ContentPresenter>().Child().OfType<TextBlock>();
         });
         s3.Setters.Add(new Setter(Layoutable.VerticalAlignmentProperty, VerticalAlignment.Center));
         Add(s3);
@@ -554,6 +569,9 @@ public partial class FluentAvaloniaTheme : Styles, IResourceProvider
     private bool _preferUserAccentColor;
     private ResourceDictionary _accentColorsDictionary;
     private IPlatformSettings _platformSettings;
+
+    private TextVerticalAlignmentOverride _textAlignmentOverride =
+        TextVerticalAlignmentOverride.EnabledNonWindows;
 
     public const string LightModeString = "Light";
     public const string DarkModeString = "Dark";


### PR DESCRIPTION
As noted in #616, text alignment was not properly centered on non-Windows systems - even if using the `TextVerticalAlignmentOverrideBehavior` property on `FluentAvaloniaTheme`. This issue was caused because FATheme gets initialized before any properties set in Xaml are set (init in ctor). This issue dates back to when FATheme was forcibly moved to a Xaml file to accommodate AOT, so its apparently been around a while. 

I've adjusted the property setter to call the method that activates the special styles so that it calls. Note, at runtime you can only turn on the override. Setting the property to turn it off will do nothing - so it still should be treated as a start-up only property. I also adjusted one of styles to correct for `ComboBox`.

Fixes #616

Note: I've tested with a non Segoe font on Windows and it is resolved, but if someone is able to test this branch on Linux or Mac without a package, please let me know if this fixes the issue.