### PR TITLE
Add missing WindowNotificationManager position pseudo classes in style

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/WindowNotificationManagerStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/WindowNotificationManagerStyles.axaml
@@ -41,6 +41,11 @@
             <Setter Property="HorizontalAlignment" Value="Right" />
         </Style>
 
+        <Style Selector="^:topcenter /template/ ReversibleStackPanel#PART_Items">
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
+
         <Style Selector="^:bottomleft /template/ ReversibleStackPanel#PART_Items">
             <Setter Property="ReverseOrder" Value="True" />
             <Setter Property="VerticalAlignment" Value="Bottom" />
@@ -51,6 +56,12 @@
             <Setter Property="ReverseOrder" Value="True" />
             <Setter Property="VerticalAlignment" Value="Bottom" />
             <Setter Property="HorizontalAlignment" Value="Right" />
+        </Style>
+
+        <Style Selector="^:bottomcenter /template/ ReversibleStackPanel#PART_Items">
+            <Setter Property="ReverseOrder" Value="True" />
+            <Setter Property="VerticalAlignment" Value="Bottom" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
         </Style>
     </ControlTheme>
 </ResourceDictionary>


### PR DESCRIPTION
Currently, the style for the [WindowNotificationManager](https://api-docs.avaloniaui.net/docs/T_Avalonia_Controls_Notifications_WindowNotificationManager) templated control does not include selectors for all available [position](https://api-docs.avaloniaui.net/docs/T_Avalonia_Controls_Notifications_NotificationPosition) pseudo classes (`bottomcenter` and `topcenter` are missing).

This pull request adds the missing selectors.
Now the implementation matches the one in [Avalonia](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/WindowNotificationManager.xaml#L35).

Related issue: #632 