### PR TITLE
FA 2.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.1.0</AvaloniaVersion>
+    <AvaloniaVersion>11.2.3</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.2.3</AvaloniaVersion>
+    <AvaloniaVersion>11.2.5</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,8 +4,8 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>2.1.0</Version>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <Version>2.3.0</Version>
+    <AssemblyVersion>2.3.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <!-- Add Package Icon -->

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DatePickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DatePickerStyles.axaml
@@ -40,6 +40,10 @@
 
     <Thickness x:Key="DateTimeFlyoutBorderThickness">1</Thickness>
 
+    <x:String x:Key="DatePickerMonthTextPlaceholder">month</x:String>
+    <x:String x:Key="DatePickerDayTextPlaceholder">day</x:String>
+    <x:String x:Key="DatePickerYearTextPlaceholder">year</x:String>
+
     <ControlTheme x:Key="DateTimePickerItem" TargetType="ListBoxItem">
         <Setter Property="Foreground" Value="{DynamicResource LoopingSelectorItemForeground}" />
         <Setter Property="Padding" Value="{DynamicResource DatePickerFlyoutPresenterItemPadding}"/>
@@ -271,17 +275,23 @@
                                 VerticalContentAlignment="Stretch"
                                 TemplatedControl.IsTemplateFocusTarget="True">
                             <Grid Name="PART_ButtonContentGrid" ColumnDefinitions="78*,Auto,132*,Auto,78*">
-                                <TextBlock Name="PART_DayTextBlock" Text="day" HorizontalAlignment="Center"
+                                <TextBlock Name="PART_DayTextBlock" 
+                                           Text="{DynamicResource DatePickerDayTextPlaceholder}" 
+                                           HorizontalAlignment="Center"
                                            Padding="{DynamicResource DatePickerHostPadding}"
                                            FontFamily="{TemplateBinding FontFamily}"
                                            FontWeight="{TemplateBinding FontWeight}"
                                            FontSize="{TemplateBinding FontSize}"/>
-                                <TextBlock Name="PART_MonthTextBlock" Text="month" TextAlignment="Left"
+                                <TextBlock Name="PART_MonthTextBlock" 
+                                           Text="{DynamicResource DatePickerMonthTextPlaceholder}" 
+                                           TextAlignment="Left"
                                            Padding="{DynamicResource DatePickerHostMonthPadding}"
                                            FontFamily="{TemplateBinding FontFamily}"
                                            FontWeight="{TemplateBinding FontWeight}"
                                            FontSize="{TemplateBinding FontSize}"/>
-                                <TextBlock Name="PART_YearTextBlock" Text="year" HorizontalAlignment="Center"
+                                <TextBlock Name="PART_YearTextBlock"
+                                           Text="{DynamicResource DatePickerYearTextPlaceholder}" 
+                                           HorizontalAlignment="Center"
                                            Padding="{DynamicResource DatePickerHostPadding}"
                                            FontFamily="{TemplateBinding FontFamily}"
                                            FontWeight="{TemplateBinding FontWeight}"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TimePickerStyles.axaml
@@ -24,6 +24,9 @@
     <x:Double x:Key="TimePickerFlyoutPresenterItemHeight">40</x:Double>
     <Thickness x:Key="TimePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
     <Thickness x:Key="TimePickerHostPadding">0,3,0,6</Thickness>
+    <x:String x:Key="TimePickerHourTextPlaceholder">hour</x:String>
+    <x:String x:Key="TimePickerMinuteTextPlaceholder">minute</x:String>
+    <x:String x:Key="TimePickerSecondTextPlaceholder">seconds</x:String>
 
     <ControlTheme x:Key="TimePickerFlyoutButtonStyle" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -85,6 +88,7 @@
                                 <Border Name="PART_FirstPickerHost" Grid.Column="0" 
                                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                     <TextBlock Name="PART_HourTextBlock"
+                                               Text="{DynamicResource TimePickerHourTextPlaceholder}"
                                                HorizontalAlignment="Center"
                                                Padding="{DynamicResource TimePickerHostPadding}"
                                                FontFamily="{TemplateBinding FontFamily}"
@@ -101,6 +105,7 @@
                                 <Border Name="PART_SecondPickerHost" Grid.Column="2"
                                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                     <TextBlock Name="PART_MinuteTextBlock"
+                                               Text="{DynamicResource TimePickerMinuteTextPlaceholder}"
                                                HorizontalAlignment="Center"
                                                Padding="{DynamicResource TimePickerHostPadding}"
                                                FontFamily="{TemplateBinding FontFamily}"
@@ -115,6 +120,23 @@
                                            Grid.Column="3" />
 
                                 <Border Name="PART_ThirdPickerHost" Grid.Column="4" 
