### PR TITLE
Number box enhancements

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NumberBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NumberBoxStyles.axaml
@@ -8,7 +8,11 @@
                 <ui:NumberBox Width="150" SpinButtonPlacementMode="Compact" Minimum="0" Maximum="100" Value="10" />
                 <ui:NumberBox Width="150" SpinButtonPlacementMode="Inline" Minimum="0" Maximum="100" Value="10" />
                 <ui:NumberBox Width="150" SpinButtonPlacementMode="Hidden" Minimum="0" Maximum="100" Value="10" />
-                <ui:NumberBox Width="150" PlaceholderText="Enter Number" />
+                <ui:NumberBox Width="150" PlaceholderText="Enter Number" />            
+                <Rectangle Height="1" Fill="Black" Margin="8" />
+                <ui:NumberBox Width="150" PlaceholderText="Enter Number"
+                              SpinButtonPlacementMode="Inline"
+                              Theme="{DynamicResource CompactNumberBoxStyle}"/>
             </StackPanel>
         </Border>
     </Design.PreviewWith>
@@ -243,6 +247,240 @@
                                       Theme="{StaticResource NumberBoxSpinButtonStyle}"
                                       Margin="0 4 4 4"
                                       IsVisible="False"/>
+
+                        <ContentPresenter Name="DescriptionPresenter"
+                                          Grid.Row="2"
+                                          Grid.ColumnSpan="3"
+                                          Content="{TemplateBinding Description}"
+                                          Foreground="{DynamicResource SystemControlDescriptionTextForegroundBrush}"/>
+                    </Grid>
+                </DataValidationErrors>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:disabled /template/ ContentPresenter#HeaderPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource TextControlHeaderForegroundDisabled}" />
+        </Style>
+
+        <Style Selector="^:spinvisible">
+            <Style Selector="^ /template/ RepeatButton#UpSpinButton">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+            <Style Selector="^ /template/ RepeatButton#DownSpinButton">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+            <Style Selector="^ /template/ Border#InputEater">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:updisabled">
+            <Style Selector="^ /template/ RepeatButton#UpSpinButton">
+                <Setter Property="IsEnabled" Value="False" />
+            </Style>
+            <Style Selector="^ /template/ RepeatButton#PopupUpSpinButton">
+                <Setter Property="IsEnabled" Value="False" />
+            </Style>
+        </Style>
+        <Style Selector="^:downdisabled">
+            <Style Selector="^ /template/ RepeatButton#DownSpinButton">
+                <Setter Property="IsEnabled" Value="False" />
+            </Style>
+            <Style Selector="^ /template/ RepeatButton#PopupDownSpinButton">
+                <Setter Property="IsEnabled" Value="False" />
+            </Style>
+        </Style>
+    </ControlTheme>
+
+
+    <!-- Compact NumberBox -->
+    <ControlTheme TargetType="TextBox"
+                  x:Key="CompactNumberBoxTextBoxStyle"
+                  BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Panel>
+                    <Border Name="PART_BorderElement"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MinHeight="{TemplateBinding MinHeight}"
+                            CornerRadius="{TemplateBinding CornerRadius}" />
+
+                    <Border Margin="{TemplateBinding BorderThickness}">
+                        <Grid ColumnDefinitions="Auto,*,Auto" >
+                            <ContentPresenter Grid.Column="0"
+                                              Grid.ColumnSpan="1"
+                                              Content="{TemplateBinding InnerLeftContent}"/>
+                            <DockPanel x:Name="PART_InnerDockPanel"
+                                       Grid.Column="1"
+                                       Grid.ColumnSpan="1"
+                                       Margin="{TemplateBinding Padding}">
+                                <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                              VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
+                                    <Panel>
+                                        <TextBlock Name="PART_Watermark"
+                                                   Foreground="{DynamicResource TextControlPlaceholderForeground}"
+                                                   Text="{TemplateBinding Watermark}"
+                                                   TextAlignment="{TemplateBinding TextAlignment}"
+                                                   TextWrapping="{TemplateBinding TextWrapping}"
+                                                   IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.IsNullOrEmpty}}"
+                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                   IsHitTestVisible="False"/>
+                                        <TextPresenter Name="PART_TextPresenter"
+                                                       Text="{TemplateBinding Text, Mode=TwoWay}"
+                                                       CaretIndex="{TemplateBinding CaretIndex}"
+                                                       SelectionStart="{TemplateBinding SelectionStart}"
+                                                       SelectionEnd="{TemplateBinding SelectionEnd}"
+                                                       TextAlignment="{TemplateBinding TextAlignment}"
+                                                       TextWrapping="{TemplateBinding TextWrapping}"
+                                                       PasswordChar="{TemplateBinding PasswordChar}"
+                                                       RevealPassword="{TemplateBinding RevealPassword}"
+                                                       SelectionBrush="{TemplateBinding SelectionBrush}"
+                                                       SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                                       CaretBrush="{TemplateBinding CaretBrush}"
+                                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    </Panel>
+                                </ScrollViewer>
+                            </DockPanel>
+                            <ContentPresenter Content="{TemplateBinding InnerRightContent}"
+                                              Name="InnerRightContent"
+                                              Grid.Column="2" Grid.ColumnSpan="1"/>
+                        </Grid>
+                    </Border>
+                </Panel>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^.clearButton[AcceptsReturn=False][IsReadOnly=False]:focus:not(TextBox:empty)">
+            <Setter Property="InnerRightContent">
+                <Template>
+                    <Button Theme="{StaticResource TextBoxDeleteButtonStyle}"
+                            Command="{Binding $parent[TextBox].Clear}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ControlCornerRadius}"
+                            Padding="{StaticResource HelperButtonThemePadding}"
+                            IsTabStop="False"
+                            Focusable="False"
+                            FontSize="{TemplateBinding FontSize}"
+                            Width="30" Background="Red"
+                            VerticalAlignment="Stretch" />
+                </Template>
+            </Setter>
+        </Style>
+
+        <Style Selector="^ /template/ ContentPresenter#InnerRightContent">
+            <Setter Property="Margin" Value="0 0 24 0" />
+        </Style>
+    </ControlTheme>
+    
+    <ControlTheme x:Key="CompactNumberBoxStyle" 
+                  TargetType="ui:NumberBox">
+        <Setter Property="SelectionHighlightColor" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="SpinButtonPlacementMode" Value="Inline" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DataValidationErrors>
+                    <Grid Name="Root" RowDefinitions="Auto,*,Auto"
+                          ColumnDefinitions="*,Auto,Auto">
+
+                        <ContentPresenter Name="HeaderContentPresenter"
+                                          Grid.ColumnSpan="3"
+                                          Content="{TemplateBinding Header}"
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                          FontWeight="Normal"
+                                          Margin="{DynamicResource TextBoxTopHeaderMargin}"
+                                          FontSize="{TemplateBinding FontSize}"
+                                          FontFamily="{TemplateBinding FontFamily}"
+                                          VerticalAlignment="Top"
+                                          IsVisible="{TemplateBinding Header, Converter={x:Static ObjectConverters.IsNotNull}}"/>
+
+                        <TextBox Name="InputBox"
+                                 Grid.Row="1"
+                                 Grid.ColumnSpan="3"
+                                 Foreground="{TemplateBinding Foreground}"
+                                 Watermark="{TemplateBinding PlaceholderText}"
+                                 DataValidationErrors.Errors="{TemplateBinding DataValidationErrors.Errors}"
+                                 SelectionBrush="{TemplateBinding SelectionHighlightColor}"
+                                 FontSize="{TemplateBinding FontSize}"
+                                 FontWeight="{TemplateBinding FontWeight}"
+                                 FontFamily="{TemplateBinding FontFamily}"
+                                 TextAlignment="{TemplateBinding TextAlignment}"
+                                 Classes="clearButton"
+                                 Theme="{StaticResource CompactNumberBoxTextBoxStyle}"
+                                 CornerRadius="{TemplateBinding CornerRadius}"/>
+
+                        <Popup Name="UpDownPopup" Focusable="False"
+                               WindowManagerAddShadowHint="False"
+                               IsLightDismissEnabled="True"
+                               Placement="AnchorAndGravity"
+                               PlacementAnchor="Right"
+                               PlacementGravity="Bottom"
+                               Grid.Row="1"
+                               Grid.Column="1"
+                               VerticalOffset="{DynamicResource NumberBoxPopupVerticalOffset}"
+                               HorizontalOffset="{DynamicResource NumberBoxPopupHorizontalOffset}"
+                               HorizontalAlignment="Left">
+
+                            <Border Name="PopupContentRoot"
+                                    Background="{DynamicResource NumberBoxPopupBackground}"
+                                    BorderBrush="{DynamicResource NumberBoxPopupBorderBrush}"
+                                    BorderThickness="{DynamicResource NumberBoxPopupBorderThickness}"
+                                    CornerRadius="{DynamicResource OverlayCornerRadius}"
+                                    Padding="6">
+
+                                <Grid RowDefinitions="*,*">
+                                    <RepeatButton Name="PopupUpSpinButton" Focusable="False"
+                                                  FontSize="18"
+                                                  Theme="{StaticResource NumberBoxPopupButton}"
+                                                  Content="{StaticResource ChevronUpGlyph}" />
+
+                                    <RepeatButton Name="PopupDownSpinButton" Focusable="False"
+                                                FontSize="18"
+                                                Theme="{StaticResource NumberBoxPopupButton}"
+                                                Grid.Row="1"
+                                                Content="{StaticResource ChevronDownGlyph}" />
+                                </Grid>
+                            </Border>
+                        </Popup>
+
+                        <!-- Prevents hover state of text box if buttons are disabled 
+                        WinUI uses a button b/c reasons, simple border works just fine -->
+                        <Border Background="Transparent"
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                Grid.ColumnSpan="2"
+                                Margin="4 0 0 0"
+                                Name="InputEater"
+                                IsVisible="False"/>
+
+                        <StackPanel Grid.Column="1"
+                                    Grid.Row="1"
+                                    Margin="4 0 2 0"
+                                    Spacing="1"
+                                    VerticalAlignment="Center">
+                            <RepeatButton Name="UpSpinButton"
+                                          FontSize="12"
+                                          Theme="{StaticResource NumberBoxSpinButtonStyle}"
+                                          Content="{StaticResource ChevronUpGlyph}"
+                                          Margin="0"
+                                          IsVisible="False"
+                                          MinWidth="24"/>
+
+                            <RepeatButton Name="DownSpinButton"
+                                          FontSize="12"
+                                          Content="{StaticResource ChevronDownGlyph}"
+                                          Theme="{StaticResource NumberBoxSpinButtonStyle}"
+                                          Margin="0"
+                                          IsVisible="False"
+                                          MinWidth="24"/>
+                        </StackPanel>
 
                         <ContentPresenter Name="DescriptionPresenter"
                                           Grid.Row="2"

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/NumberBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/NumberBoxStyles.axaml
@@ -8,11 +8,25 @@
                 <ui:NumberBox Width="150" SpinButtonPlacementMode="Compact" Minimum="0" Maximum="100" Value="10" />
                 <ui:NumberBox Width="150" SpinButtonPlacementMode="Inline" Minimum="0" Maximum="100" Value="10" />
                 <ui:NumberBox Width="150" SpinButtonPlacementMode="Hidden" Minimum="0" Maximum="100" Value="10" />
