### PR TITLE
Add WinUI Expander Animation

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ExpanderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ExpanderStyles.axaml
@@ -373,4 +373,133 @@
         </Style>
     </ControlTheme>
 
+    
+    <!-- Special ControlTheme which activates a WinUI style animation for the Expander -->
+    <ControlTheme TargetType="Expander" x:Key="ExpanderWinUIAnimationStyle">
+        <Setter Property="Background" Value="{DynamicResource ExpanderContentBackground}" />
+        <Setter Property="MinWidth" Value="{DynamicResource FlyoutThemeMinWidth}" />
+        <Setter Property="MinHeight" Value="{DynamicResource ExpanderMinHeight}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ExpanderContentBorderBrush}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="Padding" Value="{DynamicResource ExpanderContentPadding}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="ui:ExpanderExt.ExpanderAnimationType" Value="FluentV2" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DockPanel MinWidth="{TemplateBinding MinWidth}"
+                           MaxWidth="{TemplateBinding MaxWidth}">
+                    <ToggleButton Name="ExpanderHeader"
+                                  MinHeight="{TemplateBinding MinHeight}"
+                                  IsEnabled="{TemplateBinding IsEnabled}"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
+                                  IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
+                                  Content="{TemplateBinding Header}"
+                                  ContentTemplate="{TemplateBinding HeaderTemplate}" />
+
+                    <Border Name="ExpanderContentClip" ClipToBounds="True">
+                        <Border Name="ExpanderContent"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                BackgroundSizing="InnerBorderEdge"
+                                MinHeight="{TemplateBinding MinHeight}"
+                                MinWidth="{TemplateBinding MinWidth}"
+                                IsVisible="False">
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Margin="0"
+                                              IsVisible="{TemplateBinding IsExpanded}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              Content="{TemplateBinding Content}"
+                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Padding="{TemplateBinding Padding}" />
+                        </Border>
+                    </Border>
+                </DockPanel>
+            </ControlTemplate>
+        </Setter>
+
+        <Style Selector="^:noAnimation">
+            <Style Selector="^ /template/ Border#ExpanderContent">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+
+            <Style Selector="^:expanded /template/ Border#ExpanderContent">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:left /template/ ToggleButton#ExpanderHeader">
+            <Setter Property="DockPanel.Dock" Value="Right" />
+            <Setter Property="Theme" Value="{DynamicResource ExpanderToggleButtonLeftTheme}" />
+        </Style>
+        <Style Selector="^:up /template/ ToggleButton#ExpanderHeader">
+            <Setter Property="DockPanel.Dock" Value="Bottom" />
+            <Setter Property="Theme" Value="{DynamicResource ExpanderToggleButtonUpTheme}" />
+        </Style>
+        <Style Selector="^:right /template/ ToggleButton#ExpanderHeader">
+            <Setter Property="DockPanel.Dock" Value="Left" />
+            <Setter Property="Theme" Value="{DynamicResource ExpanderToggleButtonRightTheme}" />
+        </Style>
+        <Style Selector="^:down /template/ ToggleButton#ExpanderHeader">
+            <Setter Property="DockPanel.Dock" Value="Top" />
+            <Setter Property="Theme" Value="{DynamicResource ExpanderToggleButtonDownTheme}" />
+        </Style>
+
+        <Style Selector="^:down">
+            <Setter Property="BorderThickness" Value="{DynamicResource ExpanderContentDownBorderThickness}" />
+
+            <Style Selector="^:expanded /template/ ToggleButton#ExpanderHeader">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+            </Style>
+            <Style Selector="^:expanded /template/ Border#ExpanderContent">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:up">
+            <Setter Property="BorderThickness" Value="{DynamicResource ExpanderContentUpBorderThickness}" />
+
+            <Style Selector="^:expanded /template/ ToggleButton#ExpanderHeader">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+            </Style>
+            <Style Selector="^:expanded /template/ Border#ExpanderContent">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:left">
+            <Setter Property="BorderThickness" Value="{DynamicResource ExpanderContentLeftBorderThickness}" />
+
+            <Style Selector="^:expanded /template/ ToggleButton#ExpanderHeader">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}" />
+            </Style>
+            <Style Selector="^:expanded /template/ Border#ExpanderContent">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:right">
+            <Setter Property="BorderThickness" Value="{DynamicResource ExpanderContentRightBorderThickness}" />
+
+            <Style Selector="^:expanded /template/ ToggleButton#ExpanderHeader">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}" />
+            </Style>
+            <Style Selector="^:expanded /template/ Border#ExpanderContent">
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:expanded /template/ ToggleButton#ExpanderHeader">
+            <Setter Property="Tag" Value="expanded" />
+        </Style>
+
+        <Style Selector="^:not(:expanded) /template/ ToggleButton#ExpanderHeader">
+            <Setter Property="Tag" Value="collapsed" />
+        </Style>
+    </ControlTheme>
+
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/SettingsExpander/SettingsExpanderStyles.axaml
@@ -2,20 +2,25 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
     <Design.PreviewWith>