+                                        HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                    <TextBlock Name="PART_SecondTextBlock"
+                                               Text="{DynamicResource TimePickerSecondTextPlaceholder}"
+                                               HorizontalAlignment="Center"
+                                               Padding="{DynamicResource TimePickerHostPadding}"
+                                               FontFamily="{TemplateBinding FontFamily}"
+                                               FontWeight="{TemplateBinding FontWeight}"
+                                               FontSize="{TemplateBinding FontSize}" />
+                                </Border>
+
+                                <Rectangle Name="PART_ThirdColumnDivider"
+                                           Fill="{DynamicResource TimePickerSpacerFill}"
+                                           HorizontalAlignment="Center"
+                                           Width="{DynamicResource TimePickerSpacerThemeWidth}"
+                                           Grid.Column="5" />
+
+                                <Border Name="PART_FourthPickerHost" Grid.Column="6"
                                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                                     <TextBlock Name="PART_PeriodTextBlock"
                                                HorizontalAlignment="Center"
@@ -232,7 +254,23 @@
 
                             </Panel>
 
-                            <Panel Name="PART_PeriodHost" Grid.Column="4">
+                            <Panel Name="PART_SecondHost" Grid.Column="4">
+                                <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                                              VerticalScrollBarVisibility="Hidden">
+                                    <DateTimePickerPanel Name="PART_SecondSelector"
+                                                         PanelType="Second"
+                                                         ShouldLoop="True"
+                                                         ItemHeight="{DynamicResource TimePickerFlyoutPresenterItemHeight}" />
+                                </ScrollViewer>
+                                <RepeatButton Name="PART_SecondUpButton"
+                                              Theme="{StaticResource DateTimePickerFlyoutLoopingNavButton}"
+                                              Classes="UpButton"/>
+                                <RepeatButton Name="PART_SecondDownButton"
+                                              Theme="{StaticResource DateTimePickerFlyoutLoopingNavButton}"
+                                              Classes="DownButton"/>
+                            </Panel>
+
+                            <Panel Name="PART_PeriodHost" Grid.Column="6">
                                 <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                                               VerticalScrollBarVisibility="Hidden">
                                     <DateTimePickerPanel Name="PART_PeriodSelector"
@@ -254,7 +292,7 @@
                                     Background="{DynamicResource TimePickerFlyoutPresenterHighlightFill}"
                                     Margin="4 2"
                                     Grid.Column="0"
-                                    Grid.ColumnSpan="5"
+                                    Grid.ColumnSpan="7"
                                     VerticalAlignment="Center"
                                     Height="{DynamicResource TimePickerFlyoutPresenterHighlightHeight}"
                                     CornerRadius="{DynamicResource ControlCornerRadius}"/>
@@ -270,6 +308,12 @@
                                 HorizontalAlignment="Center"
                                 Width="{DynamicResource TimePickerSpacerThemeWidth}"
                                 Grid.Column="3" />
+
+                            <Rectangle Name="PART_ThirdSpacer"
+                                Fill="{DynamicResource TimePickerFlyoutPresenterSpacerFill}"
+                                HorizontalAlignment="Center"
+                                Width="{DynamicResource TimePickerSpacerThemeWidth}"
+                                Grid.Column="5" />
                         </Grid>
 
                         <Grid Grid.Row="1" Height="{DynamicResource TimePickerFlyoutPresenterAcceptDismissHostGridHeight}"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/RangeSliderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/RangeSliderStyles.axaml
@@ -4,13 +4,16 @@
 
     <Design.PreviewWith>
         <Border MinWidth="200" MinHeight="100" Background="#202020">
-            <ui:RangeSlider VerticalAlignment="Center" Margin="20"/>
+            <ui:RangeSlider VerticalAlignment="Center" Margin="20"
+                            RangeStart="20" RangeEnd="80"
+                            IsEnabled="False"/>
         </Border>
     </Design.PreviewWith>
 
     <x:Double x:Key="RangeSliderTrackCornerRadius">2</x:Double>
     <Thickness x:Key="RangeSliderToolTipPadding">4</Thickness>
     <x:Double x:Key="RangeSliderToolTipFontSize">14</x:Double>
+    <x:Double x:Key="RangeSliderTrackThemeHeight">4</x:Double>
 
     <ControlTheme TargetType="Thumb"
                   x:Key="RangeSliderThumbStyle"
@@ -32,7 +35,7 @@
                     <Border Name="OutOfRangeContentContainer" 
                             Background="Transparent"
                             Margin="2 0">