-                <ui:NumberBox Width="150" PlaceholderText="Enter Number" />            
+                <ui:NumberBox Width="150" PlaceholderText="Enter Number" />
+
+                <ui:NumberBox Width="150" PlaceholderText="Enter Number">
+                    <ui:NumberBox.InnerLeftContent>
+                        <TextBlock Text="Hi" />
+                    </ui:NumberBox.InnerLeftContent>
+                </ui:NumberBox>
+
                 <Rectangle Height="1" Fill="Black" Margin="8" />
                 <ui:NumberBox Width="150" PlaceholderText="Enter Number"
                               SpinButtonPlacementMode="Inline"
                               Theme="{DynamicResource CompactNumberBoxStyle}"/>
+                <ui:NumberBox Width="150" PlaceholderText="Enter Number"
+                              SpinButtonPlacementMode="Inline"
+                              Theme="{DynamicResource CompactNumberBoxStyle}">
+                    <ui:NumberBox.InnerLeftContent>
+                        <TextBlock Text="Hi" />
+                    </ui:NumberBox.InnerLeftContent>
+                </ui:NumberBox>
             </StackPanel>
         </Border>
     </Design.PreviewWith>
@@ -184,7 +198,8 @@
                                  TextAlignment="{TemplateBinding TextAlignment}"
                                  Classes="clearButton"
                                  Theme="{StaticResource NumberBoxTextBoxStyle}"
