### PR TITLE
Fix: Add fallback for missing DPI-related Win32 APIs

### DIFF
--- a/src/FluentAvalonia/Core/FAUISettings.cs
+++ b/src/FluentAvalonia/Core/FAUISettings.cs
@@ -64,8 +64,8 @@ public class FAUISettings
 
     private static void GetWin32DragSize(double scaling, out double cxDrag, out double cyDrag)
     {
-        cxDrag = Win32Interop.GetSystemMetricsForDpi(68, (uint)Math.Round(96 * scaling));
-        cyDrag = Win32Interop.GetSystemMetricsForDpi(69, (uint)Math.Round(96 * scaling));
+        cxDrag = Win32Interop.GetSystemMetricsWithFallback(68, (uint)Math.Round(96 * scaling));
+        cyDrag = Win32Interop.GetSystemMetricsWithFallback(69, (uint)Math.Round(96 * scaling));
     }
 
     private static readonly FAUISettings s_Instance;

--- a/src/FluentAvalonia/Interop/OSVersionHelper.cs
+++ b/src/FluentAvalonia/Interop/OSVersionHelper.cs
@@ -115,7 +115,8 @@ public static class OSVersionHelper
             if (build != osInfo.BuildNumber)
             {
                 return osInfo.BuildNumber > build;
-            }           
+            }
+            return true;
         }
 
         return false;

--- a/src/FluentAvalonia/Interop/Win32Interop.cs
+++ b/src/FluentAvalonia/Interop/Win32Interop.cs
@@ -20,17 +20,20 @@ internal static unsafe partial class Win32Interop
     public static extern BOOL AdjustWindowRectEx(RECT* lpRect, uint dwStyle, BOOL bMenu, uint dwExStyle);
 
     [DllImport(s_user32, SetLastError = true)]
-    public static extern int GetSystemMetrics(int smIndex);
+    private static extern int GetSystemMetrics(int smIndex);
 
     [DllImport(s_user32, SetLastError = true)]