-                        <Rectangle Name="BackgroundElement" Height="2"
+                        <Rectangle Name="BackgroundElement" Height="{DynamicResource RangeSliderTrackThemeHeight}"
                                    Fill="{TemplateBinding Background}"
                                    RadiusX="{DynamicResource RangeSliderTrackCornerRadius}"
                                    RadiusY="{DynamicResource RangeSliderTrackCornerRadius}" />
@@ -43,7 +46,7 @@
                             Background="Transparent"
                             ClipToBounds="False">
                         <Rectangle Name="ActiveRectangle"
-                                   Height="2"
+                                   Height="{DynamicResource RangeSliderTrackThemeHeight}"
                                    HorizontalAlignment="Stretch"
                                    VerticalAlignment="Center"
                                    Fill="{TemplateBinding Foreground}" />
@@ -80,6 +83,18 @@
                 </Panel>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^:disabled /template/ Rectangle#BackgroundElement">
+            <Setter Property="Fill" Value="{DynamicResource SliderTrackFillDisabled}" />
+        </Style>
+
+        <Style Selector="^:disabled /template/ Rectangle#ActiveRectangle">
+            <Setter Property="Fill" Value="{DynamicResource SliderTrackValueFillDisabled}" />
+        </Style>
+
+        <Style Selector="^ /template/ Thumb">
+            <Setter Property="Background" Value="{DynamicResource SliderThumbBackgroundDisabled}" />
+        </Style>
     </ControlTheme>
     
     

--- a/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
+++ b/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
@@ -3519,7 +3519,7 @@
             <StaticResource x:Key="DataGridRowHoveredBackgroundColor" ResourceKey="SubtleFillColorSecondaryBrush" />
             <SolidColorBrush x:Key="DataGridDropLocationIndicatorBackground" Color="#3F4346" />
             <StaticResource x:Key="DataGridScrollBarsSeparatorBackground" ResourceKey="ControlFillColorTertiaryBrush" />
-            <SolidColorBrush x:Key="DataGridDisabledVisualElementBackground" Color="#8CFFFFFF" />
+            <SolidColorBrush x:Key="DataGridDisabledVisualElementBackground" Color="#8C000000" />
             <StaticResource x:Key="DataGridRowBackgroundBrush" ResourceKey="SubtleFillColorTransparentBrush" />
 
 

--- a/src/FluentAvalonia/UI/Controls/IconElement/FontIcon.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/FontIcon.cs
@@ -48,8 +48,8 @@ public partial class FontIcon : FAIconElement
         var dstRect = new Rect(Bounds.Size);
         using (context.PushClip(dstRect))
         {
-            var pt = new Point(dstRect.Center.X - _textLayout.Width / 2,
-                               dstRect.Center.Y - _textLayout.Height / 2);
+            var pt = new Point(dstRect.Center.X - _textLayout.WidthIncludingTrailingWhitespace * 0.5,
+                               dstRect.Center.Y - _textLayout.Height * 0.5);
             _textLayout.Draw(context, pt);
         }
     }

--- a/src/FluentAvalonia/UI/Controls/IconElement/FontIcon.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/FontIcon.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls.Documents;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
 
@@ -48,7 +49,7 @@ public partial class FontIcon : FAIconElement
         var dstRect = new Rect(Bounds.Size);
         using (context.PushClip(dstRect))
         {
-            var pt = new Point(dstRect.Center.X - _textLayout.WidthIncludingTrailingWhitespace * 0.5,
+            var pt = new Point(dstRect.Center.X - _textLayout.Width * 0.5,
                                dstRect.Center.Y - _textLayout.Height * 0.5);
             _textLayout.Draw(context, pt);
         }

--- a/src/FluentAvalonia/UI/Controls/IconElement/SymbolIcon.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/SymbolIcon.cs
@@ -87,7 +87,7 @@ public class SymbolIcon : FAIconElement
         var dstRect = new Rect(Bounds.Size);
         using (context.PushClip(dstRect))
         {
-            var pt = new Point(dstRect.Center.X - _textLayout.WidthIncludingTrailingWhitespace * 0.5,
+            var pt = new Point(dstRect.Center.X - _textLayout.Width * 0.5,
                                dstRect.Center.Y - _textLayout.Height * 0.5);
             _textLayout.Draw(context, pt);
         }

--- a/src/FluentAvalonia/UI/Controls/IconElement/SymbolIcon.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/SymbolIcon.cs
@@ -87,8 +87,8 @@ public class SymbolIcon : FAIconElement
         var dstRect = new Rect(Bounds.Size);
         using (context.PushClip(dstRect))
         {
-            var pt = new Point(dstRect.Center.X - _textLayout.Width / 2,
-                dstRect.Center.Y - _textLayout.Height / 2);
+            var pt = new Point(dstRect.Center.X - _textLayout.WidthIncludingTrailingWhitespace * 0.5,
+                               dstRect.Center.Y - _textLayout.Height * 0.5);
             _textLayout.Draw(context, pt);
         }
     }

--- a/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
+++ b/src/FluentAvalonia/UI/Controls/NavigationView/NavigationView.cs
@@ -4365,12 +4365,12 @@ public partial class NavigationView : HeaderedContentControl
         }
     }
 