-                                 CornerRadius="{TemplateBinding CornerRadius}"/>
+                                 CornerRadius="{TemplateBinding CornerRadius}"
+                                 InnerLeftContent="{TemplateBinding InnerLeftContent}"/>
 
                         <Popup Name="UpDownPopup" Focusable="False"
                                WindowManagerAddShadowHint="False"
@@ -414,7 +429,8 @@
                                  TextAlignment="{TemplateBinding TextAlignment}"
                                  Classes="clearButton"
                                  Theme="{StaticResource CompactNumberBoxTextBoxStyle}"
-                                 CornerRadius="{TemplateBinding CornerRadius}"/>
+                                 CornerRadius="{TemplateBinding CornerRadius}"
+                                 InnerLeftContent="{TemplateBinding InnerLeftContent}"/>
 
                         <Popup Name="UpDownPopup" Focusable="False"
                                WindowManagerAddShadowHint="False"

--- a/src/FluentAvalonia/UI/Controls/NumberBox/Enums.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/Enums.cs
@@ -17,21 +17,6 @@ public enum NumberBoxValidationMode
 }
 
 /// <summary>
-/// Provides a value for TextReadingOrder properties.
-/// </summary>
-/// <remarks>
-/// This enum is currently unused, see 
-/// https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.textreadingorder?view=winui-3.0
-/// for more
-/// </remarks>
-public enum TextReadingOrder
-{
-    Default = 0,
-    UseFlowDirection = 0,
-    DetectFromContent
-}
-
-/// <summary>
 /// Defines values that specify how the spin buttons used to increment or decrement 
 /// the Value of a NumberBox are displayed.
 /// </summary>

