### PR TITLE
Fixed focus adorner style to be from ControlTheme

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/FocusAdornerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/FocusAdornerStyles.axaml
@@ -1,16 +1,12 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             x:CompileBindings="True">
-    <Styles.Resources>
-        <Thickness x:Key="SystemControlFocusVisualMargin">0</Thickness>
-        <Thickness x:Key="SystemControlFocusVisualPrimaryThickness">2</Thickness>
-        <Thickness x:Key="SystemControlFocusVisualSecondaryThickness">1</Thickness>
-    </Styles.Resources>
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+    <Thickness x:Key="SystemControlFocusVisualMargin">0</Thickness>
+    <Thickness x:Key="SystemControlFocusVisualPrimaryThickness">2</Thickness>
+    <Thickness x:Key="SystemControlFocusVisualSecondaryThickness">1</Thickness>
 
-    <Style Selector=":is(Control)">
-        <Setter Property="FocusAdorner">
+    <ControlTheme x:Key="{x:Type AdornerLayer}" TargetType="AdornerLayer">
+        <Setter Property="DefaultFocusAdorner">
             <FocusAdornerTemplate>
                 <Border BorderThickness="{DynamicResource SystemControlFocusVisualPrimaryThickness}"
                         BorderBrush="{DynamicResource FocusStrokeColorOuterBrush}"
@@ -22,5 +18,5 @@
                 </Border>
             </FocusAdornerTemplate>
         </Setter>
-    </Style>
-</Styles>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/Controls.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/Controls.axaml
@@ -58,7 +58,8 @@
                 <MergeResourceInclude Source="/Styling/ControlThemes/BasicControls/RefreshControlStyles.axaml" />
                 <MergeResourceInclude Source="/Styling/ControlThemes/BasicControls/PathIcon.axaml" />
                 <MergeResourceInclude Source="/Styling/ControlThemes/BasicControls/HyperlinkButtonStyles.axaml" />
-                
+                <MergeResourceInclude Source="/Styling/ControlThemes/BasicControls/FocusAdornerStyles.axaml" />
+
                 
                 <!-- FluentAvalonia Controls -->
                 <MergeResourceInclude Source="/Styling/ControlThemes/FAControls/FrameStyles.axaml" />
@@ -120,7 +121,6 @@
         </ResourceDictionary>
     </Styles.Resources>
 
-    <StyleInclude Source="/Styling/ControlThemes/BasicControls/FocusAdornerStyles.axaml" />
     <StyleInclude Source="/Styling/ControlThemes/BasicControls/UserControlStyles.axaml" />
 
 


### PR DESCRIPTION
Fixed focus adorner style to be from ControlTheme just like in Avalonia.
Currently the style that matches `:is(Control)` is overriding any custom Adorner set by users in ControlThemes