### PR TITLE
FA 2.4

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/ContentDialogStyles.axaml
@@ -33,7 +33,7 @@
                                 MinHeight="{DynamicResource ContentDialogMinHeight}"
                                 MaxHeight="{DynamicResource ContentDialogMaxHeight}"
                                 HorizontalAlignment="Center"
-                                VerticalAlignment="Center" Margin="100"
+                                VerticalAlignment="Center"
                                 Effect="drop-shadow(0 8 32 #66000000)"
                                 BackgroundSizing="{TemplateBinding BackgroundSizing}">
                             <!-- Even in WinUI, shadow is always black regardless of light/dark mode -->


### PR DESCRIPTION
2.4 is the removal of the `FAColorPicker` and `ColorPickerButton`, see the previous PR for that

Also removed the margin around `ContentDialog` as I've determined that really isn't needed. Fixes #664