-        <Border Padding="20" Width="700" Height="250">
-            <ui:SettingsExpander IconSource="Globe" Header="Test Header"
+        <Border Padding="20" Width="700" Height="350">
+            <!--<ui:SettingsExpander IconSource="Globe" Header="Test Header"
                                  Description="This is a description for the SettingsExpander"
                                  ActionIconSource="Save" IsClickEnabled="True">
                 <ui:SettingsExpander.Footer>
                     <Button Content="FooterButton" />
                 </ui:SettingsExpander.Footer>
                 
-                <!--<ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
+                --><!--<ui:SettingsExpanderItem Content="Content Here" ActionIconSource="Pin" IsClickEnabled="True"  />
                 <ui:SettingsExpanderItem Content="Content Here">
                     <ui:SettingsExpanderItem.Footer>
                         <Button Content="FooterButton" />
                     </ui:SettingsExpanderItem.Footer>
-                </ui:SettingsExpanderItem>-->
+                </ui:SettingsExpanderItem>--><!--
+            </ui:SettingsExpander>-->
+            <ui:SettingsExpander Header="Test">
+                <ui:SettingsExpanderItem Content="Item1" />
+                <ui:SettingsExpanderItem Content="Item2" />
+                <ui:SettingsExpanderItem Content="Item3" />
             </ui:SettingsExpander>
         </Border>
     </Design.PreviewWith>
@@ -116,21 +121,23 @@
                                   IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
                                   Content="{TemplateBinding Header}"
                                   Theme="{StaticResource SettingsExpanderToggleButtonStyle}"/>
-                    
-                    <Border Name="ExpanderContent"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource BottomCornerRadiusFilterConverter}}"
-                            IsVisible="False"
-                            BackgroundSizing="InnerBorderEdge">
-                        <ContentPresenter Name="PART_ContentPresenter"
-                                          Margin="{TemplateBinding Padding}"
-                                          IsVisible="{TemplateBinding IsExpanded}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                          Content="{TemplateBinding Content}"
-                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+                    <Border Name="ExpanderContentClip" ClipToBounds="True">
+                        <Border Name="ExpanderContent"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource BottomCornerRadiusFilterConverter}}"
+                                IsVisible="False"
+                                BackgroundSizing="InnerBorderEdge">
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Margin="{TemplateBinding Padding}"
+                                              IsVisible="{TemplateBinding IsExpanded}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              Content="{TemplateBinding Content}"
+                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        </Border>
                     </Border>
                 </StackPanel>
             </ControlTemplate>
@@ -141,7 +148,31 @@
         </Style>
     </ControlTheme>
 
-    <ControlTheme x:Key="{x:Type ui:SettingsExpander}" TargetType="ui:SettingsExpander">
+    <ControlTemplate TargetType="ui:SettingsExpander"
+                 x:Key="DefaultSettingsExpanderControlTemplate">
+        <Expander Name="Expander"
+                  Theme="{StaticResource SettingsExpanderExpanderStyle}"
+                  IsExpanded="{TemplateBinding IsExpanded, Mode=TwoWay}">
+            <Expander.Header>
+                <ui:SettingsExpanderItem Content="{TemplateBinding Header}"
+                                         ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                         Description="{TemplateBinding Description}"
+                                         IsClickEnabled="{TemplateBinding IsClickEnabled}"
+                                         IconSource="{TemplateBinding IconSource}"
+                                         ActionIconSource="{TemplateBinding ActionIconSource}"
+                                         Footer="{TemplateBinding Footer}"
+                                         FooterTemplate="{TemplateBinding FooterTemplate}"
+                                         Padding="{DynamicResource SettingsExpanderPadding}"
+                                         Background="Transparent"
+                                         Name="ContentHost" />
+            </Expander.Header>
+
+            <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}" />
+        </Expander>
+    </ControlTemplate>
+
+    <ControlTheme x:Key="{x:Type ui:SettingsExpander}" 
+                  TargetType="ui:SettingsExpander">
         <Setter Property="Background" Value="{DynamicResource ExpanderBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource ExpanderHeaderBorderThickness}" />