--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
@@ -99,14 +99,6 @@ public partial class NumberBox
     public static readonly StyledProperty<string> PlaceholderTextProperty =
         TextBox.WatermarkProperty.AddOwner<NumberBox>();
 
-    //Skip PreventKeyboardDisplayOnProgrammaticFocus
-
-    /// <summary>
-    /// Defines the <see cref="SelectionFlyout"/> property
-    /// </summary>
-    public static readonly StyledProperty<FlyoutBase> SelectionFlyoutProperty =
-        AvaloniaProperty.Register<NumberBox, FlyoutBase>(nameof(SelectionFlyout));
-
     /// <summary>
     /// Defines the <see cref="SelectionHighlightColor"/> property
     /// </summary>
@@ -132,12 +124,6 @@ public partial class NumberBox
     public static readonly DirectProperty<NumberBox, string> TextProperty =
         AvaloniaProperty.RegisterDirect<NumberBox, string>(nameof(Text),
             x => x.Text, (x, v) => x.Text = v, defaultBindingMode: BindingMode.TwoWay);
-
-    /// <summary>
-    /// Defines the <see cref="TextReadingOrder"/> property
-    /// </summary>
-    public static readonly StyledProperty<TextReadingOrder> TextReadingOrderProperty =
-        AvaloniaProperty.Register<NumberBox, TextReadingOrder>(nameof(TextReadingOrder));
 
     /// <summary>
     /// Defines the <see cref="NumberBoxValidationMode"/> property