-    public static extern int GetSystemMetricsForDpi(int nIndex, uint dpi);
+    private static extern int GetSystemMetricsForDpi(int nIndex, uint dpi);
 
     [DllImport(s_user32, SetLastError = true)]
     public static extern BOOL SetWindowPos(HWND hWnd, HWND hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
 
     [DllImport(s_user32, SetLastError = true)]
-    public static extern BOOL AdjustWindowRectExForDpi(RECT* lpRect, int dwStyle, BOOL bMenu, int dwExStyle, int dpi);
-
+    private static extern BOOL AdjustWindowRectExForDpi(RECT* lpRect, int dwStyle, BOOL bMenu, int dwExStyle, int dpi);
+    
+    [DllImport(s_user32, SetLastError = true)]
+    private static extern bool AdjustWindowRectEx(RECT* lpRect, int dwStyle, bool bMenu, int dwExStyle);
+    
     [DllImport(s_user32, SetLastError = true)]
     public static extern LRESULT DefWindowProcW(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
 
@@ -63,6 +66,33 @@ internal static unsafe partial class Win32Interop
     // Below is adapted from TerraFX.Interop.Windows, MIT License
     public static delegate*<HWND, int, nint> GetWindowLongPtr => &GetWindowLongPtrW;
 
+    public static int GetSystemMetricsWithFallback(int nIndex, uint dpi)
+    {
+        try
+        {
+            return GetSystemMetricsForDpi(nIndex, dpi);
+        }
+        catch (EntryPointNotFoundException)
+        {
+            // Older Windows
+            return GetSystemMetrics(nIndex);
+        }
+    }
+    
+    public static void AdjustWindowRectExWithFallback(RECT* lpRect, int dwStyle, BOOL bMenu, int dwExStyle, int dpi)
+    {
+        try
+        {
+            // >= Windows 10 1607
+            AdjustWindowRectExForDpi(lpRect, dwStyle, bMenu, dwExStyle, dpi);
+        }
+        catch (EntryPointNotFoundException)
+        {
+            // Older Windows
+            AdjustWindowRectEx(lpRect, dwStyle, bMenu, dwExStyle);
+        }
+    }
+    
     public static nint GetWindowLongPtrW(HWND hWnd, int nIndex)
     {
         if (sizeof(nint) == 4)

--- a/src/FluentAvalonia/Interop/Win32Interop.cs
+++ b/src/FluentAvalonia/Interop/Win32Interop.cs
@@ -68,29 +68,19 @@ internal static unsafe partial class Win32Interop
 
     public static int GetSystemMetricsWithFallback(int nIndex, uint dpi)
     {
-        try
-        {
+        if (OSVersionHelper.IsWindowsAtLeast(10, 0, 14393)) // 1607
             return GetSystemMetricsForDpi(nIndex, dpi);
-        }
-        catch (EntryPointNotFoundException)
-        {
-            // Older Windows
-            return GetSystemMetrics(nIndex);
-        }
+        return GetSystemMetrics(nIndex);
     }
     
     public static void AdjustWindowRectExWithFallback(RECT* lpRect, int dwStyle, BOOL bMenu, int dwExStyle, int dpi)
     {
-        try
+        if (OSVersionHelper.IsWindowsAtLeast(10, 0, 14393)) // 1607
         {
-            // >= Windows 10 1607
             AdjustWindowRectExForDpi(lpRect, dwStyle, bMenu, dwExStyle, dpi);
+            return;
         }
-        catch (EntryPointNotFoundException)
-        {
-            // Older Windows
-            AdjustWindowRectEx(lpRect, dwStyle, bMenu, dwExStyle);
-        }
+        AdjustWindowRectEx(lpRect, dwStyle, bMenu, dwExStyle);
     }
     
     public static nint GetWindowLongPtrW(HWND hWnd, int nIndex)

--- a/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
+++ b/src/FluentAvalonia/UI/Windowing/Win32/Win32WindowManager.cs
@@ -156,8 +156,8 @@ internal unsafe class Win32WindowManager
         _window.RenderScaling;
 
     private int GetResizeHandleHeight() =>
-        GetSystemMetricsForDpi(SM_CXPADDEDBORDER, (uint)(96 * GetScaling())) +
-        GetSystemMetricsForDpi(SM_CYSIZEFRAME, (uint)(96 * GetScaling()));
+        GetSystemMetricsWithFallback(SM_CXPADDEDBORDER, (uint)(96 * GetScaling())) +
+        GetSystemMetricsWithFallback(SM_CYSIZEFRAME, (uint)(96 * GetScaling()));
 
     private int GetTopBorderHeight()
     {
@@ -178,7 +178,7 @@ internal unsafe class Win32WindowManager
         var exStyle = (int)GetWindowLongPtr((HWND)Hwnd, -20);
 
         RECT frame;
-        AdjustWindowRectExForDpi(&frame, style, false, exStyle, (int)(GetScaling() * 96));
+        AdjustWindowRectExWithFallback(&frame, style, false, exStyle, (int)(GetScaling() * 96));
 
         marg.topHeight = -frame.top;
 
@@ -229,7 +229,7 @@ internal unsafe class Win32WindowManager
             var exStyle = (int)GetWindowLongPtr((HWND)Hwnd, -20);
 
             RECT frame;
-            AdjustWindowRectExForDpi(&frame, style, false, exStyle, (int)(GetScaling() * 96));
+            AdjustWindowRectExWithFallback(&frame, style, false, exStyle, (int)(GetScaling() * 96));
 
             newSize.left -= frame.left; // left frame is negative, subtract to add it back
             newSize.right -= frame.right; // right frame is positive, subtract to pull it back


### PR DESCRIPTION
<img width="996" alt="image" src="https://github.com/user-attachments/assets/1af43492-6d1b-4d6b-8e99-e3dffd06c67c" />

fix #628