-    private class StepEasingFunction : IEasing
+    private class StepEasingFunction : Easing
     {
         // TODO: What is the default step count for WinUI's StepEasingFunction
         public int Steps { get; set; }
 
-        public double Ease(double progress)
+        public override double Ease(double progress)
         {
             return Math.Round(progress * Steps) * (1 / Steps);
         }

--- a/src/FluentAvalonia/UI/Controls/Repeater/ItemsRepeater.cs
+++ b/src/FluentAvalonia/UI/Controls/Repeater/ItemsRepeater.cs
@@ -15,6 +15,8 @@ public partial class ItemsRepeater : Panel
 {
     public ItemsRepeater()
     {
+        SetCurrentValue(LayoutProperty, new StackLayout());
+
         _viewportManager = new ViewportManager(this);
         _viewManager = new ViewManager(this);
         _transitionManager = new TransitionManager(this);

--- a/src/FluentAvalonia/UI/Controls/Repeater/ItemsRepeater.cs
+++ b/src/FluentAvalonia/UI/Controls/Repeater/ItemsRepeater.cs
@@ -15,11 +15,11 @@ public partial class ItemsRepeater : Panel
 {
     public ItemsRepeater()
     {
-        SetCurrentValue(LayoutProperty, new StackLayout());
-
         _viewportManager = new ViewportManager(this);
         _viewManager = new ViewManager(this);
         _transitionManager = new TransitionManager(this);
+
+        SetCurrentValue(LayoutProperty, new StackLayout());
 
         AutomationProperties.SetAccessibilityView(this, AccessibilityView.Raw);
         SetValue(KeyboardNavigation.TabNavigationProperty, KeyboardNavigationMode.Once);

--- a/src/FluentAvalonia/UI/Controls/Repeater/ItemsRepeater.props.cs
+++ b/src/FluentAvalonia/UI/Controls/Repeater/ItemsRepeater.props.cs
@@ -28,7 +28,7 @@ public partial class ItemsRepeater : Panel
     /// Defines the <see cref="Layout"/> property
     /// </summary>
     public static readonly StyledProperty<Layout> LayoutProperty =
-        AvaloniaProperty.Register<ItemsRepeater, Layout>(nameof(Layout), defaultValue: new StackLayout());
+        AvaloniaProperty.Register<ItemsRepeater, Layout>(nameof(Layout));
 
     /// <summary>
     /// Defines the <see cref="ItemsSource"/> property

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
@@ -402,7 +403,13 @@ public class TabViewListView : ListBox
 
         if (!_isInDrag && _initialPoint.HasValue)
         {
-            _dragReorderPopup.Host?.ConfigurePosition(this, PlacementMode.Pointer, _popupOffset);
+            _dragReorderPopup.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(x =>
+            {
+                x.Offset = _popupOffset;
+            });
+            //var req = PopupPositionRequest.
+            //_dragReorderPopup.Host?
+            //    .ConfigurePosition(this, PlacementMode.Pointer, _popupOffset);
         }
     }
 


### PR DESCRIPTION
Updates FA to package version 2.3 - which requires Avalonia 11.2.5 minimum

- Text issue with icons should be fixed thanks to upstream PR. I'm keeping `SymbolIcon` and `FontIcon` using TextLayout.Width and rendering seems ok
Should address:
fixes #648 
fixes #647 
fixes #630

Date & TimePicker changes
- Updates the FA styles to account for the PR that added seconds, closes #638 
- Also added string resources to both `DatePicker` and `TimePicker` for the placeholder texts when no date or time is set (hour, minute, etc.) This bring the FA styles more inline with upstream and you can change the labels as you wish now

ItemsRepeater
- Alternate, better, solution to #645. Don't create a default value for the `ItemsRepeater.Layout` property as the StackLayout reference can cause event handler leaks. Instead use `SetCurrentValue` in the ctor. Closes #644

RangeSlider
- Fixes Track height to match `Slider`, fixes #650
- Fixes RangeSlider disabled style, fixes #653
Note because of the semi-transparency in Fluent2, the RangeSlider will have slightly darker colors in disabled mode because of overlapping visuals.

DataGrid
- Uses user suggestion for DataGrid disabled color, closes #598

Addresses some other things that required changes as of Avalonia 11.2.3

Package will also include previous PRs that are in master but not published yet:
#635 
#631 
#629