@@ -291,17 +277,6 @@ public partial class NumberBox
     }
 
     /// <summary>
-    /// Gets or sets the flyout that is shown when text is selected, or null if no flyout is shown.
-    /// NOTE: This property is not implemented
-    /// </summary>
-    [NotImplemented]
-    public FlyoutBase SelectionFlyout
-    {
-        get => GetValue(SelectionFlyoutProperty);
-        set => SetValue(SelectionFlyoutProperty, value);
-    }
-
-    /// <summary>
     /// Gets or sets the brush used to highlight the selected text.
     /// </summary>
     public IBrush SelectionHighlightColor
@@ -343,17 +318,6 @@ public partial class NumberBox
                 UpdateValueToText();
             }
         }
-    }
-
-    /// <summary>
-    /// Gets or sets a value that indicates how the reading order is determined for the NumberBox.
-    /// NOTE This property is not implemented
-    /// </summary>
-    [NotImplemented]
-    public TextReadingOrder TextReadingOrder
-    {
-        get => GetValue(TextReadingOrderProperty);
-        set => SetValue(TextReadingOrderProperty, value);
     }
 
     /// <summary>

--- a/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/NumberBox/NumberBox.properties.cs
@@ -168,6 +168,12 @@ public partial class NumberBox
         AvaloniaProperty.Register<NumberBox, string>(nameof(SimpleNumberFormat));
 
     /// <summary>
+    /// Defines the <see cref="InnerLeftContent"/> property
+    /// </summary>
+    public static readonly StyledProperty<object> InnerLeftContentProperty =
+        TextBox.InnerLeftContentProperty.AddOwner<NumberBox>();
+
+    /// <summary>
     /// Toggles whether the control will accept and evaluate a basic formulaic expression entered as input.
     /// </summary>
     public bool AcceptsExpression
@@ -345,6 +351,15 @@ public partial class NumberBox
     {
         get => GetValue(TextAlignmentProperty);
         set => SetValue(TextAlignmentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the inner left content of the TextBox within the NumberBox
+    /// </summary>
+    public object InnerLeftContent
+    {
+        get => GetValue(InnerLeftContentProperty);
+        set => SetValue(InnerLeftContentProperty, value);
     }
 
     /// <summary>


### PR DESCRIPTION
Adds a couple enhancements to the `NumberBox` control

1. Adds a "compact" NumberBox style that positions the inline buttons closer to the traditional Win32/Winforms NumericUpDown. Note, this style only has an effect if you want the inline buttons, which is set by default in the Control Theme. This also may not be touch friendly so if your application allows touch input, you may want to consider sticking with the default template or adjusting on the fly based on input method. However, it can make a much nicer appearance for mouse-only situations.
<img width="325" height="85" alt="image" src="https://github.com/user-attachments/assets/e21bb4d0-e54f-426c-b459-312e2f88e2ce" />

You can access this control theme by setting `Theme={StaticResource CompactNumberBoxStyle}` on any NumberBox you want to display like this.

NOTE: This is only for the NumberBox control. I have no plans to adjust NumericUpDown with something similar.

2. Adds the `InnerLeftContent` property to `NumberBox`. This property was copied over TextBox. Can be useful if you want to add a header or other indicator for the value of the NumberBox. It works with both the normal and compact themes. Because the right side of the NumberBox already has content, I'm not adding `InnerRightContent`. Note that InnerLeftContent is based on LTR layout, adjusting the flow layout will flip this to show on the right side. 

<img width="335" height="164" alt="image" src="https://github.com/user-attachments/assets/72a7cf20-dbda-4e3e-8b26-97e95c66559c" />

I've also removed the 2 unused properties on NumberBox `SelectionFlyout` and `TextReadingOrder`.