@@ -153,32 +184,39 @@
                 <StackPanel Spacing="1" />
             </ItemsPanelTemplate>
         </Setter>
-        <Setter Property="Template">
-            <ControlTemplate>
-                <Expander Name="Expander"
-                          Theme="{StaticResource SettingsExpanderExpanderStyle}"
-                          IsExpanded="{TemplateBinding IsExpanded, Mode=TwoWay}">
-                    <Expander.Header>
-                        <ui:SettingsExpanderItem Content="{TemplateBinding Header}"
-                                                 ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                 Description="{TemplateBinding Description}"
-                                                 IsClickEnabled="{TemplateBinding IsClickEnabled}"
-                                                 IconSource="{TemplateBinding IconSource}"
-                                                 ActionIconSource="{TemplateBinding ActionIconSource}"
-                                                 Footer="{TemplateBinding Footer}"
-                                                 FooterTemplate="{TemplateBinding FooterTemplate}"
-                                                 Padding="{DynamicResource SettingsExpanderPadding}"
-                                                 Background="Transparent"
-                                                 Name="ContentHost" />
-                    </Expander.Header>
-                    
-                    <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}" />
-                </Expander>
-            </ControlTemplate>
-        </Setter>
+        <Setter Property="Template" Value="{StaticResource DefaultSettingsExpanderControlTemplate}" />
 
         <Style Selector="^:empty /template/ ItemsPresenter#ItemsHost">
             <Setter Property="IsVisible" Value="False" />
         </Style>
+
+        <Style Selector="^ /template/ Expander#Expander">
+            <Setter Property="ui:ExpanderExt.ExpanderAnimationType" Value="FluentV2" />
+        </Style>
     </ControlTheme>
+
+    <ControlTheme x:Key="SettingsExpanderNoAnimationStyle"
+                  TargetType="ui:SettingsExpander">
+        <Setter Property="Background" Value="{DynamicResource ExpanderBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource ExpanderHeaderBorderThickness}" />
+        <Setter Property="Padding" Value="{DynamicResource SettingsExpanderPadding}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="MinHeight" Value="{DynamicResource SettingsExpanderMinHeight}" />
+        <Setter Property="ItemsPanel">
+            <ItemsPanelTemplate>
+                <StackPanel Spacing="1" />
+            </ItemsPanelTemplate>
+        </Setter>
+        <Setter Property="Template" Value="{StaticResource DefaultSettingsExpanderControlTemplate}" />
+
+        <Style Selector="^:empty /template/ ItemsPresenter#ItemsHost">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+
+        <Style Selector="^ /template/ Expander#Expander">
+            <Setter Property="ui:ExpanderExt.ExpanderAnimationType" Value="{x:Null}" />
+        </Style>
+    </ControlTheme>
+
 </ResourceDictionary>

