### PR TITLE
fix(localization): avoid CultureInfo creation in InvariantGlobalization mode

### DIFF
--- a/src/FluentAvalonia/UI/FALocalizationHelper.cs
+++ b/src/FluentAvalonia/UI/FALocalizationHelper.cs
@@ -41,22 +41,32 @@ public partial class FALocalizationHelper
     /// </remarks>
     public string GetLocalizedStringResource(CultureInfo ci, string resName)
     {
-        // Don't allow InvariantCulture - default to en-us in that case
+        string cultureName;
+    
+        // If running in globalization-invariant mode, always use "en-US" fallback
         if (ci == CultureInfo.InvariantCulture)
-            ci = new CultureInfo(s_enUS);
-
+        {
+            cultureName = s_enUS;
+        }
+        else
+        {
+            cultureName = ci.Name;
+        }
+    
         if (_mappings.ContainsKey(resName))
         {
-            if (_mappings[resName].ContainsKey(ci.Name))
+            var cultureMap = _mappings[resName];
+    
+            if (cultureMap.ContainsKey(cultureName))
             {
-                return _mappings[resName][ci.Name];
+                return cultureMap[cultureName];
             }
-            else if (_mappings[resName].ContainsKey(s_enUS))
+            else if (cultureMap.ContainsKey(s_enUS))
             {
-                return _mappings[resName][s_enUS];
+                return cultureMap[s_enUS];
             }
         }
-
+    
         return string.Empty;
     }
 


### PR DESCRIPTION
Avoids constructing a CultureInfo object when the passed culture is InvariantCulture,
which would otherwise throw a CultureNotFoundException in InvariantGlobization environments.
 Instead, it falls back to using "en-US" without relying on CultureInfo.

To be clear, when in InvariantGlobalization environments, the **ONLY** known culture is the InvariantCulture.

