### PR TITLE
Provide way to create custom IconSources

### DIFF
--- a/src/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
@@ -155,6 +155,14 @@ public static class IconHelpers
         return null;
     }
 
+    /// <summary>
+    /// Registers a <see cref="FAIconElement"/> creation factory for custom <see cref="IconSource"/> types
+    /// </summary>
+    /// <remarks>
+    /// When creating a custom IconSource, you will also need to create a matching FAIconElement type that
+    /// will actually be used for display. Just as the built-in icons do, you will need to handle the mapping
+    /// between the custom IconSource and related FAIconElement.
+    /// </remarks>
     public static void RegisterCustomIconSourceFactory(Type typeOfIconSource, Func<IconSource, FAIconElement> factory)
     {
         _customConverters ??= new Dictionary<Type, Func<IconSource, FAIconElement>>();

--- a/src/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
+++ b/src/FluentAvalonia/UI/Controls/IconElement/IconHelpers.cs
@@ -5,9 +5,9 @@ using FluentAvalonia.Core;
 
 namespace FluentAvalonia.UI.Controls;
 
-internal static class IconHelpers
+public static class IconHelpers
 {
-    public static FontIcon CreateFontIconFromFontIconSource(FontIconSource fis)
+    internal static FontIcon CreateFontIconFromFontIconSource(FontIconSource fis)
     {
         var fi = new FontIcon
         {
@@ -32,7 +32,7 @@ internal static class IconHelpers
         return fi;
     }
 
-    public static FAPathIcon CreatePathIconFromPathIconSource(PathIconSource pis)
+    internal static FAPathIcon CreatePathIconFromPathIconSource(PathIconSource pis)
     {
         var pi = new FAPathIcon
         {
@@ -55,7 +55,7 @@ internal static class IconHelpers
         return pi;
     }
 
-    public static SymbolIcon CreateSymbolIconFromSymbolIconSource(SymbolIconSource sis)
+    internal static SymbolIcon CreateSymbolIconFromSymbolIconSource(SymbolIconSource sis)
     {
         var si = new SymbolIcon
         {
@@ -77,7 +77,7 @@ internal static class IconHelpers
         return si;
     }
 
-    public static BitmapIcon CreateBitmapIconFromBitmapIconSource(BitmapIconSource bis)
+    internal static BitmapIcon CreateBitmapIconFromBitmapIconSource(BitmapIconSource bis)
     {
         // This one works slightly differently to avoid holding multiple instances of the same
         // bitmap in memory (since IconSources are meant for sharing). We don't alter the properties, 
@@ -99,7 +99,7 @@ internal static class IconHelpers
         return bi;
     }
 
-    public static ImageIcon CreateImageIconFromImageIconSource(ImageIconSource iis)
+    internal static ImageIcon CreateImageIconFromImageIconSource(ImageIconSource iis)
     {
         var ii = new ImageIcon
         {
@@ -120,7 +120,7 @@ internal static class IconHelpers
         return ii;
     }
 
-    public static FAIconElement CreateFromUnknown(IconSource src)
+    internal static FAIconElement CreateFromUnknown(IconSource src)
     {
         if (src is BitmapIconSource bis)
         {
@@ -143,6 +143,24 @@ internal static class IconHelpers
             return CreateImageIconFromImageIconSource(iis);
         }
 
+        if (_customConverters != null)
+        {
+            var type = src.GetType();
+            if (_customConverters.TryGetValue(type, out var value))
+            {
+                return value(src);
+            }
+        }
+
         return null;
     }
+
+    public static void RegisterCustomIconSourceFactory(Type typeOfIconSource, Func<IconSource, FAIconElement> factory)
+    {
+        _customConverters ??= new Dictionary<Type, Func<IconSource, FAIconElement>>();
+
+        _customConverters.Add(typeOfIconSource, factory);
+    }
+
+    private static Dictionary<Type, Func<IconSource, FAIconElement>> _customConverters;
 }


### PR DESCRIPTION
Currently, there isn't anything stopping anyone from inheriting from `FAIconElement` and creating your own custom icon type. However, all FA controls that use icons use `IconSource` instead. `IconSource` has been able to be extended, but couldn't really be used since FA wouldn't know how to convert that into an `FAIconElement`. This PR adds a way to do just that. Note that you will still need an equivalent FAIconElement to map to and you will be responsible for how to map between the Source and Element, just as the built-in icons do.

The `IconHelper` class which was previously internal and stored all the conversion logic is now public, with a public method for registering a custom factory:
```C#
void RegisterCustomIconSourceFactory(Type typeOfIconSource, Func<IconSource, FAIconElement> factory)
```

To use, just register your custom icon source type with a Func that specifies the FAIconElement to use and now your custom IconSource type can be used anywhere.

```C#
// Register your icon factory - this should only be done once (app startup for example)
IconHelpers.RegisterCustomIconSourceFactory(typeof(TestIconSource),
    x => new TestIconElement());

// Custom IconSource Type
public class TestIconSource : IconSource
{
// Do whatever you want here
}

// This is the matching IconElement for the custom IconSource. See built-in implementations for ideas/how to map between IconSource and FAIconElement.
public class TestIconElement : FAIconElement
{
    protected override Size MeasureOverride(Size availableSize)
    {
        return new Size(30, 30);
    }

    public override void Render(DrawingContext context)
    {
        context.FillRectangle(Brushes.Red, new Rect(5, 5, 20, 20));
    }
}
```
Produces this:
<img width="534" height="140" alt="image" src="https://github.com/user-attachments/assets/97d605e3-f39c-4aca-a55e-1d97a484814d" />