--- a/src/FluentAvalonia/UI/Controls/ExpanderExt.cs
+++ b/src/FluentAvalonia/UI/Controls/ExpanderExt.cs
@@ -1,0 +1,319 @@
+﻿using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+using Avalonia.Rendering.Composition;
+using Avalonia.Styling;
+using FluentAvalonia.Core;
+
+namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Special helper class to enable WinUI like animations on the Expander control
+/// </summary>
+public sealed class ExpanderExt : AvaloniaObject
+{
+    static ExpanderExt()
+    {
+        ExpanderAnimationTypeProperty.Changed.Subscribe(
+            new SimpleObserver<AvaloniaPropertyChangedEventArgs>(HandleExpanderAnimationTypeChanged));
+    }
+
+    /// <summary>
+    /// Defines the ExpanderAnimationType attached property
+    /// </summary>
+    public static readonly AttachedProperty<string> ExpanderAnimationTypeProperty =
+        AvaloniaProperty.RegisterAttached<ExpanderExt, Expander, string>("ExpanderAnimationType");
+
+    private static readonly AttachedProperty<ExpanderInfo> ExpanderAnimationInfoProperty =
+        AvaloniaProperty.RegisterAttached<ExpanderExt, Expander, ExpanderInfo>("ExpanderAnimationInfo");
+
+    /// <summary>
+    /// Gets the current value of the <see cref="ExpanderAnimationTypeProperty"/>
+    /// </summary>
+    public static string GetExpanderAnimationType(Expander exp) =>
+        exp.GetValue(ExpanderAnimationTypeProperty);
+
+    /// <summary>
+    /// Sets the current value of the <see cref="ExpanderAnimationTypeProperty"/>
+    /// </summary>
+    public static void SetExpanderAnimationType(Expander exp, string value) =>
+        exp.SetValue(ExpanderAnimationTypeProperty, value);
+
+    private static void HandleExpanderAnimationTypeChanged(AvaloniaPropertyChangedEventArgs args)
+    {
+        var val = args.GetNewValue<string>();
+        var expander = args.Sender as Expander;
+
+        if (expander == null)
+            return;
+
+        if (val.Equals(s_Fluentv2, StringComparison.OrdinalIgnoreCase))
+        {
+            expander.SetValue(ExpanderAnimationInfoProperty, new ExpanderInfo(expander));
+        }
+        else
+        {
+            var info = expander.GetValue(ExpanderAnimationInfoProperty);
+            info?.Dispose();
+            expander.ClearValue(ExpanderAnimationInfoProperty);
+        }
+    }
+        
+
+    private static readonly string s_Fluentv2 = "FluentV2";
+
+    private class ExpanderInfo : IDisposable
+    {
+        public ExpanderInfo(Expander expander)
+        {
+            _expander = expander;
+
+            expander.TemplateApplied += HandleExpanderTemplateApplied;
+            _expandedChangedNotice = expander.GetPropertyChangedObservable(Expander.IsExpandedProperty)
+                .Subscribe(new SimpleObserver<AvaloniaPropertyChangedEventArgs>(HandleIsExpandedChanged));
+        }
+
+        private void HandleExpanderTemplateApplied(object sender, TemplateAppliedEventArgs e)
+        {
+            if (_expanderContent != null)
+            {
+                _expanderContent.SizeChanged -= HandleContentSizeChanged;
+            }
+
+            var expanderContentClip = e.NameScope.Get<Border>("ExpanderContentClip");
+            var visual = ElementComposition.GetElementVisual(expanderContentClip);
+            // WinUI uses an actual CompositionClip here (CreateInsetClip())
+            // but we don't have that so just clip to bounds for now
+            visual.ClipToBounds = true;
+
+            var expanderContent = e.NameScope.Get<Border>("ExpanderContent");
+            SetExpanderContent(expanderContent);
+
+            UpdateExpandState(false);
+        }
+
+        private void SetExpanderContent(Border expanderContent)
+        {
+            _expanderContent = expanderContent;
+            expanderContent.SizeChanged += HandleContentSizeChanged;
+        }
+
+        private void HandleContentSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            _contentSize = e.NewSize;
+        }
+
+        private void HandleIsExpandedChanged(AvaloniaPropertyChangedEventArgs args)
+        {
+            UpdateExpandState(true);
+        }
+
+        private void UpdateExpandState(bool useTransitions)
+        {
+            var expanded = _expander.IsExpanded;
+
+            if (useTransitions && _expanderContent == null)
+                useTransitions = false;
+
+            var pc = _expander.Classes as IPseudoClasses;
+            pc.Set(":noAnimation", !useTransitions);
+            pc.Set(":expanded", expanded);
+
+            if (useTransitions)
+            {
+                var direction = _expander.ExpandDirection;
+
+                if (expanded)
+                {
+                    switch (direction)
+                    {
+                        case ExpandDirection.Down:
+                        case ExpandDirection.Up:
+                            RunExpandDownUpAnimation(direction == ExpandDirection.Down);
+                            break;
+
+                        case ExpandDirection.Left:
+                        case ExpandDirection.Right:
+                            RunExpandLeftRightAnimation(direction == ExpandDirection.Right);
+                            break;
+                    }                    
+                }
+                else
+                {
+                    switch (direction)
+                    {
+                        case ExpandDirection.Down:
+                        case ExpandDirection.Up:
+                            RunCollapseDownUpAnimation(direction == ExpandDirection.Down);
+                            break;
+
+                        case ExpandDirection.Left:
+                        case ExpandDirection.Right:
+                            RunCollapseLeftRightAnimation(direction == ExpandDirection.Right);
+                            break;
+                    }                    
+                }
+            }
+        }
+
+        private async void RunExpandDownUpAnimation(bool down)
+        {
+            _expanderContent.SetCurrentValue(Visual.IsVisibleProperty, true);
+            _expanderContent.Measure(Size.Infinity);
+            _contentSize = _expanderContent.DesiredSize;
+            var startY = down ? -_contentSize.Height : _contentSize.Height;
+            var ani = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(333),
+                FillMode = FillMode.Forward,
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.Zero,
+                        Setters =
+                        {
+                            new Setter(Visual.IsVisibleProperty, true),
+                            new Setter(TranslateTransform.YProperty, startY)
+                        }
+                    },
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.FromMilliseconds(333),
+                        Setters =
+                        {
+                            new Setter(TranslateTransform.YProperty, 0d)
+                        },
+                        KeySpline = new KeySpline(0,0,0,1)
+                    }
+                }
+            };
+
+            await ani.RunAsync(_expanderContent);
+        }
+
+        private async void RunCollapseDownUpAnimation(bool down)
+        {
+            var endY = down ? -_contentSize.Height : _contentSize.Height;
+            var ani = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(167),
+                FillMode = FillMode.Forward,
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.Zero,
+                        Setters =
+                        {
+                            new Setter(TranslateTransform.YProperty, 0d)
+                        }
+                    },
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.FromMilliseconds(167),
+                        Setters =
+                        {
+                            new Setter(TranslateTransform.YProperty, endY),
+                            new Setter(Visual.IsVisibleProperty, false)
+                        },
+                        KeySpline = new KeySpline(1,1,0,1)
+                    }
+                }
+            };
+
+            await ani.RunAsync(_expanderContent);
+
+            _expanderContent.SetValue(Visual.IsVisibleProperty, false);
+        }
+
+        private async void RunExpandLeftRightAnimation(bool right)
+        {
+            _expanderContent.SetCurrentValue(Visual.IsVisibleProperty, true);
+            _expanderContent.Measure(Size.Infinity);
+            _contentSize = _expanderContent.DesiredSize;
+            var startX = right ? -_contentSize.Width : _contentSize.Width;
+            var ani = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(333),
+                FillMode = FillMode.Forward,
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.Zero,
+                        Setters =
+                        {
+                            new Setter(Visual.IsVisibleProperty, true),
+                            new Setter(TranslateTransform.XProperty, startX)
+                        }
+                    },
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.FromMilliseconds(333),
+                        Setters =
+                        {
+                            new Setter(TranslateTransform.XProperty, 0d)
+                        },
+                        KeySpline = new KeySpline(0,0,0,1)
+                    }
+                }
+            };
+
+            await ani.RunAsync(_expanderContent);
+        }
+
+        private async void RunCollapseLeftRightAnimation(bool right)
+        {
+            var endX = right ? -_contentSize.Width : _contentSize.Width;
+            var ani = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(167),
+                FillMode = FillMode.Forward,
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.Zero,
+                        Setters =
+                        {
+                            new Setter(TranslateTransform.XProperty, 0d)
+                        }
+                    },
+                    new KeyFrame
+                    {
+                        KeyTime = TimeSpan.FromMilliseconds(167),
+                        Setters =
+                        {
+                            new Setter(TranslateTransform.XProperty, endX),
+                            new Setter(Visual.IsVisibleProperty, false)
+                        },
+                        KeySpline = new KeySpline(1,1,0,1)
+                    }
+                }
+            };
+
+            await ani.RunAsync(_expanderContent);
+
+            _expanderContent.SetValue(Visual.IsVisibleProperty, false);
+        }
+
+        public void Dispose()
+        {
+            _expandedChangedNotice?.Dispose();
+            _expander.TemplateApplied -= HandleExpanderTemplateApplied;
+
+            if (_expanderContent != null)
+            {
+                _expanderContent.SizeChanged -= HandleContentSizeChanged;
+            }
+        }
+
+        private readonly Expander _expander;
+        private Border _expanderContent;
+        private Size _contentSize;
+        private IDisposable _expandedChangedNotice;
+    }
+}

