### PR TITLE
Add check to avoid System.NullReferenceException using NumberBox

### DIFF
--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
@@ -242,15 +242,7 @@ public partial class NumberBox : TemplatedControl
         if (_textBox == null)
             return;
 
-        // Validate the text of the inner textbox
-        if (_textBox.Text == null)
-        {
-            // Override text to current value
-            UpdateTextToValue();
-            return;
-        }
-
-        var text = _textBox.Text.Trim();
+        var text = _textBox.Text?.Trim();
 
         // Handles empty TextBox case, set text ot current value
         if (string.IsNullOrEmpty(text))

--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.cs
@@ -242,6 +242,14 @@ public partial class NumberBox : TemplatedControl
         if (_textBox == null)
             return;
 
+        // Validate the text of the inner textbox
+        if (_textBox.Text == null)
+        {
+            // Override text to current value
+            UpdateTextToValue();
+            return;
+        }
+
         var text = _textBox.Text.Trim();
 
         // Handles empty TextBox case, set text ot current value


### PR DESCRIPTION
Add check on the string? “Text” of the "_textBox" variable to avoid System.NullReferenceException

Fixes #667 