### PR TITLE
Fix Expander header should stretch horizontally

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ExpanderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ExpanderStyles.axaml
@@ -52,7 +52,7 @@
         <Setter Property="BorderThickness" Value="{DynamicResource ExpanderHeaderBorderThickness}" />
         <Setter Property="Foreground" Value="{DynamicResource ExpanderHeaderForeground}" />
         <Setter Property="Padding" Value="{DynamicResource ExpanderHeaderPadding}" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />


### PR DESCRIPTION
Demo code:
```xaml
 <Design.PreviewWith>
     <Border Width="550" Padding="50">
         <StackPanel Spacing="5">
          
             <Expander>
                 <Expander.Header>
                     <Grid Margin="0,16,0,16" ColumnDefinitions="Auto,*,Auto">
                         <Grid Grid.Column="0" Margin="0,0,12,0">
                             <TextBlock MinWidth="26"
                                        Margin="4,0,0,0"
                                        HorizontalAlignment="Center"
                                        VerticalAlignment="Center"
                                        FontFamily="{StaticResource SymbolThemeFontFamily}"
                                        FontSize="18"
                                        Text="{x:Static ui:FontSymbols.System}" />
                         </Grid>
                         <Grid Grid.Column="1" RowDefinitions="Auto,Auto">
                             <TextBlock Grid.Row="0" Text="Header" />
                             <TextBlock Grid.Row="1"
                                        FontSize="11"
                                        Foreground="{DynamicResource SystemFillColorSolidNeutralBrush}"
                                        Text="Hint" />
                         </Grid>
                         <Grid Grid.Column="2" Margin="0,0,0,0">
                             <ToggleSwitch OffContent="" OnContent="" />
                         </Grid>
                     </Grid>
                 </Expander.Header>
                 <TextBox />
             </Expander>

         </StackPanel>
     </Border>
 </Design.PreviewWith>
```

Rendering results:

Before PR:

![image](https://github.com/user-attachments/assets/2c825fb7-ae63-41b8-9c9b-705b20b6fa50)


After PR:

![image](https://github.com/user-attachments/assets/b0d15545-23d5-42f7-bd01-742c4d3fc5b9)