--- a/src/FluentAvalonia/UI/Controls/ExpanderExt.cs
+++ b/src/FluentAvalonia/UI/Controls/ExpanderExt.cs
@@ -49,7 +49,7 @@ public sealed class ExpanderExt : AvaloniaObject
         if (expander == null)
             return;
 
-        if (val.Equals(s_Fluentv2, StringComparison.OrdinalIgnoreCase))
+        if (val != null && val.Equals(s_Fluentv2, StringComparison.OrdinalIgnoreCase))
         {
             expander.SetValue(ExpanderAnimationInfoProperty, new ExpanderInfo(expander));
         }
@@ -161,8 +161,20 @@ public sealed class ExpanderExt : AvaloniaObject
         private async void RunExpandDownUpAnimation(bool down)
         {
             _expanderContent.SetCurrentValue(Visual.IsVisibleProperty, true);
-            _expanderContent.Measure(Size.Infinity);
-            _contentSize = _expanderContent.DesiredSize;
+
+            if (_expander.Parent is SettingsExpander se && se.Presenter != null)
+            {
+                // SettingsExpander does not use Virtualization, so it's safe here to use
+                // Infinity to measure
+                se.Presenter.Measure(Size.Infinity);
+                _contentSize = se.Presenter.DesiredSize;
+            }
+            else
+            {
+                _expanderContent.Measure(Size.Infinity);
+                _contentSize = _expanderContent.DesiredSize;
+            }
+                
             var startY = down ? -_contentSize.Height : _contentSize.Height;
             var ani = new Animation
             {


### PR DESCRIPTION
Currently, the Expander control uses the Avalonia provided CrossFade ContentTransition when expanding/collapsing. This does not match the animation in WinUI (and IMO doesn't look good anyway). SettingsExpander has also had its animations disabled in part because of this. The way Avalonia implemented animations on Expander is very rigid and previously implementing the WinUI expander animation was either extremely difficult or not possible using the existing `IPageTransition` interface. I don't feel like getting into the details as to why.

To overcome this limitation and enable the animation, I am building it on as an AttachedProperty. As if we were using the normal IPageTransition, the animation is still defined in code and isn't editable, but it was built off of the WinUI xaml animation. I have also implemented it for all ExpandDirections, even though WinUI only does Down/Up.

![ExpanderDemo](https://github.com/user-attachments/assets/64b4c6b6-ff83-470f-a202-d51bfa1020e7)


<h3>Enabling the Animation</h3>

By default, on a regular `Expander`, the animation is opt-in since this is a stock Avalonia control and I don't know what ways its being used. There are a few ways to enable it:

1. Set the control theme that enables the animation 
```xaml
<Expander Theme="{StaticResource ExpanderWinUIAnimationStyle}" />
```

3. You can also set the attached property yourself (useful if you customize the Expander template):
```xaml
<Expander ui:ExpanderExt.ExpanderAnimationType="FluentV2" />
```
If you set the attached property, the value is case-insensitive however it must be equivalent to FluentV2

NOTE: if you customize the expander template and want to use this, make sure you look at the updated ControlTheme as there is a required Border that must be provided that is not part of the original template. It's `ClipToBounds` property must also be set to True to ensure correct behavior.

4. If you want this to apply to all expanders, you can use a simple `Style` defined in App.Styles or any parent container:
```xaml
<Style Selector="Expander">
    <Setter Property="Theme" Value="{StaticResource ExpanderWinUIAnimationStyle}" />
</Style>
```

<h3>SettingsExpander</h3>

**`SettingsExpander` will have this animation on by default, and is opt-out.** This has previously been requested and is not a stock Avalonia control, so I feel it is ok to make this opt-out. If you would like to opt-out, you'll set the control theme `SettingsExpanderNoAnimationStyle` on any SettingsExpander you don't want the animation. The Style trick from above should apply if you want to disable for all.