### PR TITLE
Fix per window DPI awareness in AppWindow

### DIFF
--- a/src/FluentAvalonia/Interop/Win32Interop.cs
+++ b/src/FluentAvalonia/Interop/Win32Interop.cs
@@ -40,6 +40,12 @@ internal static unsafe partial class Win32Interop
     [DllImport(s_user32, SetLastError = true)]
     public static extern LRESULT CallWindowProcW(nint lpPrevWndProc, HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
 
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern uint GetDpiForWindow(HWND hwnd);
+    
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr SendMessage(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam);
+
 
     [DllImport(s_user32, SetLastError = true)]
     public static extern BOOL PostMessage(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
@@ -225,6 +231,7 @@ internal static unsafe partial class Win32Interop
     public const int WM_SETTINGCHANGE = 0x001A; // Also WM_WININICHANGE
     public const int WM_SYSCOLORCHANGE = 0x0015;
     public const int WM_DESTROY = 0x0002;
+    public const int WM_SHOWWINDOW = 0x0018;
 
     //SC
     public const int SC_CLOSE = 0xF060;


### PR DESCRIPTION
Hello!

I discovered a serious issue with AppWindow that occurs when a user has two monitors with different scaling settings.

For example, consider this configuration:
- Main display: 1440p at 100% scaling
- Second display: 1080p at 125% scaling

When I launch an app on the second display and it shows a window using AppWindow, the window itself is sized correctly, but the AppWindow content is not - it renders as if using 100% scaling instead of 125%.

<img width="1316" height="822" alt="Broken AppWindow" src="https://github.com/user-attachments/assets/aa3948f8-f7fc-4eca-9d11-342f286764b9" />

The issue can be temporarily resolved by dragging the window to the main monitor and back to the second display, which forces it to render at the correct 125% scale.

If the DPI configuration is reversed, the situation is also reversed: the window gets cut off. This is particularly problematic because having higher scaling on the main display is more common, and when the window is cut off, it can hide critical UI elements including the close button.

It took me several hours to fix this issue as I have little Win32 knowledge, but the final solution seems to be elegant and concise. It works seamlessly without causing visual artifacts like blinking, and I haven't encountered any issues during testing.