### PR TITLE
TabView Overhaul (Part 1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.3.10</AvaloniaVersion>
+    <AvaloniaVersion>11.3.12</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/src/FluentAvalonia/Core/StringBuilderCache.cs
+++ b/src/FluentAvalonia/Core/StringBuilderCache.cs
@@ -1,0 +1,67 @@
+﻿// This file is imported from dotnet/runtime
+// Source Link: https://github.com/dotnet/runtime/blob/e63d21947e734db2da5093510a6636b5b7fb45b5/src/libraries/Common/src/System/Text/StringBuilderCache.cs
+// Commit: a9c5ead on Feb 10, 2021, https://github.com/dotnet/runtime/commit/a9c5eadd951dcba73167f72cc624eb790573663a
+// 
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Avalonia.Utilities;
+
+/// <summary>Provide a cached reusable instance of stringbuilder per thread.</summary>
+internal static class StringBuilderCache
+{
+    // The value 360 was chosen in discussion with performance experts as a compromise between using
+    // as little memory per thread as possible and still covering a large part of short-lived
+    // StringBuilder creations on the startup path of VS designers.
+    internal const int MaxBuilderSize = 360;
+    private const int DefaultCapacity = 16; // == StringBuilder.DefaultCapacity
+
+    // WARNING: We allow diagnostic tools to directly inspect this member (t_cachedInstance).
+    // See https://github.com/dotnet/corert/blob/master/Documentation/design-docs/diagnostics/diagnostics-tools-contract.md for more details.
+    // Please do not change the type, the name, or the semantic usage of this member without understanding the implication for tools.
+    // Get in touch with the diagnostics team if you have questions.
+    [ThreadStatic]
+    private static StringBuilder t_cachedInstance;
+
+    /// <summary>Get a StringBuilder for the specified capacity.</summary>
+    /// <remarks>If a StringBuilder of an appropriate size is cached, it will be returned and the cache emptied.</remarks>
+    public static StringBuilder Acquire(int capacity = DefaultCapacity)
+    {
+        if (capacity <= MaxBuilderSize)
+        {
+            StringBuilder sb = t_cachedInstance;
+            if (sb != null)
+            {
+                // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                // when the requested size is larger than the current capacity
+                if (capacity <= sb.Capacity)
+                {
+                    t_cachedInstance = null;
+                    sb.Clear();
+                    return sb;
+                }
+            }
+        }
+
+        return new StringBuilder(capacity);
+    }
+
+    /// <summary>Place the specified builder in the cache if it is not too big.</summary>
+    public static void Release(StringBuilder sb)
+    {
+        if (sb.Capacity <= MaxBuilderSize)
+        {
+            t_cachedInstance = sb;
+        }
+    }
+
+    /// <summary>ToString() the stringbuilder, Release it to the cache, and return the resulting string.</summary>
+    public static string GetStringAndRelease(StringBuilder sb)
+    {
+        string result = sb.ToString();
+        Release(sb);
+        return result;
+    }
+}

--- a/src/FluentAvalonia/FluentAvalonia.csproj
+++ b/src/FluentAvalonia/FluentAvalonia.csproj
@@ -44,4 +44,8 @@
     <MicroComIdl Include="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.idl" CSharpInteropPath="$(MSBuildThisFileDirectory)\Interop\WinRT\WinRT.Generated.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="FluentAvaloniaTests"/>
+  </ItemGroup>
+
 </Project>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewItemStyles.axaml
@@ -5,11 +5,17 @@
                     xmlns:core="using:FluentAvalonia.Core">
 
     <Design.PreviewWith>
-        <Border Padding="20" Width="300" Height="100">
-            <StackPanel Spacing="20" HorizontalAlignment="Left">
-                <ui:TabViewItem Header="Hello" IconSource="Save"
-                                core:VisualStateHelper.ForcedClassesProperty=":selected"/>
-            </StackPanel>
+        <Border Width="800" Height="500">
+            <Panel >
+                <ui:TabView TabStripLocation="Bottom">
+                    <ui:TabView.TabItems>
+                        <ui:TabViewItem Header="Item1">
+                            <Border Background="Transparent" />
+                        </ui:TabViewItem>
+                        <ui:TabViewItem Header="Item1" />
+                    </ui:TabView.TabItems>
+                </ui:TabView>
+            </Panel>
         </Border>
     </Design.PreviewWith>
 
@@ -54,6 +60,97 @@
         </Style>
     </ControlTheme>
 
+    <!-- ControlTemplate used when tabs are vertical (Left/Right location)-->
+    <ControlTemplate x:Key="VerticalTabViewTabItemTemplate"
+                     TargetType="ui:TabViewItem">
+        <Border Name="LayoutRootBorder"
+                Padding="{TemplateBinding Padding}">
+            <Panel Name="LayoutRoot">
+
+                <Rectangle Name="SelectionIndicator"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Center"
+                           Width="3" Height="16"
+                           Margin="2 0 0 0"
+                           UseLayoutRounding="False"
+                           RadiusX="2" RadiusY="2"
+                           IsVisible="False"
+                           RenderTransform="scaleY(0)"
+                           Fill="{DynamicResource AccentFillColorDefaultBrush}">
+                    <Rectangle.Transitions>
+                        <Transitions>
+                            <TransformOperationsTransition Duration="00:00:00.167"
+                                                           Property="RenderTransform"
+                                                           Easing="0,0 0,1"/>
+                        </Transitions>
+                    </Rectangle.Transitions>
+                </Rectangle>
+
+
+                <Border Name="TabContainerBorder"
+                        Grid.Column="1"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        TemplatedControl.IsTemplateFocusTarget="True"
+                        Padding="{DynamicResource TabViewItemHeaderPadding}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <Grid Name="TabContainer">
+                        <Grid.ColumnDefinitions>
+                            <!-- x:Name = "IconColumn" -->
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Since we can't change the icon column in the styles, to avoid locking it in
+                                code, we use this Rectangle as the sizer for the column -->
+                        <Rectangle HorizontalAlignment="Stretch"
+                                   VerticalAlignment="Stretch"
+                                   Name="IconColumn" />
+
+                        <Viewbox Name="IconBox"
+                                 MaxWidth="{DynamicResource TabViewItemHeaderIconSize}"
+                                 MaxHeight="{DynamicResource TabViewItemHeaderIconSize}"
+                                 Margin="{DynamicResource TabViewItemHeaderIconMargin}"
+                                 IsVisible="False">
+                            <ContentControl Name="IconControl"
+                                            Content="{Binding TabViewTemplateSettings.IconElement, RelativeSource={RelativeSource TemplatedParent}}"
+                                            KeyboardNavigation.IsTabStop="False"
+                                            Foreground="{DynamicResource TabViewItemIconForeground}"/>
+                        </Viewbox>
+
+                        <!-- If we template bind the ContentPresenter's Content property to the TabViewItem.Header property
+                                 we unfortunately run into the following issue if the header is [null] or empty:
+                                 The TabViewItem.Content property will be implictly bound to the Content property of the ContentPresenter.
+                                 To prevent this, we explicitly set a default empty content here and update the content in code behind. -->
+
+                        <ContentPresenter Name="ContentPresenter"
+                                          Grid.Column="1"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content=""
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                          FontWeight="{TemplateBinding FontWeight}"
+                                          FontSize="{DynamicResource TabViewItemHeaderFontSize}"
+                                          Foreground="{DynamicResource TabViewItemHeaderForeground}"/>
+
+                        <Button Name="CloseButton"
+                                Grid.Column="2"
+                                Margin="{DynamicResource TabViewItemHeaderCloseMargin}"
+                                Content="&#xE711;"
+                                Theme="{StaticResource TabViewCloseButtonTheme}"
+                                KeyboardNavigation.IsTabStop="False" />
+                    </Grid>
+                </Border>
+
+            </Panel>
+        </Border>
+    </ControlTemplate>
+    
+    
+    
+    
    
     <ControlTheme x:Key="{x:Type ui:TabViewItem}" TargetType="ui:TabViewItem">
         <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
@@ -64,6 +161,8 @@
         <Setter Property="BorderThickness" Value="{DynamicResource TabViewItemBorderThickness}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TabViewItemBorderBrush}" />
         <Setter Property="ClipToBounds" Value="False" />
+
+        <!--Normal template for Horizontal Tabs-->
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid Name="LayoutRoot" Margin="{TemplateBinding Padding}" UseLayoutRounding="False">
@@ -78,30 +177,40 @@
                     <Border Name="BottomBorderLine" 
                             Background="{DynamicResource TabViewBorderBrush}" 
                             Height="1" Grid.ColumnSpan="3" VerticalAlignment="Bottom" />
-
+ 
                     <!--Note: WinUI doesn't set a Zindex here, but if we dont then the paths get clipped
                               by stuff on top and it doesn't look right. Normally you won't see it unless
-                              you're zoomed way in, but now the arcs look much nicer :) -->
+                              you're zoomed way in, but now the arcs look much nicer :) 
+                              
+                        Also: I've adjusted these paths to use Stretch Fill, despite default None being set
+                              in WinUI because it causes everything to line up better. Also added a 1px bottom
+                              margin (or 1px top for Bottom TabStripLocation) which again helps line everything
+                              up. Not really sure why its needed but it is. Note at if your remove the 1px
+                              margin, there is a slight gap between the arc & the tab border, which is also
+                              present in WinUI, so I've fixed something even upstream has :)
+                    -->
                     <Path Name="LeftRadiusRenderArc" ZIndex="1"
-                          Fill="{DynamicResource TabViewBorderBrush}" 
+                          Fill="{DynamicResource TabViewBorderBrush}" Stretch="Fill"
                           VerticalAlignment="Bottom" 
                           IsVisible="False" 
-                          Margin="-4,0,0,0" Height="4" Width="4"
+                          Margin="-4,0,0,1" Height="4" Width="4"
                           Data="M4 0C4 1.19469 3.47624 2.26706 2.64582 3H0C1.65685 3 3 1.65685 3 0H4Z" />
                     
                     <Path Name="RightRadiusRenderArc" ZIndex="1"
-                          Grid.Column="2" IsVisible="False" 
+                          Grid.Column="2" IsVisible="False" Stretch="Fill"
                           Fill="{DynamicResource TabViewBorderBrush}" VerticalAlignment="Bottom" 
-                          Margin="0,0,-4,0" Height="4" Width="4" 
+                          Margin="0,0,-4,1" Height="4" Width="4" 
                           Data="M0 0C0 1.19469 0.523755 2.26706 1.35418 3H4C2.34315 3 1 1.65685 1 0H0Z" />
                     
-                    <!-- This Path wrapped in a Canvas to prevent an infinite loop in calculating its width. -->
-                    <Canvas Grid.ColumnSpan="3">
-                        <Path Name="SelectedBackgroundPath"                                
-                              Fill="{DynamicResource TabViewItemHeaderBackgroundSelected}" 
-                              VerticalAlignment="Bottom" Margin="-4,0" 
-                              IsVisible="False" 
-                              Data="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.TabGeometry}" />
+                    <!-- (WinUI) This Path wrapped in a Canvas to prevent an infinite loop in calculating its width. 
+                    -->
+                    <Canvas Grid.ColumnSpan="3" Name="SelectedBackgroundPathHost">
+                        <Path Data="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.TabGeometry}" 
+                              Fill="{DynamicResource TabViewItemHeaderBackground}" 
+                              VerticalAlignment="Bottom"
+                              IsVisible="False" Opacity="1"
+                              Margin="-4,0"
+                              Name="SelectedBackgroundPath"/>
                     </Canvas>
 
                     <Border Name="TabSeparator" HorizontalAlignment="Right" 
@@ -123,7 +232,6 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             TemplatedControl.IsTemplateFocusTarget="True"
                             Padding="{DynamicResource TabViewItemHeaderPadding}"
-                            CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}"
                             Name="TabContainerBorder"
                             Grid.Column="1">
                         
@@ -165,8 +273,12 @@
                 </Grid> 
             </ControlTemplate>
         </Setter>
-        
-        <Style Selector="^:pointerover">
+        <Style Selector="^ /template/ Border#TabContainerBorder">
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+        </Style>
+
+        <Style Selector="^:top, ^:bottom">
+            <Style Selector="^:pointerover">
                 <Style Selector="^ /template/ Border#TabContainerBorder">
                     <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundPointerOver}" />
                 </Style>
@@ -185,102 +297,225 @@
                 </Style>
             </Style>
 
-        <Style Selector="^:pressed">
-            <Style Selector="^ /template/ Border#TabContainerBorder">
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundPressed}" />
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundPressed}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundPressed}" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemIconForegroundPressed}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonForeground}" />
+                </Style>
+                <Style Selector="^ /template/ Border#TabSeparator">
+                    <Setter Property="Opacity" Value="0" />
+                </Style>
             </Style>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundPressed}" />
-            </Style>
-            <Style Selector="^ /template/ ContentControl#IconControl">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemIconForegroundPressed}" />
-            </Style>
-            <Style Selector="^ /template/ Button#CloseButton">
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonBackground}" />
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonForeground}" />
-            </Style>
-            <Style Selector="^ /template/ Border#TabSeparator">
-                <Setter Property="Opacity" Value="0" />
-            </Style>
-        </Style>
 
-        <Style Selector="^:selected">
-            <Style Selector="^ /template/ Border#BottomBorderLine">
+            <Style Selector="^:selected">
+                <Style Selector="^ /template/ Border#BottomBorderLine">
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+                <Style Selector="^ /template/ Path#LeftRadiusRenderArc">
+                    <Setter Property="IsVisible" Value="True" />
+                </Style>
+                <Style Selector="^ /template/ Path#RightRadiusRenderArc">
+                    <Setter Property="IsVisible" Value="True" />
+                </Style>
+                <Style Selector="^ /template/ Path#SelectedBackgroundPath">
+                    <Setter Property="IsVisible" Value="True" />
+                    <Setter Property="Fill" Value="{DynamicResource TabViewItemHeaderBackgroundSelected}" />
+                </Style>
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Margin" Value="{DynamicResource TabViewSelectedItemHeaderMargin}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource TabViewSelectedItemBorderBrush}" />
+                    <Setter Property="BorderThickness" Value="{DynamicResource TabViewSelectedItemBorderThickness}" />
+                    <Setter Property="Padding" Value="{DynamicResource TabViewSelectedItemHeaderPadding}" />
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundSelected}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundSelected}" />
+                    <Setter Property="FontWeight" Value="SemiBold" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemIconForegroundSelected}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderSelectedCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderSelectedCloseButtonForeground}" />
+                </Style>
+                <Style Selector="^ /template/ Border#LayoutRootBorder">
+                    <Setter Property="Background" Value="Transparent" />
+                </Style>
+
+                <!-- 
+         :pointerover :selected 
+         :pressed :selected
+         Same changes as just :selected, so we'll let that work for us
+     -->
+            </Style>
+
+            <Style Selector="^:disabled">
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundDisabled}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundDisabled}" />
+                    <Setter Property="FontWeight" Value="SemiBold" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundDisabled}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderDisabledCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderDisabledCloseButtonForeground}" />
+                </Style>
+            </Style>
+
+
+            <!-- :borderleft WinUI: LeftOfSelectedTab -->
+            <Style Selector="^:borderleft /template/ Border#BottomBorderLine">
+                <Setter Property="Margin" Value="0 0 2 0" />
+            </Style>
+
+            <!-- :borderright WinUI: RightOfSelectedTab-->
+            <Style Selector="^:borderright /template/ Border#BottomBorderLine">
+                <Setter Property="Margin" Value="2 0 0 0" />
+            </Style>
+
+            <!-- :noborder WinUI: NoBottomBorderLine -->
+            <Style Selector="^:noborder /template/ Border#BottomBorderLine">
                 <Setter Property="IsVisible" Value="False" />
             </Style>
-            <Style Selector="^ /template/ Path#LeftRadiusRenderArc">
-                <Setter Property="IsVisible" Value="True" />
-            </Style>
-            <Style Selector="^ /template/ Path#RightRadiusRenderArc">
-                <Setter Property="IsVisible" Value="True" />
-            </Style>
-            <Style Selector="^ /template/ Path#SelectedBackgroundPath">
-                <Setter Property="IsVisible" Value="True" />
-                <Setter Property="Fill" Value="{DynamicResource TabViewItemHeaderBackgroundSelected}" />
-            </Style>
-            <Style Selector="^ /template/ Border#TabContainerBorder">
-                <Setter Property="Margin" Value="{DynamicResource TabViewSelectedItemHeaderMargin}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource TabViewSelectedItemBorderBrush}" />
-                <Setter Property="BorderThickness" Value="{DynamicResource TabViewSelectedItemBorderThickness}" />
-                <Setter Property="Padding" Value="{DynamicResource TabViewSelectedItemHeaderPadding}" />
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundSelected}" />
-            </Style>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundSelected}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-            </Style>
-            <Style Selector="^ /template/ ContentControl#IconControl">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemIconForegroundSelected}" />
-            </Style>
-            <Style Selector="^ /template/ Button#CloseButton">
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderSelectedCloseButtonBackground}" />
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderSelectedCloseButtonForeground}" />
-            </Style>
-            <Style Selector="^ /template/ Border#LayoutRootBorder">
-                <Setter Property="Background" Value="Transparent" />
-            </Style>
 
-            <!-- 
-                :pointerover :selected 
-                :pressed :selected
-                Same changes as just :selected, so we'll let that work for us
-            -->
-        </Style>
-
-        <Style Selector="^:disabled">
-            <Style Selector="^ /template/ Border#TabContainerBorder">
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundDisabled}" />
-            </Style>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundDisabled}" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-            </Style>
-            <Style Selector="^ /template/ ContentControl#IconControl">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundDisabled}" />
-            </Style>
-            <Style Selector="^ /template/ Button#CloseButton">
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderDisabledCloseButtonBackground}" />
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderDisabledCloseButtonForeground}" />
+            <!--TabWidthMode is not respected in Left/Right Orientations, so this goes here-->
+            <Style Selector="^:compact">
+                <Style Selector="^ /template/ Viewbox#IconBox">
+                    <Setter Property="Margin" Value="0" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+                <Style Selector="^ /template/ Rectangle#IconColumn">
+                    <Setter Property="Width" Value="{DynamicResource TabViewItemHeaderIconSize}" />
+                </Style>
             </Style>
         </Style>
 
+        <Style Selector="^:left,^:right">
+            <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
+            <Setter Property="Template" Value="{DynamicResource VerticalTabViewTabItemTemplate}" />
 
-        <!-- :borderleft WinUI: LeftOfSelectedTab -->
-        <Style Selector="^:borderleft /template/ Border#BottomBorderLine">
-            <Setter Property="Margin" Value="0 0 2 0" />
+            <Style Selector="^:pointerover">
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemIconForegroundPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonForeground}" />
+                </Style>
+            </Style>
+
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonForeground}" />
+                </Style>
+            </Style>
+
+            <Style Selector="^:selected">
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundSelected}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelected}" />
+                    <Setter Property="FontWeight" Value="SemiBold" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelected}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderSelectedCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderSelectedCloseButtonForeground}" />
+                </Style>
+                <Style Selector="^ /template/ Rectangle#SelectionIndicator">
+                    <Setter Property="IsVisible" Value="True" />
+                    <Setter Property="RenderTransform" Value="scaleY(1)" />
+                </Style>
+
+
+                <Style Selector="^:pointerover">
+                    <Style Selector="^ /template/ Border#TabContainerBorder">
+                        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundSelectedPointerOver}" />
+                    </Style>
+                    <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                        <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelectedPointerOver}" />
+                    </Style>
+                    <Style Selector="^ /template/ ContentControl#IconControl">
+                        <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelectedPointerOver}" />
+                    </Style>
+                    <Style Selector="^ /template/ Button#CloseButton">
+                        <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonBackground}" />
+                        <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonForeground}" />
+                    </Style>
+                </Style>
+
+                <Style Selector="^:pressed">
+                    <Style Selector="^ /template/ Border#TabContainerBorder">
+                        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundSelectedPressed}" />
+                    </Style>
+                    <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                        <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelectedPressed}" />
+                    </Style>
+                    <Style Selector="^ /template/ ContentControl#IconControl">
+                        <Setter Property="Foreground" Value="{DynamicResource ListViewItemForegroundSelectedPressed}" />
+                    </Style>
+                    <Style Selector="^ /template/ Button#CloseButton">
+                        <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonBackground}" />
+                        <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPressedCloseButtonForeground}" />
+                    </Style>
+                </Style>
+            </Style>
+
+            <Style Selector="^:disabled">
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundDisabled}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundDisabled}" />
+                    <Setter Property="FontWeight" Value="SemiBold" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundDisabled}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderDisabledCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderDisabledCloseButtonForeground}" />
+                </Style>
+            </Style>
         </Style>
 
-        <!-- :borderright WinUI: RightOfSelectedTab-->
-        <Style Selector="^:borderright /template/ Border#BottomBorderLine">
-            <Setter Property="Margin" Value="2 0 0 0" />
-        </Style>
 
-        <!-- :noborder WinUI: NoBottomBorderLine -->
-        <Style Selector="^:noborder /template/ Border#BottomBorderLine">
-            <Setter Property="IsVisible" Value="False" />
-        </Style>
-
-        <!-- WinUI: CloseButtonCollapsed TODO: CloseButtonVisible?-->
+        <!-- WinUI: CloseButtonCollapsed-->
         <Style Selector="^:closeCollapsed">
             <Style Selector="^ /template/ Border#TabContainerBorder">
                 <Setter Property="Padding" Value="{DynamicResource TabViewItemHeaderPaddingWithoutCloseButton}" />
@@ -290,26 +525,43 @@
                 <Setter Property="IsVisible" Value="False" />
             </Style>
         </Style>
-        
 
         <Style Selector="^:icon /template/ Viewbox#IconBox">
             <Setter Property="IsVisible" Value="True" />
         </Style>
 
-        <Style Selector="^:compact">
-            <Style Selector="^ /template/ Viewbox#IconBox">
-                <Setter Property="Margin" Value="0" />
-            </Style>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-                <Setter Property="IsVisible" Value="False" />
-            </Style>
-            <Style Selector="^ /template/ Rectangle#IconColumn">
-                <Setter Property="Width" Value="{DynamicResource TabViewItemHeaderIconSize}" />
-            </Style>
-        </Style>
-
         <Style Selector="^:dragging /template/ Grid#LayoutRoot">
             <Setter Property="Opacity" Value="0" />
         </Style>
+
+        <Style Selector="^:bottom">
+            <Style Selector="^ /template/ Border#BottomBorderLine">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
+
+            <Style Selector="^ /template/ Path#LeftRadiusRenderArc">
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="RenderTransform" Value="scaleY(-1)" />
+                <Setter Property="Margin" Value="-4 1 0 0" />
+            </Style>
+            <Style Selector="^ /template/ Path#RightRadiusRenderArc">
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="RenderTransform" Value="scaleY(-1)" />
+                <Setter Property="Margin" Value="0 1 -4 0" />
+            </Style>
+
+            <Style Selector="^ /template/ Border#TabContainerBorder">
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+            </Style>
+            <Style Selector="^:selected">
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Margin" Value="{DynamicResource TabViewSelectedItemHeaderMarginBottom}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource TabViewSelectedItemBorderBrushBottom}" />
+                    <Setter Property="BorderThickness" Value="1 0 1 1" />
+                </Style>
+            </Style>
+        </Style>
+       
     </ControlTheme>
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewItemStyles.axaml
@@ -8,25 +8,25 @@
         <Border Padding="20" Width="300" Height="100">
             <StackPanel Spacing="20" HorizontalAlignment="Left">
                 <ui:TabViewItem Header="Hello" IconSource="Save"
-                                core:VisualStateHelper.ForcedClassesProperty=""/>
+                                core:VisualStateHelper.ForcedClassesProperty=":selected"/>
             </StackPanel>
         </Border>
     </Design.PreviewWith>
 
     <!-- Resources in TabViewStyles.axaml -->
 
-    <ControlTheme x:Key="TabViewCloseButtonStyle" TargetType="Button">
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}"/>
-        <Setter Property="FontSize" Value="{DynamicResource TabViewItemHeaderCloseFontSize}"/>
-        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}"/>
-        <Setter Property="Width" Value="{DynamicResource TabViewItemHeaderCloseButtonWidth}"/>
-        <Setter Property="Height" Value="{DynamicResource TabViewItemHeaderCloseButtonHeight}"/>
-        <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderCloseButtonBackground}"/>
-        <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderCloseButtonForeground}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource TabViewItemHeaderCloseButtonBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="{DynamicResource TabViewItemHeaderCloseButtonBorderThickness}"/>
+    <ControlTheme x:Key="TabViewCloseButtonTheme" TargetType="Button">
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{DynamicResource TabViewItemHeaderCloseFontSize}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Width" Value="{DynamicResource TabViewItemHeaderCloseButtonWidth}" />
+        <Setter Property="Height" Value="{DynamicResource TabViewItemHeaderCloseButtonHeight}" />
+        <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderCloseButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderCloseButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TabViewItemHeaderCloseButtonBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource TabViewItemHeaderCloseButtonBorderThickness}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <ContentPresenter Name="ContentPresenter"
@@ -37,7 +37,8 @@
                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                   BorderBrush="{TemplateBinding BorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}" />
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  AutomationProperties.AccessibilityView="Raw"/>
             </ControlTemplate>
         </Setter>
 
@@ -53,7 +54,7 @@
         </Style>
     </ControlTheme>
 
-
+   
     <ControlTheme x:Key="{x:Type ui:TabViewItem}" TargetType="ui:TabViewItem">
         <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackground}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -65,148 +66,124 @@
         <Setter Property="ClipToBounds" Value="False" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="LayoutRootBorder"
-                        Padding="{TemplateBinding Padding}">
-                    <Grid Name="LayoutRoot">
+                <Grid Name="LayoutRoot" Margin="{TemplateBinding Padding}" UseLayoutRounding="False">
+                    <Grid.ColumnDefinitions>
+                        <!--x:name=LeftColumn-->
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <!--x:name=RightColumn-->
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-                        <Grid.ColumnDefinitions>
-                            <!-- x:Name = "LeftColumn" -->
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                            <!-- x:Name = "RightColumn" -->
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
+                    <Border Name="BottomBorderLine" 
+                            Background="{DynamicResource TabViewBorderBrush}" 
+                            Height="1" Grid.ColumnSpan="3" VerticalAlignment="Bottom" />
 
-                        <!-- Switched to background here as Avalonia won't render border brush with 1 edge set w/ 1px width -->
-                        <!--<Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
-                            <Setter Property="BorderThickness" Value="1" />-->
-                        <Border Name="BottomBorderLine"
-                                Background="{DynamicResource TabViewBorderBrush}"
-                                Height="1"
-                                Grid.ColumnSpan="3"
-                                VerticalAlignment="Bottom"/>
+                    <!--Note: WinUI doesn't set a Zindex here, but if we dont then the paths get clipped
+                              by stuff on top and it doesn't look right. Normally you won't see it unless
+                              you're zoomed way in, but now the arcs look much nicer :) -->
+                    <Path Name="LeftRadiusRenderArc" ZIndex="1"
+                          Fill="{DynamicResource TabViewBorderBrush}" 
+                          VerticalAlignment="Bottom" 
+                          IsVisible="False" 
+                          Margin="-4,0,0,0" Height="4" Width="4"
+                          Data="M4 0C4 1.19469 3.47624 2.26706 2.64582 3H0C1.65685 3 3 1.65685 3 0H4Z" />
+                    
+                    <Path Name="RightRadiusRenderArc" ZIndex="1"
+                          Grid.Column="2" IsVisible="False" 
+                          Fill="{DynamicResource TabViewBorderBrush}" VerticalAlignment="Bottom" 
+                          Margin="0,0,-4,0" Height="4" Width="4" 
+                          Data="M0 0C0 1.19469 0.523755 2.26706 1.35418 3H4C2.34315 3 1 1.65685 1 0H0Z" />
+                    
+                    <!-- This Path wrapped in a Canvas to prevent an infinite loop in calculating its width. -->
+                    <Canvas Grid.ColumnSpan="3">
+                        <Path Name="SelectedBackgroundPath"                                
+                              Fill="{DynamicResource TabViewItemHeaderBackgroundSelected}" 
+                              VerticalAlignment="Bottom" Margin="-4,0" 
+                              IsVisible="False" 
+                              Data="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.TabGeometry}" />
+                    </Canvas>
 
-                        <Path Name="LeftRadiusRenderArc"
-                              Fill="{DynamicResource TabViewBorderBrush}"
-                              VerticalAlignment="Bottom"
-                              IsVisible="False"
-                              Margin="-4 0 0 0"
-                              Height="4"
-                              Width="4"
-                              Data="M4 0C4 1.19469 3.47624 2.26706 2.64582 3H0C1.65685 3 3 1.65685 3 0H4Z" />
+                    <Border Name="TabSeparator" HorizontalAlignment="Right" 
+                            Width="1" Grid.Column="1" 
+                            Background="{DynamicResource TabViewItemSeparator}" 
+                            Margin="{DynamicResource TabViewItemSeparatorMargin}" />
+                    
+                    <Border Name="TabDragVisualContainer"
+                            Grid.Column="1"
+                            IsVisible="False"
+                            Background="{DynamicResource TabViewItemHeaderDragBackground}"
+                            BorderBrush="{DynamicResource TabViewBorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                    </Border>
 
-                        <Path Name="RightRadiusRenderArc"
-                              Grid.Column="2"
-                              IsVisible="False"
-                              Fill="{DynamicResource TabViewBorderBrush}"
-                              VerticalAlignment="Bottom"
-                              Margin="0 0 -4 0"
-                              Height="4"
-                              Width="4"
-                              Data="M0 0C0 1.19469 0.523755 2.26706 1.35418 3H4C2.34315 3 1 1.65685 1 0H0Z"/>
-
-                        <!-- 
-                        This Path wrapped in a Canvas to prevent an infinite loop in calculating its width. 
-                        Added as part of WinUI #8430
-                        -->
-                        <Canvas>
-                            <Path Name="SelectedBackgroundPath"
-                                  Grid.ColumnSpan="3"
-                                  Fill="{DynamicResource TabViewItemHeaderBackgroundSelected}"
-                                  VerticalAlignment="Bottom"
-                                  Margin="-4 0"
-                                  IsVisible="False"
-                                  Data="{Binding TabViewTemplateSettings.TabGeometry, RelativeSource={RelativeSource TemplatedParent}}"/>
-                        </Canvas>
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            TemplatedControl.IsTemplateFocusTarget="True"
+                            Padding="{DynamicResource TabViewItemHeaderPadding}"
+                            CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}"
+                            Name="TabContainerBorder"
+                            Grid.Column="1">
                         
-                        <!-- Switched to background here as Avalonia won't render border brush with 1 edge set w/ 1px width -->
-                        <Border Name="TabSeparator"
-                                HorizontalAlignment="Right"
-                                Width="1"
-                                Grid.Column="1"
-                                Background="{DynamicResource TabViewItemSeparator}"
-                                Margin="{DynamicResource TabViewItemSeparatorMargin}"/>
+                        <Grid Name="TabContainer">
+                            <Grid.ColumnDefinitions>
+                                <!--x:Name="IconColumn"-->
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
 
-                        <Border Name="TabContainerBorder"
-                                Grid.Column="1"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                TemplatedControl.IsTemplateFocusTarget="True"
-                                Padding="{DynamicResource TabViewItemHeaderPadding}"
-                                CornerRadius="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}">
-                            <Grid Name="TabContainer">
-                                <Grid.ColumnDefinitions>
-                                    <!-- x:Name = "IconColumn" -->
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
+                            <Viewbox Name="IconBox" MaxWidth="{DynamicResource TabViewItemHeaderIconSize}"
+                                     MaxHeight="{DynamicResource TabViewItemHeaderIconSize}"
+                                     Margin="{DynamicResource TabViewItemHeaderIconMargin}">
+                                <ContentControl x:Name="IconControl"
+                                                Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.IconElement}"
+                                                IsTabStop="False"
+                                                Foreground="{DynamicResource TabViewItemIconForeground}" />
+                            </Viewbox>
 
-                                <!-- Since we can't change the icon column in the styles, to avoid locking it in
-                                code, we use this Rectangle as the sizer for the column -->
-                                <Rectangle HorizontalAlignment="Stretch"
-                                           VerticalAlignment="Stretch"
-                                           Name="IconColumn" />
-
-                                <Viewbox Name="IconBox"
-                                         MaxWidth="{DynamicResource TabViewItemHeaderIconSize}"
-                                         MaxHeight="{DynamicResource TabViewItemHeaderIconSize}"
-                                         Margin="{DynamicResource TabViewItemHeaderIconMargin}"
-                                         IsVisible="False">
-                                    <ContentControl Name="IconControl"
-                                                    Content="{Binding TabViewTemplateSettings.IconElement, RelativeSource={RelativeSource TemplatedParent}}"
-                                                    KeyboardNavigation.IsTabStop="False"
-                                                    Foreground="{DynamicResource TabViewItemIconForeground}"/>
-                                </Viewbox>
-
-                                <!-- If we template bind the ContentPresenter's Content property to the TabViewItem.Header property
+                            <!-- If we template bind the ContentPresenter's Content property to the TabViewItem.Header property
                                  we unfortunately run into the following issue if the header is [null] or empty:
                                  The TabViewItem.Content property will be implictly bound to the Content property of the ContentPresenter.
                                  To prevent this, we explicitly set a default empty content here and update the content in code behind. -->
-
-                                <ContentPresenter Name="ContentPresenter"
-                                                  Grid.Column="1"
-                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Content=""
-                                                  ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                  FontWeight="{TemplateBinding FontWeight}"
-                                                  FontSize="{DynamicResource TabViewItemHeaderFontSize}"
-                                                  Foreground="{DynamicResource TabViewItemHeaderForeground}"/>
-
-                                <Button Name="CloseButton"
-                                        Grid.Column="2"
-                                        Margin="{DynamicResource TabViewItemHeaderCloseMargin}"
-                                        Content="&#xE711;"
-                                        Theme="{StaticResource TabViewCloseButtonStyle}"
-                                        KeyboardNavigation.IsTabStop="False"/>
-                            </Grid>
-                        </Border>
-
-                    </Grid>
-                </Border>
+                            <ContentPresenter Name="ContentPresenter" Grid.Column="1"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Content="" ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              FontWeight="{TemplateBinding FontWeight}"
+                                              FontSize="{DynamicResource TabViewItemHeaderFontSize}"
+                                              Foreground="{DynamicResource TabViewItemHeaderForeground}" />
+                            <Button Name="CloseButton" Grid.Column="2"
+                                    Margin="{DynamicResource TabViewItemHeaderCloseMargin}"
+                                    Content="&#xE711;"
+                                    IsTabStop="False" 
+                                    Theme="{DynamicResource TabViewCloseButtonTheme}"  />
+                        </Grid>
+                    </Border>
+                </Grid> 
             </ControlTemplate>
         </Setter>
-
+        
         <Style Selector="^:pointerover">
-            <Style Selector="^ /template/ Border#TabContainerBorder">
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundPointerOver}" />
+                <Style Selector="^ /template/ Border#TabContainerBorder">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderBackgroundPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ ContentControl#IconControl">
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemIconForegroundPointerOver}" />
+                </Style>
+                <Style Selector="^ /template/ Button#CloseButton">
+                    <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonBackground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonForeground}" />
+                </Style>
+                <Style Selector="^ /template/ Border#TabSeparator">
+                    <Setter Property="Opacity" Value="0" />
+                </Style>
             </Style>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderForegroundPointerOver}" />
-            </Style>
-            <Style Selector="^ /template/ ContentControl#IconControl">
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemIconForegroundPointerOver}" />
-            </Style>
-            <Style Selector="^ /template/ Button#CloseButton">
-                <Setter Property="Background" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonBackground}" />
-                <Setter Property="Foreground" Value="{DynamicResource TabViewItemHeaderPointerOverCloseButtonForeground}" />
-            </Style>
-            <Style Selector="^ /template/ Border#TabSeparator">
-                <Setter Property="Opacity" Value="0" />
-            </Style>
-        </Style>
 
         <Style Selector="^:pressed">
             <Style Selector="^ /template/ Border#TabContainerBorder">
@@ -287,10 +264,37 @@
             </Style>
         </Style>
 
+
+        <!-- :borderleft WinUI: LeftOfSelectedTab -->
+        <Style Selector="^:borderleft /template/ Border#BottomBorderLine">
+            <Setter Property="Margin" Value="0 0 2 0" />
+        </Style>
+
+        <!-- :borderright WinUI: RightOfSelectedTab-->
+        <Style Selector="^:borderright /template/ Border#BottomBorderLine">
+            <Setter Property="Margin" Value="2 0 0 0" />
+        </Style>
+
+        <!-- :noborder WinUI: NoBottomBorderLine -->
+        <Style Selector="^:noborder /template/ Border#BottomBorderLine">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+
+        <!-- WinUI: CloseButtonCollapsed TODO: CloseButtonVisible?-->
+        <Style Selector="^:closeCollapsed">
+            <Style Selector="^ /template/ Border#TabContainerBorder">
+                <Setter Property="Padding" Value="{DynamicResource TabViewItemHeaderPaddingWithoutCloseButton}" />
+            </Style>
+
+            <Style Selector="^ /template/ Button#CloseButton">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+        </Style>
+        
+
         <Style Selector="^:icon /template/ Viewbox#IconBox">
             <Setter Property="IsVisible" Value="True" />
         </Style>
-
 
         <Style Selector="^:compact">
             <Style Selector="^ /template/ Viewbox#IconBox">
@@ -304,34 +308,8 @@
             </Style>
         </Style>
 
-        <!-- :closecollapsed -->
-        <Style Selector="^:closecollapsed /template/ Button#CloseButton">
-            <Setter Property="IsVisible" Value="False" />
-        </Style>
-
-
-        <!-- :borderleft -->
-        <Style Selector="^:borderleft /template/ Border#BottomBorderLine">
-            <Setter Property="Margin" Value="0 0 2 0" />
-        </Style>
-
-        <!-- :borderright -->
-        <Style Selector="^:borderright /template/ Border#BottomBorderLine">
-            <Setter Property="Margin" Value="2 0 0 0" />
-        </Style>
-
-        <!-- :noborder -->
-        <Style Selector="^:noborder /template/ Border#BottomBorderLine">
-            <Setter Property="IsVisible" Value="False" />
-        </Style>
-        
-        <Style Selector="^:foreground">
-            <Style Selector="^ /template/ ContentControl#IconControl">
-                <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
-            </Style>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-                <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
-            </Style>
+        <Style Selector="^:dragging /template/ Grid#LayoutRoot">
+            <Setter Property="Opacity" Value="0" />
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
@@ -6,9 +6,13 @@
                     x:CompileBindings="True">
 
     <Design.PreviewWith>
-        <Border Padding="20" Width="800" Background="Beige">
-            <ui:TabView>
+        <Border Padding="20" Width="500" Height="150" Background="Beige">
+            <ui:TabView TabStripLocation="Top">
                 <ui:TabView.TabItems>
+                    <ui:TabViewItem Header="Item1" />
+                    <ui:TabViewItem Header="Item1"/>
+                    <ui:TabViewItem Header="Item1" />
+                    <ui:TabViewItem Header="Item1"/>
                     <ui:TabViewItem Header="Item1" />
                     <ui:TabViewItem Header="Item1"/>
                 </ui:TabView.TabItems>
@@ -56,7 +60,7 @@
         <Style Selector="^:disabled /template/ ContentPresenter">
             <Setter Property="Background" Value="{DynamicResource TabViewScrollButtonBackgroundDisabled}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource TabViewScrollButtonBackgroundPointerOver}"/>
-            <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonBorderBrushDisabled}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonForegroundDisabled}"/>
         </Style>
     </ControlTheme>
 
@@ -71,11 +75,16 @@
 
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" MinWidth="2" />
+                            <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
+                        <!--Since we can't adjust coldefs in styles, use this-->
+                        <Border Name="Column0MinWidthSpacer"
+                                IsHitTestVisible="False"
+                                IsEnabled="False" MinWidth="2" />
+                        
                         <Rectangle Name="LeftBottomBorderLine"
                                    Fill="{DynamicResource TabViewBorderBrush}"
                                    Height="1"
@@ -99,9 +108,13 @@
                                           Theme="{StaticResource TabViewScrollButtonTheme}"/>
                         </Border>
 
+                        <!--Note: WinUI has 1px left padding here, which I've removed to prevent a gap
+                                  in all these border lines. Not sure why they need the 1px padding but
+                                  it doesn't work here which might just be from us having to do it differently
+                                  since we don't have Header/Footer on the ItemsPresenter-->
                         <ScrollContentPresenter Name="ScrollContentPresenter"
                                                 Grid.Column="1"
-                                                Padding="1 0 0 0"
+                                                Padding="0 0 0 0"
                                                 KeyboardNavigation.TabNavigation="Once"
                                                 Content="{TemplateBinding Content}"
                                                 HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
@@ -128,6 +141,10 @@
                                           Theme="{StaticResource TabViewScrollButtonTheme}"/>
                         </Border>
 
+                        <!--This ScrollBar is here for Vertical tabs-->
+                        <ScrollBar Name="PART_VerticalScrollBar"
+                                   Grid.Column="2" />
+                        
                     </Grid>
 
                 </Border>
@@ -138,6 +155,30 @@
         <Style Selector="^:noborder /template/ Rectangle#LeftBottomBorderLine,
                          ^:noborder /template/ Rectangle#RightBottomBorderLine">
             <Setter Property="IsVisible" Value="False" />
+        </Style>
+
+        <Style Selector="^:left, ^:right">
+            <Style Selector="^ /template/ Rectangle#LeftBottomBorderLine">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+            <Style Selector="^ /template/ Rectangle#RightBottomBorderLine">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+            <Style Selector="^ /template/ Border#Column0MinWidthSpacer">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+            <Style Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:bottom">
+            <Style Selector="^ /template/ Rectangle#LeftBottomBorderLine">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
+            <Style Selector="^ /template/ Rectangle#RightBottomBorderLine">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
         </Style>
     </ControlTheme>
 
@@ -165,18 +206,17 @@
                 <Border BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Background="{TemplateBinding Background}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
+                        CornerRadius="{TemplateBinding CornerRadius}" Name="Test">
 
                     <ScrollViewer AutomationProperties.AccessibilityView="Raw"
                                   BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
                                   HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                   IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                                   IsScrollChainingEnabled="{TemplateBinding ScrollViewer.IsScrollChainingEnabled}"
-                                  KeyboardNavigation.TabNavigation="{TemplateBinding KeyboardNavigation.TabNavigation}" 
-                                  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"                                  
-                                  Theme="{StaticResource TabScrollViewerTheme}"
-                                  Name="ScrollViewer">
-
+                                  KeyboardNavigation.TabNavigation="{TemplateBinding KeyboardNavigation.TabNavigation}"
+                                  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                  Name="ScrollViewer"
+                                  Theme="{DynamicResource TabScrollViewerTheme}">
                         <DockPanel Margin="{TemplateBinding Padding}" VerticalAlignment="Stretch">
                             <!-- 
                             Avalonia ItemsPresenter doesn't have Header for Footer properties
@@ -185,38 +225,71 @@
                             StackPanel doesn't mess with anything and all still works...
                             -->
 
-                            <Grid Width="4" DockPanel.Dock="Left" VerticalAlignment="Bottom">
-                                <Border Name="LeftBottomBorderLine" 
-                                        Background="{DynamicResource TabViewBorderBrush}" 
-                                        Width="4" Height="1" VerticalAlignment="Bottom" 
+                            <Grid Width="4" DockPanel.Dock="Left" VerticalAlignment="Bottom"
+                                  Name="LeftLineHost">
+                                <Border Name="LeftBottomBorderLine"
+                                        Background="{DynamicResource TabViewBorderBrush}"
+                                        Width="4" Height="1" VerticalAlignment="Bottom"
                                         HorizontalAlignment="Left" />
                             </Grid>
-                            <Grid Width="4" DockPanel.Dock="Right" VerticalAlignment="Bottom">
-                                <Border Name="RightBottomBorderLine" 
-                                        Background="{DynamicResource TabViewBorderBrush}" 
-                                        Width="4" Height="1" VerticalAlignment="Bottom" 
+                            <Grid Width="4" DockPanel.Dock="Right" VerticalAlignment="Bottom"
+                                  Name="RightLineHost">
+                                <Border Name="RightBottomBorderLine"
+                                        Background="{DynamicResource TabViewBorderBrush}"
+                                        Width="4" Height="1" VerticalAlignment="Bottom"
                                         HorizontalAlignment="Right" />
                             </Grid>
-                            
+
                             <ItemsPresenter Name="TabItemsPresenter"
                                             ItemsPanel="{TemplateBinding ItemsPanel}"/>
                         </DockPanel>
+
                     </ScrollViewer>
                 </Border>
             </ControlTemplate>
         </Setter>
+        
+        <Style Selector="^:top, ^:bottom">
+            <Style Selector="^:leftShort /template/ Border#LeftBottomBorderLine">
+                <Setter Property="Width" Value="2" />
+            </Style>
+            <Style Selector="^:rightShort /template/ Border#RightBottomBorderLine">
+                <Setter Property="Width" Value="2" />
+            </Style>
+            <Style Selector="^:noBorder">
+                <Style Selector="^ /template/ Border#LeftBottomBorderLine">
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+                <Style Selector="^ /template/ Border#RightBottomBorderLine">
+                    <Setter Property="IsVisible" Value="False" />
+                </Style>
+            </Style>
+        </Style>
 
-        <Style Selector="^:leftShort /template/ Border#LeftBottomBorderLine">
-            <Setter Property="Width" Value="2" />
-        </Style>
-        <Style Selector="^:rightShort /template/ Border#RightBottomBorderLine">
-            <Setter Property="Width" Value="2" />
-        </Style>
-        <Style Selector="^:noBorder">
+
+        <Style Selector="^:bottom">
+            <Style Selector="^ /template/ Grid#LeftLineHost">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
+            <Style Selector="^ /template/ Grid#RightLineHost">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
             <Style Selector="^ /template/ Border#LeftBottomBorderLine">
-                <Setter Property="IsVisible" Value="False" />
+                <Setter Property="VerticalAlignment" Value="Top" />
             </Style>
             <Style Selector="^ /template/ Border#RightBottomBorderLine">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
+        </Style>
+        
+        <Style Selector="^:left, ^:right">            
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+
+            <Style Selector="^ /template/ Grid#LeftLineHost">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+            <Style Selector="^ /template/ Grid#RightLineHost">
                 <Setter Property="IsVisible" Value="False" />
             </Style>
         </Style>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewListViewStyles.axaml
@@ -6,11 +6,11 @@
                     x:CompileBindings="True">
 
     <Design.PreviewWith>
-        <Border Padding="20" Width="800" >
+        <Border Padding="20" Width="800" Background="Beige">
             <ui:TabView>
                 <ui:TabView.TabItems>
                     <ui:TabViewItem Header="Item1" />
-                    <ui:TabViewItem Header="Item1" />
+                    <ui:TabViewItem Header="Item1"/>
                 </ui:TabView.TabItems>
             </ui:TabView>
         </Border>
@@ -19,8 +19,10 @@
     <!-- Resources in TabViewStyles.axaml -->
     <conv:ScrollViewerVisibilityToBoolConverter x:Key="SVVTBC" />
 
-    <ControlTheme x:Key="TabViewScrollButtonStyle" TargetType="RepeatButton">
+    <ControlTheme x:Key="TabViewScrollButtonTheme" TargetType="RepeatButton">
         <Setter Property="Background" Value="{DynamicResource TabViewScrollButtonBackground}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource TabViewButtonBorderThickness}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TabViewScrollButtonBorderBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonForeground}"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}"/>
         <Setter Property="FontSize" Value="{DynamicResource TabViewItemScrollButtonFontSize}"/>
@@ -43,19 +45,23 @@
 
         <Style Selector="^:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="{DynamicResource TabViewScrollButtonBackgroundPointerOver}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource TabViewScrollButtonBorderBrushPointerOver}"/>
             <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonForegroundPointerOver}"/>
         </Style>
         <Style Selector="^:pressed /template/ ContentPresenter">
             <Setter Property="Background" Value="{DynamicResource TabViewScrollButtonBackgroundPressed}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource TabViewScrollButtonBorderBrushPressed}"/>
             <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonForegroundPressed}"/>
         </Style>
         <Style Selector="^:disabled /template/ ContentPresenter">
             <Setter Property="Background" Value="{DynamicResource TabViewScrollButtonBackgroundDisabled}"/>
-            <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonForegroundDisabled}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource TabViewScrollButtonBackgroundPointerOver}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TabViewScrollButtonBorderBrushDisabled}"/>
         </Style>
     </ControlTheme>
 
-    <ControlTheme x:Key="TabScrollViewerStyle" TargetType="ScrollViewer">
+
+    <ControlTheme x:Key="TabScrollViewerTheme" TargetType="ScrollViewer">
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="Root"
@@ -89,7 +95,8 @@
                                           Delay="50"
                                           Interval="100"
                                           Content="&#xEDD9;"
-                                          Theme="{StaticResource TabViewScrollButtonStyle}"/>
+                                          AutomationProperties.AccessibilityView="Raw"
+                                          Theme="{StaticResource TabViewScrollButtonTheme}"/>
                         </Border>
 
                         <ScrollContentPresenter Name="ScrollContentPresenter"
@@ -117,7 +124,8 @@
                                           Delay="50"
                                           Interval="100"
                                           Content="&#xEDDA;"
-                                          Theme="{StaticResource TabViewScrollButtonStyle}"/>
+                                          AutomationProperties.AccessibilityView="Raw"
+                                          Theme="{StaticResource TabViewScrollButtonTheme}"/>
                         </Border>
 
                     </Grid>
@@ -126,12 +134,15 @@
             </ControlTemplate>
         </Setter>
 
+        <!-- WinUI: NoBottomBorderLine-->
         <Style Selector="^:noborder /template/ Rectangle#LeftBottomBorderLine,
                          ^:noborder /template/ Rectangle#RightBottomBorderLine">
             <Setter Property="IsVisible" Value="False" />
         </Style>
     </ControlTheme>
 
+
+    
     <ControlTheme x:Key="{x:Type uip:TabViewListView}" TargetType="uip:TabViewListView">
         <!-- WinUI doesn't set a background here, but this allows us to receive drag events
              over the TabViewListView and allows the icon to display properly for the drag effects -->
@@ -141,14 +152,12 @@
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Once" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
+
         <Setter Property="ItemsPanel">
             <ItemsPanelTemplate>
-                <!-- 
-                NOTE: This panel enables the reordering/drag effects
-                changing this will disable all drag/drop/reordering
-                logic on the TabView
-                -->
-                <ui:TabViewStackPanel />
+                <VirtualizingStackPanel Orientation="Horizontal" />
             </ItemsPanelTemplate>
         </Setter>
         <Setter Property="Template">
@@ -158,43 +167,59 @@
                         Background="{TemplateBinding Background}"
                         CornerRadius="{TemplateBinding CornerRadius}">
 
-                    <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                  Theme="{StaticResource TabScrollViewerStyle}"
+                    <ScrollViewer AutomationProperties.AccessibilityView="Raw"
+                                  BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+                                  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                                  IsScrollChainingEnabled="{TemplateBinding ScrollViewer.IsScrollChainingEnabled}"
+                                  KeyboardNavigation.TabNavigation="{TemplateBinding KeyboardNavigation.TabNavigation}" 
+                                  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"                                  
+                                  Theme="{StaticResource TabScrollViewerTheme}"
                                   Name="ScrollViewer">
 
-                        <DockPanel>
+                        <DockPanel Margin="{TemplateBinding Padding}" VerticalAlignment="Stretch">
                             <!-- 
                             Avalonia ItemsPresenter doesn't have Header for Footer properties
                             Which is required here to get the solid border beneath the tab items
                             So we have to fake it and hope putting the ItemsPresenter within the
                             StackPanel doesn't mess with anything and all still works...
                             -->
+
+                            <Grid Width="4" DockPanel.Dock="Left" VerticalAlignment="Bottom">
+                                <Border Name="LeftBottomBorderLine" 
+                                        Background="{DynamicResource TabViewBorderBrush}" 
+                                        Width="4" Height="1" VerticalAlignment="Bottom" 
+                                        HorizontalAlignment="Left" />
+                            </Grid>
+                            <Grid Width="4" DockPanel.Dock="Right" VerticalAlignment="Bottom">
+                                <Border Name="RightBottomBorderLine" 
+                                        Background="{DynamicResource TabViewBorderBrush}" 
+                                        Width="4" Height="1" VerticalAlignment="Bottom" 
+                                        HorizontalAlignment="Right" />
+                            </Grid>
                             
-                            <Rectangle Name="LeftBottomBorderLine"
-                                       Margin="-1,0,0,0"
-                                       Fill="{DynamicResource TabViewBorderBrush}"
-                                       Width="4" Height="1"
-                                       VerticalAlignment="Bottom"
-                                       HorizontalAlignment="Left"
-                                       DockPanel.Dock="Left"/>
-                            <Rectangle Name="RightBottomBorderLine"
-                                       Fill="{DynamicResource TabViewBorderBrush}"
-                                       Margin="-1,0,0,0"
-                                       Width="4" Height="1"
-                                       VerticalAlignment="Bottom"
-                                       HorizontalAlignment="Right"
-                                       DockPanel.Dock="Right"/>
                             <ItemsPresenter Name="TabItemsPresenter"
-                                            Margin="{TemplateBinding Padding}"
-                                            ItemsPanel="{TemplateBinding ItemsPanel}" />
+                                            ItemsPanel="{TemplateBinding ItemsPanel}"/>
                         </DockPanel>
-
-
                     </ScrollViewer>
-
                 </Border>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^:leftShort /template/ Border#LeftBottomBorderLine">
+            <Setter Property="Width" Value="2" />
+        </Style>
+        <Style Selector="^:rightShort /template/ Border#RightBottomBorderLine">
+            <Setter Property="Width" Value="2" />
+        </Style>
+        <Style Selector="^:noBorder">
+            <Style Selector="^ /template/ Border#LeftBottomBorderLine">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+            <Style Selector="^ /template/ Border#RightBottomBorderLine">
+                <Setter Property="IsVisible" Value="False" />
+            </Style>
+        </Style>
+        
     </ControlTheme>
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
@@ -6,22 +6,19 @@
 
     <Design.PreviewWith>
         <Border Width="800" Height="500">
-            <ui:TabView TabStripLocation="Left">
+            <ui:TabView TabStripLocation="Top">
                 <ui:TabView.TabItems>
-                    <ui:TabViewItem Header="Item1" />
+                    <ui:TabViewItem Header="Item1">
+                        <Border Background="Transparent" />
+                    </ui:TabViewItem>
                     <ui:TabViewItem Header="Item1" />
                 </ui:TabView.TabItems>
             </ui:TabView>
         </Border>
     </Design.PreviewWith>
-
-    <!-- Change from WinUI:
-        Must setting H padding here so ItemsPresenter sits slightly offset so the curve on the 
-        bottom left of the first tab (if selected) shows, and the separator on the last item
-        shows. Otherwise they get clipped by the ScrollContentPresenter
-        -->
     
     <Thickness x:Key="TabViewHeaderPadding">0,8,0,0</Thickness>
+    <Thickness x:Key="TabViewBottomHeaderPadding">0,0,0,8</Thickness>
     <Thickness x:Key="TabViewItemHeaderPadding">8,3,4,3</Thickness>
     <Thickness x:Key="TabViewSelectedItemHeaderPadding">9,3,5,4</Thickness>
     <x:Double x:Key="TabViewItemMinHeight">32</x:Double>
@@ -47,11 +44,14 @@
     <x:Double x:Key="TabViewItemAddButtonHeight">24</x:Double>
     <x:Double x:Key="TabViewItemAddButtonFontSize">12</x:Double>
     <Thickness x:Key="TabViewItemAddButtonContainerPadding">3,0,0,3</Thickness>
+    <Thickness x:Key="TabViewBottomItemAddButtonContainerPadding">3,3,0,0</Thickness>
+    <Thickness x:Key="VerticalTabViewItemAddButtonContainerPadding">3</Thickness>
     <x:Double x:Key="TabViewShadowDepth">16</x:Double>
     <Thickness x:Key="TabViewItemSeparatorMargin">0,8,0,8</Thickness>
     <Thickness x:Key="TabViewItemBorderThickness">1</Thickness>
     <Thickness x:Key="TabViewSelectedItemBorderThickness">1,1,1,0</Thickness>
     <Thickness x:Key="TabViewSelectedItemHeaderMargin">-1,0,-1,1</Thickness>
+    <Thickness x:Key="TabViewSelectedItemHeaderMarginBottom">-1,1,-1,0</Thickness>
     
     <ControlTheme x:Key="TabViewButtonTheme" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource TabViewButtonBackground}"/>
@@ -95,22 +95,30 @@
 
 
     <ControlTheme x:Key="{x:Type ui:TabView}" TargetType="ui:TabView">
-        <Setter Property="VerticalAlignment" Value="Top" />
+        <!--Change from WinUI: It makes far more sense for this to be Stretch rather than Top-->
+        <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Padding" Value="{DynamicResource TabViewHeaderPadding}" />
         <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
         <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid>
+                <Grid Name="LayoutRoot" Background="Transparent">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    
-                    <Grid Name="TabContainerGrid" 
-                          Background="{TemplateBinding Background}" 
+
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <Grid Name="TabContainerGrid"
+                          Background="{TemplateBinding Background}"
                           XYFocus.NavigationModes="Enabled">
-                        
+
                         <Grid.ColumnDefinitions>
                             <!--x:Name=LeftContentColumn-->
                             <ColumnDefinition Width="Auto" MinWidth="2" />
@@ -121,52 +129,202 @@
                             <!-- x:Name=RightContentColumn-->
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        
-                        <Border Name="LeftBottomBorderLine" 
-                                Background="{DynamicResource TabViewBorderBrush}" 
+
+                        <Border Name="LeftBottomBorderLine"
+                                Background="{DynamicResource TabViewBorderBrush}"
                                 Height="1" VerticalAlignment="Bottom" />
-                        
-                        <Border Name="RightBottomBorderLine" 
-                                Background="{DynamicResource TabViewBorderBrush}" 
-                                Height="1" Grid.Column="2" Grid.ColumnSpan="2" 
+
+                        <Border Name="RightBottomBorderLine"
+                                Background="{DynamicResource TabViewBorderBrush}"
+                                Height="1" Grid.Column="2" Grid.ColumnSpan="2"
                                 VerticalAlignment="Bottom" />
-                                                
-                        <ContentPresenter Grid.Column="0" Name="LeftContentPresenter" 
-                                          Content="{TemplateBinding TabStripHeader}" 
+
+                        <ContentPresenter Grid.Column="0" Name="LeftContentPresenter"
+                                          Content="{TemplateBinding TabStripHeader}"
                                           ContentTemplate="{TemplateBinding TabStripHeaderTemplate}" />
-                        
-                        <uip:TabViewListView Grid.Column="1" HorizontalAlignment="Stretch" 
-                                             Name="TabListView" Padding="{TemplateBinding Padding}" 
-                                             CanReorderItems="{TemplateBinding CanReorderTabs}" 
-                                             CanDragItems="{TemplateBinding CanDragTabs}" 
+
+                        <uip:TabViewListView Name="TabListView" Grid.Column="1" HorizontalAlignment="Stretch" 
+                                             Padding="{TemplateBinding Padding}"
+                                             CanReorderItems="{TemplateBinding CanReorderTabs}"
+                                             CanDragItems="{TemplateBinding CanDragTabs}"
                                              DragDrop.AllowDrop="{TemplateBinding AllowDropTabs}"
                                              ItemsSource="{TemplateBinding TabItemsSource}"
                                              ItemTemplate="{TemplateBinding TabItemTemplate}" />
-                        
-                        <Border IsVisible="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}" 
+
+                        <Border IsVisible="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}"
                                 Grid.Column="2"
-                                Padding="{DynamicResource TabViewItemAddButtonContainerPadding}" 
-                                VerticalAlignment="Bottom">
-                            <Button Name="AddButton" HorizontalAlignment="Center" 
-                                    VerticalAlignment="Center" 
-                                    Content="&#xE710;" 
-                                    Command="{TemplateBinding AddTabButtonCommand}" 
-                                    CommandParameter="{TemplateBinding AddTabButtonCommandParameter}" 
+                                Padding="{DynamicResource TabViewItemAddButtonContainerPadding}"
+                                VerticalAlignment="Bottom"
+                                Name="AddButtonHost">
+                            <Button Name="AddButton" HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Content="&#xE710;"
+                                    Command="{TemplateBinding AddTabButtonCommand}"
+                                    CommandParameter="{TemplateBinding AddTabButtonCommandParameter}"
                                     Theme="{DynamicResource TabViewButtonTheme}" />
                         </Border>
-                        
-                        <ContentPresenter Grid.Column="3" Name="RightContentPresenter" 
-                                          HorizontalAlignment="Stretch" 
-                                          Content="{TemplateBinding TabStripFooter}" 
+
+                        <ContentPresenter Grid.Column="3" Name="RightContentPresenter"
+                                          HorizontalAlignment="Stretch"
+                                          Content="{TemplateBinding TabStripFooter}"
                                           ContentTemplate="{TemplateBinding TabStripFooterTemplate}" />
+
+                        <!-- This will be the resize handle for left/right tabs
+                             Note we set the MinWidth so it isn't impossible to grab
+                             the resize handle with the mouse-->
+                        <Border IsVisible="False"
+                                Cursor="SizeWestEast"
+                                MinWidth="3"
+                                HorizontalAlignment="Right"
+                                Name="BorderResizeHandleHost">
+                            <Rectangle Name="BorderResizeHandle"
+                                       Fill="{DynamicResource TabViewBorderBrush}"
+                                       Width="1"
+                                       HorizontalAlignment="Right" />
+                        </Border>
                     </Grid>
-                    
-                    <ContentPresenter Name="TabContentPresenter" Grid.Row="1" 
+
+                    <ContentPresenter Name="TabContentPresenter"
                                       BorderBrush="{TemplateBinding BorderBrush}"
                                       BorderThickness="{TemplateBinding BorderThickness}"
                                       CornerRadius="{TemplateBinding CornerRadius}"/>
                 </Grid>
             </ControlTemplate>
-        </Setter>        
+        </Setter>
+
+        <Style Selector="^:top">
+            <Style Selector="^ /template/ Grid#TabContainerGrid">
+                <Setter Property="Grid.Column" Value="1" />
+                <Setter Property="Grid.Row" Value="0" />
+            </Style>
+
+            <Style Selector="^ /template/ ContentPresenter#TabContentPresenter">
+                <Setter Property="Grid.Column" Value="1" />
+                <Setter Property="Grid.Row" Value="1" />
+            </Style>
+        </Style>
+
+
+        <!-- In all honesty, left/right really should use the SplitView -->
+        <Style Selector="^:left,^:right">
+            <Setter Property="Template">
+                <ControlTemplate TargetType="ui:TabView">
+                    <SplitView IsPaneOpen="{TemplateBinding IsVerticalPaneOpen, Mode=TwoWay}"
+                               OpenPaneLength="{TemplateBinding VerticalOpenPaneLength, Mode=TwoWay}"
+                               CompactPaneLength="{TemplateBinding MinimumVerticalOpenPaneLength}"
+                               DisplayMode="{TemplateBinding VerticalPaneDisplayMode}"
+                               PaneBackground="Transparent"
+                               Name="RootSplitView">
+                        <SplitView.Pane>
+                            <Grid Name="TabContainerGrid"
+                                  Background="{TemplateBinding Background}"
+                                  XYFocus.NavigationModes="Enabled">
+
+                                <Grid.RowDefinitions>
+                                    <!--x:Name=LeftContentColumn-->
+                                    <RowDefinition Height="Auto"  />
+                                    <!-- x:Name=TabColumn-->
+                                    <RowDefinition Height="Auto" />
+                                    <!-- x:Name=AddButtonColumn-->
+                                    <RowDefinition Height="Auto" />
+                                    <!-- x:Name=RightContentColumn-->
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <ContentPresenter Grid.Row="0" Name="LeftContentPresenter"
+                                                  Content="{TemplateBinding TabStripHeader}"
+                                                  ContentTemplate="{TemplateBinding TabStripHeaderTemplate}" />
+
+                                <uip:TabViewListView Grid.Row="1" HorizontalAlignment="Stretch"
+                                                     Name="TabListView" Padding="{TemplateBinding Padding}"
+                                                     CanReorderItems="{TemplateBinding CanReorderTabs}"
+                                                     CanDragItems="{TemplateBinding CanDragTabs}"
+                                                     DragDrop.AllowDrop="{TemplateBinding AllowDropTabs}"
+                                                     ItemsSource="{TemplateBinding TabItemsSource}"
+                                                     ItemTemplate="{TemplateBinding TabItemTemplate}" />
+                                
+                                <Border IsVisible="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}"
+                                        Grid.Row="2"
+                                        Padding="{DynamicResource VerticalTabViewItemAddButtonContainerPadding}"
+                                        VerticalAlignment="Bottom"
+                                        Name="AddButtonHost"
+                                        HorizontalAlignment="Stretch">
+                                    <Button Name="AddButton" HorizontalAlignment="Stretch"
+                                            Width="NaN"
+                                            VerticalAlignment="Center"
+                                            Content="&#xE710;"
+                                            Command="{TemplateBinding AddTabButtonCommand}"
+                                            CommandParameter="{TemplateBinding AddTabButtonCommandParameter}"
+                                            Theme="{DynamicResource TabViewButtonTheme}" />
+                                </Border>
+
+                                <ContentPresenter Grid.Row="3" Name="RightContentPresenter"
+                                                  HorizontalAlignment="Stretch"
+                                                  Content="{TemplateBinding TabStripFooter}"
+                                                  ContentTemplate="{TemplateBinding TabStripFooterTemplate}" />
+
+                                <!-- This will be the resize handle for left/right tabs
+                                     Note we set the MinWidth so it isn't impossible to grab
+                                     the resize handle with the mouse-->
+                                <Border Cursor="SizeWestEast"
+                                        Grid.RowSpan="4"
+                                        MinWidth="3"
+                                        HorizontalAlignment="Right"
+                                        Background="Transparent"
+                                        Name="BorderResizeHandleHost">
+                                    <Rectangle Name="BorderResizeHandle"
+                                               Fill="{DynamicResource TabViewBorderBrush}"
+                                               Width="1"
+                                               HorizontalAlignment="Right" />
+                                </Border>
+                            </Grid>
+                        </SplitView.Pane>
+                        
+                        <ContentPresenter Name="TabContentPresenter" />
+                    </SplitView>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+
+        <Style Selector="^:right">
+            <Style Selector="^ /template/ SplitView#RootSplitView">
+                <Setter Property="PanePlacement" Value="Right" />
+            </Style>
+
+            <Style Selector="^ /template/ Border#BorderResizeHandleHost">
+                <Setter Property="IsVisible" Value="True" />
+                <Setter Property="Grid.RowSpan" Value="4" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+            </Style>
+            <Style Selector="^ /template/ Rectangle#BorderResizeHandle">
+                <Setter Property="HorizontalAlignment" Value="Left" />
+            </Style>
+        </Style>
+        
+        <Style Selector="^:bottom">
+            <Setter Property="Padding" Value="{DynamicResource TabViewBottomHeaderPadding}" />
+            
+            <Style Selector="^ /template/ Border#AddButtonHost">
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="Padding" Value="{DynamicResource TabViewBottomItemAddButtonContainerPadding}" />
+            </Style>
+
+            <Style Selector="^ /template/ Grid#TabContainerGrid">
+                <Setter Property="Grid.Column" Value="1" />
+                <Setter Property="Grid.Row" Value="2" />
+            </Style>
+
+            <Style Selector="^ /template/ ContentPresenter#TabContentPresenter">
+                <Setter Property="Grid.Column" Value="1" />
+                <Setter Property="Grid.Row" Value="1" />
+            </Style>
+
+            <Style Selector="^ /template/ Border#LeftBottomBorderLine">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
+            <Style Selector="^ /template/ Border#RightBottomBorderLine">
+                <Setter Property="VerticalAlignment" Value="Top" />
+            </Style>
+        </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/FAControls/TabView/TabViewStyles.axaml
@@ -6,7 +6,7 @@
 
     <Design.PreviewWith>
         <Border Width="800" Height="500">
-            <ui:TabView>
+            <ui:TabView TabStripLocation="Left">
                 <ui:TabView.TabItems>
                     <ui:TabViewItem Header="Item1" />
                     <ui:TabViewItem Header="Item1" />
@@ -20,7 +20,8 @@
         bottom left of the first tab (if selected) shows, and the separator on the last item
         shows. Otherwise they get clipped by the ScrollContentPresenter
         -->
-    <Thickness x:Key="TabViewHeaderPadding">2,8,2,0</Thickness>
+    
+    <Thickness x:Key="TabViewHeaderPadding">0,8,0,0</Thickness>
     <Thickness x:Key="TabViewItemHeaderPadding">8,3,4,3</Thickness>
     <Thickness x:Key="TabViewSelectedItemHeaderPadding">9,3,5,4</Thickness>
     <x:Double x:Key="TabViewItemMinHeight">32</x:Double>
@@ -34,9 +35,11 @@
     <x:Double x:Key="TabViewItemHeaderCloseButtonSize">16</x:Double>
     <x:Double x:Key="TabViewItemHeaderCloseFontSize">12</x:Double>
     <Thickness x:Key="TabViewItemHeaderCloseMargin">4,0,0,0</Thickness>
+    <Thickness x:Key="TabViewItemHeaderPaddingWithCloseButton">8,3,4,3</Thickness>
+    <Thickness x:Key="TabViewItemHeaderPaddingWithoutCloseButton">8,3,8,3</Thickness>
     <x:Double x:Key="TabViewItemScrollButtonWidth">32</x:Double>
     <x:Double x:Key="TabViewItemScrollButtonHeight">24</x:Double>
-    <x:Double x:Key="TabViewItemScrollButtonFontSize">14</x:Double>
+    <x:Double x:Key="TabViewItemScrollButonFontSize">8</x:Double>
     <Thickness x:Key="TabViewItemScrollButtonPadding">7,3,7,3</Thickness>
     <Thickness x:Key="TabViewItemLeftScrollButtonContainerPadding">8,0,3,3</Thickness>
     <Thickness x:Key="TabViewItemRightScrollButtonContainerPadding">3,0,8,3</Thickness>
@@ -48,9 +51,9 @@
     <Thickness x:Key="TabViewItemSeparatorMargin">0,8,0,8</Thickness>
     <Thickness x:Key="TabViewItemBorderThickness">1</Thickness>
     <Thickness x:Key="TabViewSelectedItemBorderThickness">1,1,1,0</Thickness>
-    <Thickness x:Key="TabViewSelectedItemHeaderMargin">-1,0,-1,0</Thickness>
-
-    <ControlTheme x:Key="TabViewButtonStyle" TargetType="Button">
+    <Thickness x:Key="TabViewSelectedItemHeaderMargin">-1,0,-1,1</Thickness>
+    
+    <ControlTheme x:Key="TabViewButtonTheme" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource TabViewButtonBackground}"/>
         <Setter Property="Foreground" Value="{DynamicResource TabViewButtonForeground}"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}"/>
@@ -64,11 +67,15 @@
             <ControlTemplate>
                 <ContentPresenter Name="ContentPresenter"
                                   Background="{TemplateBinding Background}"
+                                  BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
                                   Content="{TemplateBinding Content}"
                                   ContentTemplate="{TemplateBinding ContentTemplate}"
                                   CornerRadius="{TemplateBinding CornerRadius}"
                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  AutomationProperties.AccessibilityView="Raw"/>
             </ControlTemplate>
         </Setter>
 
@@ -86,6 +93,7 @@
         </Style>
     </ControlTheme>
 
+
     <ControlTheme x:Key="{x:Type ui:TabView}" TargetType="ui:TabView">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Padding" Value="{DynamicResource TabViewHeaderPadding}" />
@@ -93,76 +101,72 @@
         <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid RowDefinitions="Auto,*">
-
-                    <Grid Name="TabContainerGrid"
-                          Background="{TemplateBinding Background}">
-
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    
+                    <Grid Name="TabContainerGrid" 
+                          Background="{TemplateBinding Background}" 
+                          XYFocus.NavigationModes="Enabled">
+                        
                         <Grid.ColumnDefinitions>
-                            <!-- x:Name="LeftContentColumn -->
+                            <!--x:Name=LeftContentColumn-->
                             <ColumnDefinition Width="Auto" MinWidth="2" />
-                            <!-- x:Name="TabColumn" -->
+                            <!-- x:Name=TabColumn-->
                             <ColumnDefinition Width="Auto" />
-                            <!-- x:Name="AddButtonColumn" -->
+                            <!-- x:Name=AddButtonColumn-->
                             <ColumnDefinition Width="Auto" />
-                            <!-- x:Name="RightContentColumn"-->
+                            <!-- x:Name=RightContentColumn-->
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-
-                        <Rectangle Name="LeftBottomBorderLine"
-                                   Fill="{DynamicResource TabViewBorderBrush}"
-                                   Height="1"
-                                   VerticalAlignment="Bottom"/>
-
-                        <Rectangle Name="RightBottomBorderLine"
-                                   Fill="{DynamicResource TabViewBorderBrush}"
-                                   Height="1"
-                                   Grid.Column="2" Grid.ColumnSpan="2"
-                                   VerticalAlignment="Bottom"/>
-
-                        <ContentPresenter Grid.Column="0"
-                                          Name="LeftContentPresenter"
-                                          Content="{TemplateBinding TabStripHeader}"
-                                          ContentTemplate="{TemplateBinding TabStripHeaderTemplate}"/>
-
-                        <uip:TabViewListView Grid.Column="1"
-                                             Name="TabListView"
-                                             Padding="{TemplateBinding Padding}"
-                                             ItemsSource="{TemplateBinding TabItems}"
-                                             ItemTemplate="{TemplateBinding TabItemTemplate}"
-                                             CanReorderItems="{TemplateBinding CanReorderTabs}"
-                                             CanDragItems="{TemplateBinding CanDragTabs}"
-                                             DragDrop.AllowDrop="{TemplateBinding AllowDropTabs}" />
-
-                        <Border IsVisible="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}"
+                        
+                        <Border Name="LeftBottomBorderLine" 
+                                Background="{DynamicResource TabViewBorderBrush}" 
+                                Height="1" VerticalAlignment="Bottom" />
+                        
+                        <Border Name="RightBottomBorderLine" 
+                                Background="{DynamicResource TabViewBorderBrush}" 
+                                Height="1" Grid.Column="2" Grid.ColumnSpan="2" 
+                                VerticalAlignment="Bottom" />
+                                                
+                        <ContentPresenter Grid.Column="0" Name="LeftContentPresenter" 
+                                          Content="{TemplateBinding TabStripHeader}" 
+                                          ContentTemplate="{TemplateBinding TabStripHeaderTemplate}" />
+                        
+                        <uip:TabViewListView Grid.Column="1" HorizontalAlignment="Stretch" 
+                                             Name="TabListView" Padding="{TemplateBinding Padding}" 
+                                             CanReorderItems="{TemplateBinding CanReorderTabs}" 
+                                             CanDragItems="{TemplateBinding CanDragTabs}" 
+                                             DragDrop.AllowDrop="{TemplateBinding AllowDropTabs}"
+                                             ItemsSource="{TemplateBinding TabItemsSource}"
+                                             ItemTemplate="{TemplateBinding TabItemTemplate}" />
+                        
+                        <Border IsVisible="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}" 
                                 Grid.Column="2"
-                                Padding="{DynamicResource TabViewItemAddButtonContainerPadding}"
+                                Padding="{DynamicResource TabViewItemAddButtonContainerPadding}" 
                                 VerticalAlignment="Bottom">
-                            <Button Name="AddButton"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Content="&#xE710;"
-                                    Command="{TemplateBinding AddTabButtonCommand}"
-                                    CommandParameter="{TemplateBinding AddTabButtonCommandParameter}"
-                                    Theme="{StaticResource TabViewButtonStyle}" />
+                            <Button Name="AddButton" HorizontalAlignment="Center" 
+                                    VerticalAlignment="Center" 
+                                    Content="&#xE710;" 
+                                    Command="{TemplateBinding AddTabButtonCommand}" 
+                                    CommandParameter="{TemplateBinding AddTabButtonCommandParameter}" 
+                                    Theme="{DynamicResource TabViewButtonTheme}" />
                         </Border>
-
-                        <ContentPresenter Grid.Column="3"
-                                          Name="RightContentPresenter"
-                                          HorizontalAlignment="Stretch"
-                                          Content="{TemplateBinding TabStripFooter}"
-                                          ContentTemplate="{TemplateBinding TabStripFooterTemplate}"/>
+                        
+                        <ContentPresenter Grid.Column="3" Name="RightContentPresenter" 
+                                          HorizontalAlignment="Stretch" 
+                                          Content="{TemplateBinding TabStripFooter}" 
+                                          ContentTemplate="{TemplateBinding TabStripFooterTemplate}" />
                     </Grid>
-
-                    <ContentPresenter Name="TabContentPresenter"
-                                      Grid.Row="1"
-                                      Background="{DynamicResource TabViewItemHeaderBackgroundSelected}"
+                    
+                    <ContentPresenter Name="TabContentPresenter" Grid.Row="1" 
                                       BorderBrush="{TemplateBinding BorderBrush}"
-                                      BorderThickness="{TemplateBinding BorderThickness}" />
-
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      CornerRadius="{TemplateBinding CornerRadius}"/>
                 </Grid>
             </ControlTemplate>
-        </Setter>
+        </Setter>        
     </ControlTheme>
-
 </ResourceDictionary>

--- a/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
+++ b/src/FluentAvalonia/Styling/StylesV2/Fluentv2.axaml
@@ -1695,80 +1695,90 @@
 
 
             <!-- TABVIEW -->
-            <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SubtleFillColorTransparentBrush" />
-            <!-- Colors adjusted for next 5 items from WinUI #6763 -->
-            <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
-
-            <StaticResource x:Key="TabViewItemHeaderForeground"                             ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundPressed"                      ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundSelected"                     ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundPointerOver"                  ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundDisabled"                     ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewItemIconForeground"                               ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundPressed"                        ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundSelected"                       ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundPointerOver"                    ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundDisabled"                       ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewButtonBackground"                                 ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundPressed"                          ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundPointerOver"                      ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundDisabled"                         ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewButtonForeground"                                 ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundPressed"                          ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundPointerOver"                      ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundDisabled"                         ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackground"                           ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundPressed"                    ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver"                ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundDisabled"                   ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForeground"                           ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundPressed"                    ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver"                ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundDisabled"                   ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewItemSeparator"                                    ResourceKey="DividerStrokeColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground"                  ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed"           ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPointerOver"       ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonBackground"           ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonBackground"       ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonBackground"          ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonBackground"          ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForeground"                  ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPressed"           ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPointerOver"       ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonForeground"           ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonForeground"       ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonForeground"          ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground"          ResourceKey="TextFillColorDisabledBrush" />
-            <!-- Resources added from WinUI #6787 & #6790 -->
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrush"                 ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPointerOver"      ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPressed"          ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushSelected"         ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushDisabled"         ResourceKey="SubtleFillColorTransparentBrush" />
-
-
-            <!-- Note: These theme resources below are no longer used and might be removed in a future WinUI update. -->
-            <StaticResource x:Key="TabViewButtonBackgroundActiveTab"                        ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundActiveTab"                        ResourceKey="ControlStrongFillColorDefaultBrush" />
-
-            <StaticResource x:Key="TabViewBorderBrush"                                      ResourceKey="CardStrokeColorDefault" />
-            <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackground" ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDragBackground" ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver" ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed" ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled" ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewItemIconForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemSeparator" ResourceKey="DividerStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushSelected" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundActiveTab" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundActiveTab" ResourceKey="ControlStrongFillColorDefaultBrush" />
+            <StaticResource x:Key="TabViewBorderBrush" ResourceKey="CardStrokeColorDefault" />
+            <StaticResource x:Key="TabViewItemBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <Thickness x:Key="TabViewButtonBorderThickness">0</Thickness>
             <Thickness x:Key="TabViewItemHeaderCloseButtonBorderThickness">0</Thickness>
-            <!-- NOTE THIS WAS CHANGED UNTIL WE GET BRUSH TRANSFORMS IMPLEMENTED -->
-            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-                <!--MappingMode="Absolute" 
-        <LinearGradientBrush.RelativeTransform>
-            <ScaleTransform ScaleY="-1" CenterY="0.5"/>
-        </LinearGradientBrush.RelativeTransform>-->
+            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0,0" EndPoint="0,4" 
+                                 TransformOrigin="50%,50%">
+                <LinearGradientBrush.Transform>
+                    <ScaleTransform ScaleY="-1" />
+                </LinearGradientBrush.Transform>
                 <LinearGradientBrush.GradientStops>
-                    <GradientStop Offset="0.88" Color="{DynamicResource CardStrokeColorDefault}"/>
-                    <GradientStop Offset="0.88" Color="Transparent"/>
+                    <GradientStop Offset="1.0" Color="Transparent" />
+                    <GradientStop Offset="1.0" Color="{DynamicResource CardStrokeColorDefault}" />
+                </LinearGradientBrush.GradientStops>
+            </LinearGradientBrush>
 
+            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrushBottom" StartPoint="0,0" EndPoint="0,4"
+                                 TransformOrigin="50%,50%">
+                
+                <LinearGradientBrush.GradientStops>
+                    <GradientStop Offset="1.0" Color="Transparent" />
+                    <GradientStop Offset="1.0" Color="{DynamicResource CardStrokeColorDefault}" />
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
 
@@ -1886,6 +1896,8 @@
             <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
             
         </ResourceDictionary>
+        
+        
         <ResourceDictionary x:Key="Dark">
             <!-- Brushes -->
 
@@ -3586,84 +3598,92 @@
 
 
             <!-- TAB VIEW -->
-            <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SubtleFillColorTransparentBrush" />
-            <!-- Colors adjusted for next 5 items from WinUI #6763 -->
-            <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
-
-            <StaticResource x:Key="TabViewItemHeaderForeground"                             ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundPressed"                      ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundSelected"                     ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundPointerOver"                  ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundDisabled"                     ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewItemIconForeground"                               ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundPressed"                        ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundSelected"                       ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundPointerOver"                    ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundDisabled"                       ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewButtonBackground"                                 ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundPressed"                          ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundPointerOver"                      ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundDisabled"                         ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewButtonForeground"                                 ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundPressed"                          ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundPointerOver"                      ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundDisabled"                         ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackground"                           ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundPressed"                    ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver"                ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundDisabled"                   ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForeground"                           ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundPressed"                    ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver"                ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundDisabled"                   ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="TabViewItemSeparator"                                    ResourceKey="DividerStrokeColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground"                  ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed"           ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPointerOver"       ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonBackground"           ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonBackground"       ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonBackground"          ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonBackground"          ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForeground"                  ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPressed"           ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPointerOver"       ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonForeground"           ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonForeground"       ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonForeground"          ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground"          ResourceKey="TextFillColorDisabledBrush" />
-            <!-- Resources added from WinUI #6787 & #6790 -->
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrush"                 ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPointerOver"      ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPressed"          ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushSelected"         ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushDisabled"         ResourceKey="SubtleFillColorTransparentBrush" />
-
-            <!-- Note: These theme resources below are no longer used and might be removed in a future WinUI update. -->
-            <StaticResource x:Key="TabViewButtonBackgroundActiveTab"                        ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundActiveTab"                        ResourceKey="ControlStrongFillColorDefaultBrush" />
-
-            <StaticResource x:Key="TabViewBorderBrush"                                      ResourceKey="CardStrokeColorDefault" />
-            <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackground" ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDragBackground" ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver" ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed" ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled" ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewItemIconForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundPressed" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemSeparator" ResourceKey="DividerStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushSelected" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundActiveTab" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundActiveTab" ResourceKey="ControlStrongFillColorDefaultBrush" />
+            <StaticResource x:Key="TabViewBorderBrush" ResourceKey="CardStrokeColorDefault" />
+            <StaticResource x:Key="TabViewItemBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <Thickness x:Key="TabViewButtonBorderThickness">0</Thickness>
             <Thickness x:Key="TabViewItemHeaderCloseButtonBorderThickness">0</Thickness>
-
-            <!-- NOTE THIS WAS CHANGED UNTIL WE GET BRUSH TRANSFORMS IMPLEMENTED -->
-            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-                <!--MappingMode="Absolute" 
-        <LinearGradientBrush.RelativeTransform>
-            <ScaleTransform ScaleY="-1" CenterY="0.5"/>
-        </LinearGradientBrush.RelativeTransform>-->
+            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0,0" EndPoint="0,4"
+                                 TransformOrigin="50%,50%">
+                <LinearGradientBrush.Transform>
+                    <ScaleTransform ScaleY="-1" />
+                </LinearGradientBrush.Transform>
                 <LinearGradientBrush.GradientStops>
-                    <GradientStop Offset="0.88" Color="{DynamicResource CardStrokeColorDefault}"/>
-                    <GradientStop Offset="0.88" Color="Transparent"/>
-
+                    <GradientStop Offset="1.0" Color="Transparent" />
+                    <GradientStop Offset="1.0" Color="{DynamicResource CardStrokeColorDefault}" />
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
 
+            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrushBottom" StartPoint="0,0" EndPoint="0,4"
+                                             TransformOrigin="50%,50%">
 
+                <LinearGradientBrush.GradientStops>
+                    <GradientStop Offset="1.0" Color="Transparent" />
+                    <GradientStop Offset="1.0" Color="{DynamicResource CardStrokeColorDefault}" />
+                </LinearGradientBrush.GradientStops>
+            </LinearGradientBrush>
 
             <!-- TASK DIALOG -->
             <!-- Dialog -->
@@ -3779,6 +3799,8 @@
             
             
         </ResourceDictionary>
+        
+        
         <ResourceDictionary x:Key="{x:Static sty:FluentAvaloniaTheme.HighContrastTheme}">
             <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="{DynamicResource SystemColorWindowTextColor}" />
             <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{DynamicResource SystemColorWindowTextColor}" />
@@ -5480,79 +5502,91 @@
             <Thickness x:Key="IconInfoBadgeIconMargin">4,4,4,4</Thickness>
 
             <!-- TABVIEW (Resources updated in WinUI #6787) -->
-            <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForeground"                             ResourceKey="SystemColorWindowTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundPressed"                      ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundSelected"                     ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundPointerOver"                  ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderForegroundDisabled"                     ResourceKey="SystemColorGrayTextColorBrush" />
-            <StaticResource x:Key="TabViewItemIconForeground"                               ResourceKey="SystemColorWindowTextColorBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundPressed"                        ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundSelected"                       ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundPointerOver"                    ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewItemIconForegroundDisabled"                       ResourceKey="SystemColorGrayTextColorBrush" />
-            <StaticResource x:Key="TabViewButtonBackground"                                 ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundPressed"                          ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundPointerOver"                      ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundDisabled"                         ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewButtonForeground"                                 ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundPressed"                          ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundPointerOver"                      ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewButtonForegroundDisabled"                         ResourceKey="SystemColorGrayTextColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackground"                           ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundPressed"                    ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver"                ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonBackgroundDisabled"                   ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForeground"                           ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundPressed"                    ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver"                ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForegroundDisabled"                   ResourceKey="SystemColorGrayTextColorBrush" />
-            <StaticResource x:Key="TabViewItemSeparator"                                    ResourceKey="SystemColorWindowTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground"                  ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed"           ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPointerOver"       ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonBackground"           ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonBackground"       ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonBackground"          ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonBackground"          ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForeground"                  ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPressed"           ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPointerOver"       ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonForeground"           ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonForeground"       ResourceKey="SystemColorHighlightTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonForeground"          ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground"          ResourceKey="SystemColorGrayTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrush"                 ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPointerOver"      ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPressed"          ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushSelected"         ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushDisabled"         ResourceKey="SystemControlTransparentBrush" />
-
-            <!-- Note: These theme resources below are no longer used and might be removed in a future WinUI update. -->
-            <!--<StaticResource x:Key="TabViewButtonBackgroundActiveTab"                        ResourceKey="SystemControlTransparentBrush" />-->
-            <!--<StaticResource x:Key="TabViewButtonForegroundActiveTab"                        ResourceKey="SystemControlBackgroundBaseMediumBrush" />-->
-
-            <StaticResource x:Key="TabViewBorderBrush"                                      ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewBackground" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackground" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDragBackground" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForeground" ResourceKey="SystemColorWindowTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundSelected" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewItemIconForeground" ResourceKey="SystemColorWindowTextColorBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundSelected" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewItemIconForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonBackground" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundDisabled" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TabViewButtonForeground" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackground" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBackgroundDisabled" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForeground" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewItemSeparator" ResourceKey="SystemColorWindowTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPointerOver" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonBackground" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForeground" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPressed" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonForegroundPointerOver" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPressedCloseButtonForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderPointerOverCloseButtonForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderSelectedCloseButtonForeground" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderDisabledCloseButtonForeground" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPointerOver" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushPressed" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushSelected" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewItemHeaderCloseButtonBorderBrushDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundActiveTab" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonForegroundActiveTab" ResourceKey="SystemControlBackgroundBaseMediumBrush" />
+            <SolidColorBrush x:Key="TabViewBorderBrush" Color="{DynamicResource SystemColorHighlightColor}" />
+            <StaticResource x:Key="TabViewItemBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
+            <Thickness x:Key="TabViewButtonBorderThickness">1</Thickness>
             <Thickness x:Key="TabViewItemHeaderCloseButtonBorderThickness">1</Thickness>
-
-            <!-- NOTE THIS WAS CHANGED UNTIL WE GET BRUSH TRANSFORMS IMPLEMENTED -->
-            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-                <!--MappingMode="Absolute" 
-        <LinearGradientBrush.RelativeTransform>
-            <ScaleTransform ScaleY="-1" CenterY="0.5"/>
-        </LinearGradientBrush.RelativeTransform>-->
+            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" StartPoint="0,0" EndPoint="0,4"
+                                 TransformOrigin="50%,50%">
+                <LinearGradientBrush.Transform>
+                    <ScaleTransform ScaleY="-1" />
+                </LinearGradientBrush.Transform>
                 <LinearGradientBrush.GradientStops>
-                    <GradientStop Offset="0.88" Color="{DynamicResource SystemColorHighlightColor}"/>
-                    <GradientStop Offset="0.88" Color="Transparent"/>
+                    <GradientStop Offset="1.0" Color="Transparent" />
+                    <GradientStop Offset="1.0" Color="{DynamicResource SystemColorHighlightColor}" />
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
+            <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrushBottom" StartPoint="0,0" EndPoint="0,4"
+                                             TransformOrigin="50%,50%">
 
+                <LinearGradientBrush.GradientStops>
+                    <GradientStop Offset="1.0" Color="Transparent" />
+                    <GradientStop Offset="1.0" Color="{DynamicResource SystemColorHighlightColor}" />
+                </LinearGradientBrush.GradientStops>
+            </LinearGradientBrush>
 
 
             <!-- TASK DIALOG -->

--- a/src/FluentAvalonia/UI/Controls/Internal/SelectorItem.cs
+++ b/src/FluentAvalonia/UI/Controls/Internal/SelectorItem.cs
@@ -1,0 +1,132 @@
+﻿using System.ComponentModel;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Mixins;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using FluentAvalonia.Core;
+
+namespace FluentAvalonia.UI.Controls.Internal;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class SelectorItem : ContentControl, ISelectable
+{
+    static SelectorItem()
+    {
+        SelectableMixin.Attach<SelectorItem>(IsSelectedProperty);
+        FocusableProperty.OverrideDefaultValue<SelectorItem>(true);
+        AutomationProperties.IsOffscreenBehaviorProperty.OverrideDefaultValue<SelectorItem>(IsOffscreenBehavior.FromClip);
+    }
+
+    /// <summary>
+    /// Defines the <see cref="IsSelected"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsSelectedProperty =
+        SelectingItemsControl.IsSelectedProperty.AddOwner<SelectorItem>();
+
+    /// <summary>
+    /// Gets or sets whether the item is selected
+    /// </summary>
+    public bool IsSelected
+    {
+        get => GetValue(IsSelectedProperty);
+        set => SetValue(IsSelectedProperty, value);
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+
+        if (IgnorePointerId(e.Pointer.Id))
+            return;
+
+        if (e.Pointer.Type == PointerType.Mouse)
+        {
+            _isPressed = e.GetCurrentPoint(this).Properties.IsLeftButtonPressed;
+        }
+        else
+        {
+            _isPressed = true;
+        }
+
+        if (_isPressed)
+            UpdateVisualState();
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+
+        ProcessPointerOver(e);
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+
+        if (IgnorePointerId(e.Pointer.Id))
+            return;
+
+        if (_isPressed)
+        {
+            _isPressed = false;
+            UpdateVisualState();
+        }
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+
+        ProcessPointerCanceled(e.Pointer);
+    }
+
+    private void ProcessPointerOver(PointerEventArgs args)
+    {
+        if (IgnorePointerId(args.Pointer.Id))
+            return;
+
+        var rc = new Rect(Bounds.Size);
+        var pt = args.GetPosition(this);
+        _isPressed = rc.Contains(pt);
+        PseudoClasses.Set(":pointerover", _isPressed);
+    }
+
+    private void ProcessPointerCanceled(IPointer args)
+    {
+        if (IgnorePointerId(args.Id))
+            return;
+
+        _isPressed = false;
+        ResetTrackedPointerId();
+        UpdateVisualState();
+    }
+
+    private void ResetTrackedPointerId()
+    {
+        _trackedPointerId = 0;
+    }
+
+    private bool IgnorePointerId(int id)
+    {
+        if (_trackedPointerId == 0)
+        {
+            _trackedPointerId = id;
+        }
+        else if (_trackedPointerId != id)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private void UpdateVisualState()
+    {
+        PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, _isPressed);
+    }
+
+    private bool _isPressed;
+    private int _trackedPointerId;
+}

--- a/src/FluentAvalonia/UI/Controls/TabView/Enums/TabViewTabStripLocation.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/Enums/TabViewTabStripLocation.cs
@@ -1,0 +1,27 @@
+﻿namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Defines constants for where a TabStrip should appear in a <see cref="TabView"/>
+/// </summary>
+public enum TabViewTabStripLocation
+{
+    /// <summary>
+    /// The TabStrip should appear at the top of the TabView, above the content
+    /// </summary>
+    Top,
+
+    /// <summary>
+    /// The TabStrip should appear on the left of the TabView
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// The TabStrip should appear on the right of the TabView
+    /// </summary>
+    Right,
+
+    /// <summary>
+    /// The TabStrip should appear at the bottom of the TabView, below the content
+    /// </summary>
+    Bottom
+}

--- a/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
@@ -40,7 +40,8 @@ internal class LiveReorderHelper
             CacheContainerBounds();
         }
 
-        var dragPoint = args.GetPosition(_owner);
+        // AdjustDragPoint adjusts the coordinate for scrolling
+        var dragPoint = AdjustDragPoint(args.GetPosition(_owner), _owner.Scroller.Offset, orientation);
         int draggedIndex = dragItemIndex;
         int insertionIndex = -1;
         int dragOverIndex = GetClosestElement(dragPoint);// IndexFromContainer(currentItem); // The raw item index under the pointer
@@ -71,7 +72,7 @@ internal class LiveReorderHelper
             }
         }
 
-        //var old = dragOverIndex; // Keep this here for debug purposes, if needed
+        // var old = dragOverIndex; // Keep this here for debug purposes, if needed
         if (insertionIndex == itemsCount)
         {
             dragOverIndex = itemsCount;
@@ -82,7 +83,7 @@ internal class LiveReorderHelper
             dragOverIndex = GetDragOverIndex(dragOverIndex, insertionIndex, previousDragOverIndex);
         }
 
-        // Debug.WriteLine($"\tLive Reorder DragOverIndex: {dragOverIndex} || DragOverBeforeAdj: {old} || InsertionIndex {insertionIndex} || PrevDragOverIndex {previousDragOverIndex}");
+        //Debug.WriteLine($"\tLive Reorder DragOverIndex: {dragOverIndex} || DragOverBeforeAdj: {old} || InsertionIndex {insertionIndex} || PrevDragOverIndex {previousDragOverIndex}");
 
         _liveReorderIndices = new LiveReorderIndices(draggedIndex, dragOverIndex, itemsCount);
 
@@ -170,8 +171,8 @@ internal class LiveReorderHelper
         var panel = ItemsPanelRoot;
         if (panel is VirtualizingStackPanel vsp)
         {
-            var firstRealized = vsp.FirstRealizedIndex;
-            var lastRealized = vsp.LastRealizedIndex;
+            var firstRealized = _firstCachedContainerIndex;
+            var lastRealized = firstRealized + _cachedContainerBounds.Count - 1;
             var orientation = vsp.Orientation;
             var movedItems = _movedItems.AsSpan();
             int closestIndex = -1;
@@ -360,9 +361,9 @@ internal class LiveReorderHelper
             // make sure we grab the original bounds. If virtualizing, translate
             // to index in our container cache
             var adjIndex = host.ItemsPanelRoot is VirtualizingStackPanel vsp ?
-                index - vsp.FirstRealizedIndex : index;
+                index - host._firstCachedContainerIndex : index;
 
-            if (adjIndex >= host._cachedContainerBounds.Count)
+            if (adjIndex < 0 || adjIndex >= host._cachedContainerBounds.Count)
                 return default;
 
             return host._cachedContainerBounds[adjIndex];
@@ -417,6 +418,7 @@ internal class LiveReorderHelper
         {
             var firstRealized = vsp.FirstRealizedIndex;
             var lastRealized = vsp.LastRealizedIndex;
+            _firstCachedContainerIndex = firstRealized;
             _cachedContainerBounds ??= new List<Rect>((lastRealized - firstRealized) + 1);
 
             for (int i = firstRealized; i <= lastRealized; i++)
@@ -427,6 +429,7 @@ internal class LiveReorderHelper
         }
         else if (panel is StackPanel sp)
         {
+            _firstCachedContainerIndex = 0;
             var itemCount = _owner.ItemCount;
             _cachedContainerBounds ??= new List<Rect>(itemCount);
             // Stack Panels don't virtualize and arrange in order so this is safe
@@ -446,6 +449,25 @@ internal class LiveReorderHelper
         // ceases completely, set it to null
         if (clearCompletely)
             _cachedContainerBounds = null;
+
+        _firstCachedContainerIndex = -1;
+    }
+
+    private static Point AdjustDragPoint(Point rawPoint, Vector offset, Orientation? orientation)
+    {
+        if (orientation.HasValue)
+        {
+            if (orientation.Value == Orientation.Horizontal)
+            {
+                return new Point(rawPoint.X + offset.X, rawPoint.Y);
+            }
+            else
+            {
+                return new Point(rawPoint.X, rawPoint.Y + offset.Y);
+            }
+        }
+
+        return rawPoint + offset;
     }
 
 
@@ -454,6 +476,7 @@ internal class LiveReorderHelper
     private DispatcherTimer _liveReorderTimer;
     private readonly MovedItems _movedItems = new MovedItems();
     private List<Rect> _cachedContainerBounds;
+    private int _firstCachedContainerIndex = -1;
 }
 
 internal struct LiveReorderIndices

--- a/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -299,8 +296,6 @@ internal class LiveReorderHelper
     {
         StopLiveReorderTimer();
 
-        Debug.Assert(_liveReorderIndices.draggedItemIndex != -1);
-
         var orientation = _owner.GetLogicalOrientation().Value;
 
         using var newItems = new PooledList<MovedItem>();
@@ -314,11 +309,6 @@ internal class LiveReorderHelper
         MoveItemsForLiveReorder(false /*areNewItems*/, oldItemsToMoveBack);
 
         MoveItemsForLiveReorder(true, newItemsToMove);
-
-        foreach (var item in _movedItems.AsSpan())
-        {
-            Debug.WriteLine($"\t MovedItems: {item.sourceIndex} -> {item.destinationIndex} || {item.sourceRect} -> {item.destinationRect}");
-        }
     }
 
     private void GetNewMovedItemsForLiveReorder(IList<MovedItem> newItems)

--- a/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
@@ -150,7 +150,7 @@ internal class LiveReorderHelper
         ClearContainerBoundsCache();
     }
 
-    private int GetInsertionIndexForLiveReorder()
+    public int GetInsertionIndexForLiveReorder()
     {
         var draggedIndex = _liveReorderIndices.draggedItemIndex;
         var insertIndex = _liveReorderIndices.draggedOverIndex;
@@ -167,7 +167,7 @@ internal class LiveReorderHelper
         return insertIndex;
     }
 
-    private int GetClosestElement(Point dragPoint, bool requestingInsertionIndex = false)
+    public int GetClosestElement(Point dragPoint, bool requestingInsertionIndex = false)
     {
         // This estimates the container index given the current pointer position
         var panel = ItemsPanelRoot;

--- a/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
@@ -1,0 +1,697 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using FluentAvalonia.Collections;
+using FluentAvalonia.UI.Controls.Primitives;
+
+namespace FluentAvalonia.UI.Controls;
+
+internal class LiveReorderHelper
+{
+    public LiveReorderHelper(TabViewListView owner)
+    {
+        _owner = owner;
+    }
+
+    public Panel ItemsPanelRoot => _owner.ItemsPanelRoot;
+
+    public void ProcessLiveReorder(DragEventArgs args, int dragItemIndex)
+    {
+        var orientation = _owner.GetLogicalOrientation();
+        if (orientation == null)
+            return; // We're in a panel we don't know how to deal with, exit out
+
+        // If we don't have a cache of the current realized container bounds,
+        // create it now before we start doing anything. This happens on first
+        // startup, but can also be reset through the drag operation (autoscroll,
+        // drag outside, etc). The cache is cleared on ResetAllItemsForLiveReorder()
+        if (ShouldCacheContainerBounds())
+        {
+            // had to add UpdateLayout here b/c TabView inserts that extra blank space at the end
+            // of the list (see TabView), which causes the panel to resize to account for that
+            // but that wasn't happening until after our caching occurred, which meant our bounds
+            // were incorrect and things were not lining up anymore.
+            _owner.UpdateLayout();
+            CacheContainerBounds();
+        }
+
+        var dragPoint = args.GetPosition(_owner);
+        int draggedIndex = dragItemIndex;
+        int insertionIndex = -1;
+        int dragOverIndex = GetClosestElement(dragPoint);// IndexFromContainer(currentItem); // The raw item index under the pointer
+        var previousDragOverIndex = _liveReorderIndices.draggedOverIndex;
+        int itemsCount = _owner.ItemCount;
+
+        if (draggedIndex == -1)
+            draggedIndex = itemsCount;
+
+        if (previousDragOverIndex == -1)
+        {
+            previousDragOverIndex = draggedIndex;
+        }
+
+        // The estimated insertion index in the panel
+        insertionIndex = GetClosestElement(dragPoint, true /*requestingInsertionIndex*/);
+
+        if (draggedIndex == itemsCount && insertionIndex == itemsCount - 1)
+        {
+            // If we didn't start in this TabView, see if the index is actually the end or -1
+            var spLastElement = _owner.ContainerFromIndex(insertionIndex);
+            if (spLastElement is TabViewItem tvi)
+            {
+                if (IsInBottomHalf(args.GetPosition(spLastElement), new Rect(spLastElement.Bounds.Size), orientation.Value))
+                {
+                    insertionIndex = itemsCount;
+                }
+            }
+        }
+
+        //var old = dragOverIndex; // Keep this here for debug purposes, if needed
+        if (insertionIndex == itemsCount)
+        {
+            dragOverIndex = itemsCount;
+        }
+        else
+        {
+            // This adjusts the dragover index based on the direction of the drag
+            dragOverIndex = GetDragOverIndex(dragOverIndex, insertionIndex, previousDragOverIndex);
+        }
+
+        // Debug.WriteLine($"\tLive Reorder DragOverIndex: {dragOverIndex} || DragOverBeforeAdj: {old} || InsertionIndex {insertionIndex} || PrevDragOverIndex {previousDragOverIndex}");
+
+        _liveReorderIndices = new LiveReorderIndices(draggedIndex, dragOverIndex, itemsCount);
+
+        if (previousDragOverIndex == draggedIndex || previousDragOverIndex != dragOverIndex)
+        {
+            StartLiveReorderTimer();
+        }
+
+        static bool IsInBottomHalf(Point pt, Rect rc, Orientation orientation)
+        {
+            if (orientation == Orientation.Horizontal)
+            {
+                return (pt.X - rc.Left) >= rc.Width * 0.5;
+            }
+            else
+            {
+                return (pt.Y - rc.Top) >= rc.Height * 0.5;
+            }
+        }
+
+        static int GetDragOverIndex(int closestElementIndex, int insertionIndex, int previousDragOverIndex)
+        {
+            int dragOverIndex = closestElementIndex;
+
+            if (insertionIndex == closestElementIndex)
+            {
+                if (previousDragOverIndex < insertionIndex)
+                {
+                    --dragOverIndex;
+                }
+            }
+            else
+            {
+                if (previousDragOverIndex >= insertionIndex)
+                {
+                    ++dragOverIndex;
+                }
+            }
+
+            return dragOverIndex;
+        }
+    }
+
+    public int GetInsertionIndexForLiveReorder()
+    {
+        var draggedIndex = _liveReorderIndices.draggedItemIndex;
+        var insertIndex = _liveReorderIndices.draggedOverIndex;
+
+        if (draggedIndex < insertIndex)
+        {
+            insertIndex++;
+        }
+
+        // make sure we don't go out of range
+        if (insertIndex > _liveReorderIndices.itemsCount)
+            insertIndex = _liveReorderIndices.itemsCount;
+
+        return insertIndex;
+    }
+
+    public int GetClosestElement(Point dragPoint, bool requestingInsertionIndex = false)
+    {
+        // This estimates the container index given the current pointer position
+        var panel = ItemsPanelRoot;
+        if (panel is VirtualizingStackPanel vsp)
+        {
+            var firstRealized = vsp.FirstRealizedIndex;
+            var lastRealized = vsp.LastRealizedIndex;
+            var orientation = vsp.Orientation;
+            var movedItems = _movedItems.AsSpan();
+            int closestIndex = -1;
+            double closestDist = double.PositiveInfinity;
+            Rect closestItemRect = default;
+
+            // Loop over the currently realized items to find the closest
+            for (int i = firstRealized; i <= lastRealized; i++)
+            {
+                // If the item is currently in our MovedItems list, it may not be 
+                // where it usually is, so we can't test the actual Bounds or we'll
+                // estimate the wrong index, but we have the original bounds saved
+                Rect rc = _cachedContainerBounds[i - firstRealized];
+                double dist;
+
+                if (orientation == Orientation.Horizontal)
+                {
+                    double cx = double.Clamp(dragPoint.X, rc.X, rc.Right);
+                    dist = double.Abs(dragPoint.X - cx);
+                }
+                else
+                {
+                    double cy = double.Clamp(dragPoint.Y, rc.Y, rc.Bottom);
+                    dist = double.Abs(dragPoint.Y - cy);
+                }
+
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closestIndex = i;
+                    closestItemRect = rc;
+                }
+            }
+
+            if (requestingInsertionIndex)
+            {
+                if (orientation == Orientation.Horizontal)
+                {
+                    if (dragPoint.X - closestItemRect.X >= closestItemRect.Width * 0.5)
+                    {
+                        closestIndex++;
+                    }
+                }
+                else if (orientation == Orientation.Vertical)
+                {
+                    if (dragPoint.Y - closestItemRect.Y >= closestItemRect.Height * 0.5)
+                    {
+                        closestIndex++;
+                    }
+                }
+            }
+
+            return closestIndex;
+        }
+        else if (panel is StackPanel sp)
+        {
+            //var children = sp.Children;
+            //var orientation = sp.Orientation;
+            //var movedItems = _movedItems.AsSpan();
+
+            //for (int i = 0; i < children.Count; i++)
+            //{
+            //    // If the item is currently in our MovedItems list, it may not be 
+            //    // where it usually is, so we can't test the actual Bounds or we'll
+            //    // estimate the wrong index, but we have the original bounds saved
+            //    if (IsInMovedItems(movedItems, i, out var rc))
+            //    {
+            //        if (rc.Contains(dragPoint))
+            //        {
+            //            return i;
+            //        }
+            //    }
+            //    else
+            //    {
+            //        // The item is not in moved items, so it is safe to use the Bounds directly
+            //        if (children[i].Bounds.Contains(dragPoint))
+            //        {
+            //            return i;
+            //        }
+            //    }
+            //}
+        }
+
+        return -1;
+
+        //static bool IsInMovedItems(ReadOnlySpan<MovedItem> items, int sourceIndex, out Rect srcRect)
+        //{
+        //    foreach (var item in items)
+        //    {
+        //        if (item.sourceIndex == sourceIndex)
+        //        {
+        //            srcRect = item.sourceRect;
+        //            return true;
+        //        }
+        //    }
+
+        //    srcRect = default;
+        //    return false;
+        //}
+    }
+
+    public void StartLiveReorderTimer()
+    {
+        StopLiveReorderTimer();
+
+        EnsureLiveReorderTimer();
+
+        _liveReorderTimer.Interval = TimeSpan.FromMilliseconds(200);
+        _liveReorderTimer.Start();
+    }
+
+    public void EnsureLiveReorderTimer()
+    {
+        if (_liveReorderTimer == null)
+        {
+            _liveReorderTimer = new DispatcherTimer();
+            _liveReorderTimer.Tick += LiveReorderTimerTickHandler;
+        }
+    }
+
+    public void LiveReorderTimerTickHandler(object sender, EventArgs e)
+    {
+        StopLiveReorderTimer();
+
+        Debug.Assert(_liveReorderIndices.draggedItemIndex != -1);
+
+        var orientation = _owner.GetLogicalOrientation().Value;
+
+        using var newItems = new PooledList<MovedItem>();
+        using var newItemsToMove = new PooledList<MovedItem>();
+        using var oldItemsToMoveBack = new PooledList<MovedItem>();
+
+        GetNewMovedItemsForLiveReorder(newItems);
+
+        _movedItems.Update(orientation == Orientation.Vertical, newItems, newItemsToMove, oldItemsToMoveBack);
+
+        MoveItemsForLiveReorder(false /*areNewItems*/, oldItemsToMoveBack);
+
+        MoveItemsForLiveReorder(true, newItemsToMove);
+
+        foreach (var item in _movedItems.AsSpan())
+        {
+            Debug.WriteLine($"\t MovedItems: {item.sourceIndex} -> {item.destinationIndex} || {item.sourceRect} -> {item.destinationRect}");
+        }
+    }
+
+    public void GetNewMovedItemsForLiveReorder(IList<MovedItem> newItems)
+    {
+        int startIndex = _liveReorderIndices.draggedItemIndex;
+        int endIndex = _liveReorderIndices.draggedOverIndex;
+        int increment = (startIndex < endIndex) ? 1 : -1;
+
+        // Debug.WriteLine($"GetNewMovedItems: {startIndex} -> {endIndex}");
+
+        newItems.Clear();
+        for (int i = startIndex; i != endIndex; i += increment)
+        {
+            int targetIndex = i - increment;
+
+            if (i == startIndex)
+            {
+                targetIndex = -1;
+            }
+
+            AddNewItemForLiveReorder(i, targetIndex, newItems, _liveReorderIndices.itemsCount, this);
+        }
+
+        AddNewItemForLiveReorder(endIndex, endIndex - increment, newItems, _liveReorderIndices.itemsCount, this);
+
+        // Debug.WriteLine($"TotalNewItems: {newItems.Count}");
+
+        static void AddNewItemForLiveReorder(int sourceIndex, int targetIndex, IList<MovedItem> newItems,
+            int itemsCount, LiveReorderHelper host)
+        {
+            Rect src = default;
+            Rect target = default;
+
+            if (sourceIndex != targetIndex)
+            {
+                src = GetLayoutSlot(host, sourceIndex);
+            }
+
+            if (targetIndex != -1 && targetIndex != itemsCount)
+            {
+                target = GetLayoutSlot(host, targetIndex);
+            }
+
+            newItems.Add(new MovedItem(sourceIndex, targetIndex, src, target));
+        }
+
+        static Rect GetLayoutSlot(LiveReorderHelper host, int index)
+        {
+            // make sure we grab the original bounds. If virtualizing, translate
+            // to index in our container cache
+            var adjIndex = host.ItemsPanelRoot is VirtualizingStackPanel vsp ?
+                index - vsp.FirstRealizedIndex : index;
+
+            if (adjIndex >= host._cachedContainerBounds.Count)
+                return default;
+
+            return host._cachedContainerBounds[adjIndex];
+            //return host.ContainerFromIndex(index)?.Bounds ?? default;
+        }
+    }
+
+    public void MoveItemsForLiveReorder(bool areNewItems, PooledList<MovedItem> newItemsToMove)
+    {
+        Rect rc;
+        foreach (var item in newItemsToMove.AsSpan())
+        {
+            var container = _owner.ContainerFromIndex(item.sourceIndex);
+
+            if (container is Control c)
+            {
+                if (areNewItems)
+                {
+                    rc = item.destinationRect;
+                }
+                else
+                {
+                    rc = item.sourceRect;
+                }
+
+                c.Arrange(rc);
+            }
+        }
+    }
+
+    public void ResetAllItemsForLiveReorder()
+    {
+        StopLiveReorderTimer();
+
+        foreach (var item in _movedItems.AsSpan())
+        {
+            if (item.destinationIndex != -1)
+            {
+                var cont = _owner.ContainerFromIndex(item.sourceIndex);
+                if (cont is Control c)
+                {
+                    c.Arrange(item.sourceRect);
+                }
+            }
+        }
+
+        _movedItems.Clear();
+        _liveReorderIndices = new LiveReorderIndices(-1, -1, -1);
+        ClearContainerBoundsCache();
+    }
+
+    public void StopLiveReorderTimer()
+    {
+        _liveReorderTimer?.Stop();
+    }
+
+    public bool ShouldCacheContainerBounds() =>
+        _cachedContainerBounds == null || _cachedContainerBounds.Count == 0;
+
+    public void CacheContainerBounds()
+    {
+        Debug.WriteLine("CACHING CONTAINER BOUNDS");
+        // Because reorder will arrange the containers in new places
+        // the Bounds on the container may not actually reflect where
+        // the item actually is. In WinUI, ModernCollectionBasePanel's 
+        // ContainerManager caches arrange rects and are used for estimation
+        // APIs. Here we are mimicing that
+        // This must be called at the start of drag/drop, when the auto scroll
+        // of the scrollviewer stops, or when we first drag onto the TabView
+        // if that TabView didn't start the dragdrop operation
+
+        var panel = ItemsPanelRoot;
+        if (panel is VirtualizingStackPanel vsp)
+        {
+            var firstRealized = vsp.FirstRealizedIndex;
+            var lastRealized = vsp.LastRealizedIndex;
+            _cachedContainerBounds ??= new List<Rect>((lastRealized - firstRealized) + 1);
+
+            for (int i = firstRealized; i <= lastRealized; i++)
+            {
+                var cont = _owner.ContainerFromIndex(i);
+                _cachedContainerBounds.Add(cont.Bounds);
+            }
+        }
+        else if (panel is StackPanel sp)
+        {
+            var itemCount = _owner.ItemCount;
+            _cachedContainerBounds ??= new List<Rect>(itemCount);
+            // Stack Panels don't virtualize and arrange in order so this is safe
+            for (int i = 0; i < itemCount; i++)
+            {
+                _cachedContainerBounds.Add(panel.Children[i].Bounds);
+            }
+        }
+    }
+
+    public void ClearContainerBoundsCache(bool clearCompletely = false)
+    {
+        // Clear container bounds
+        _cachedContainerBounds?.Clear();
+
+        // Don't keep this memory when not in use, so when drag drop operation
+        // ceases completely, set it to null
+        if (clearCompletely)
+            _cachedContainerBounds = null;
+    }
+
+
+    private readonly TabViewListView _owner;
+    private LiveReorderIndices _liveReorderIndices = new LiveReorderIndices(-1, -1, -1);
+    private DispatcherTimer _liveReorderTimer;
+    private readonly MovedItems _movedItems = new MovedItems();
+    private List<Rect> _cachedContainerBounds;
+}
+
+internal struct LiveReorderIndices
+{
+    public LiveReorderIndices(int dragItemIndex, int dragOverIndex, int count)
+    {
+        draggedItemIndex = dragItemIndex;
+        draggedOverIndex = dragOverIndex;
+        itemsCount = count;
+    }
+
+    public int draggedItemIndex;
+    public int draggedOverIndex;
+    public int itemsCount;
+}
+
+internal struct MovedItem
+{
+    public MovedItem(int src, int dst, Rect srcRc, Rect dstRc)
+    {
+        sourceIndex = src;
+        destinationIndex = dst;
+        sourceRect = srcRc;
+        destinationRect = dstRc;
+    }
+
+    public int sourceIndex;
+    public int destinationIndex;
+    public Rect sourceRect;
+    public Rect destinationRect;
+}
+
+internal class MovedItems : IEnumerable<MovedItem>
+{
+    public void Update(in bool isOrientationVertical, IList<MovedItem> newItems,
+        IList<MovedItem> newItemsToMove, IList<MovedItem> oldItemsToMoveBack)
+    {
+        int newItemsSize = newItems.Count;
+        int movedItemsSize = _items.Count;
+
+        // our items should always be ordered from the dragIndex to the dragOverIndex
+        int newItemsStartIndex = newItems[0].sourceIndex;
+        int newItemsEndIndex = newItems[^1].sourceIndex;
+        int newItemsIncrement = (newItemsStartIndex < newItemsEndIndex) ? 1 : -1;
+
+        // the index we should use to start adding new items
+        int startIndexForAddMovedItems = -1;
+
+        newItemsToMove.Clear();
+        oldItemsToMoveBack.Clear();
+
+        if (movedItemsSize > 0)
+        {
+            int movedItemsStartIndex = _items[0].sourceIndex;
+            int movedItemsEndIndex = _items[^1].sourceIndex;
+            int movedItemsIncrement = (movedItemsStartIndex < movedItemsEndIndex) ? 1 : -1;
+
+            // in the same drag motion, the sourceIndex should always be the same
+            Debug.Assert(newItemsStartIndex == movedItemsStartIndex);
+            //Debug.WriteLine($"FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL newItemsStartIndex == movedItemsStartIndex {newItemsStartIndex} - {movedItemsStartIndex}");
+
+
+            // remove the indices that are now out of range of new indexes
+            RemoveMovedItems((newItemsIncrement == movedItemsIncrement) ? newItemsSize : 1, movedItemsSize - 1, oldItemsToMoveBack);
+
+            // set the starting index for the items
+            // basically here, we are subtracting the two ranges of _items and newItems
+            if (newItemsIncrement == movedItemsIncrement)
+            {
+                // add the new items which should start after the end of the current moved items
+                startIndexForAddMovedItems = movedItemsSize;
+            }
+            else
+            {
+                // drag index was already added so no need to go over it again
+                startIndexForAddMovedItems = 1;
+            }
+        }
+        else
+        {
+            // this is the first time we enter this function
+            // start from the drag index (located at array index 0)
+            startIndexForAddMovedItems = 0;
+        }
+
+        // add the new moved items
+        if (startIndexForAddMovedItems < newItemsSize)
+        {
+            AddMovedItems(isOrientationVertical, startIndexForAddMovedItems, newItems, newItemsToMove);
+        }
+    }
+
+    public void RemoveMovedItems(int from, int to, IList<MovedItem> oldItemsToMoveBack)
+    {
+        for (int i = to; i >= from; --i)
+        {
+            oldItemsToMoveBack.Add(_items[i]);
+            _items.RemoveAt(i);
+        }
+    }
+
+    public void AddMovedItems(bool isOrientationVertical, int from,
+        IList<MovedItem> newItems, IList<MovedItem> newItemsToMove)
+    {
+        // move the new indexes that have not been moved yet
+        for (int i = from; i < newItems.Count; i++)
+        {
+            var newItem = newItems[i];
+
+            // if moved items is empty, this means that the first item is the dragged item
+            // we simply add it to the list
+            if (_items.Count > 0)
+            {
+                // find the item whose sourceIndex is the destinationIndex of the new item to be moved
+                var destination = _items[^1];
+
+                bool forward = (newItem.sourceIndex > newItem.destinationIndex) ? true : false;
+
+                // if the items are of the same size, use the destinations original location
+                // else if the destination is the sourceIndex of the first moved item (meaning it's the dragged item), use its original location
+                // otherwise, we use the destination's current (moved) location
+                if (newItem.sourceRect.Width == destination.sourceRect.Width && newItem.sourceRect.Height == destination.sourceRect.Height)
+                {
+                    newItem.destinationRect = new Rect(destination.sourceRect.X,
+                        destination.sourceRect.Y, newItem.destinationRect.Width,
+                        newItem.destinationRect.Height);
+                }
+                else if (destination.sourceIndex == _items[0].sourceIndex)
+                {
+                    newItem.destinationRect = new Rect(destination.sourceRect.X,
+                        destination.sourceRect.Y, newItem.destinationRect.Width,
+                        newItem.destinationRect.Height);
+
+                    // if they're of different sizes, account for the difference of size
+
+                    if (!forward)
+                    {
+                        if (isOrientationVertical)
+                        {
+                            newItem.destinationRect = newItem.destinationRect.WithY(
+                                newItem.destinationRect.Y - newItem.sourceRect.Height - destination.sourceRect.Height);
+
+                            if (newItem.destinationRect.Y < 0)
+                            {
+                                newItem.destinationRect = new Rect(newItem.sourceRect.X,
+                                    newItem.sourceRect.Y + newItem.sourceRect.Height,
+                                    newItem.destinationRect.Width, newItem.destinationRect.Height);
+                            }
+                        }
+                        else
+                        {
+                            newItem.destinationRect = newItem.destinationRect.WithX(
+                                newItem.destinationRect.X - newItem.sourceRect.Width - destination.sourceRect.Width);
+
+                            if (newItem.destinationRect.X < 0)
+                            {
+                                newItem.destinationRect = new Rect(newItem.sourceRect.X + newItem.sourceRect.Width,
+                                    newItem.sourceRect.Y, newItem.destinationRect.Width, newItem.destinationRect.Height);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    newItem.destinationRect = new Rect(destination.destinationRect.X,
+                        destination.destinationRect.Y, newItem.destinationRect.Width,
+                        newItem.destinationRect.Height);
+
+                    // we should offset the location by the size of the destination in case we're moving forward (sourceIndex > destinationIndex)
+                    // otherwise, we subtract the size of the item itself
+                    if (isOrientationVertical)
+                    {
+                        if (forward)
+                        {
+                            newItem.destinationRect = newItem.destinationRect.WithY(
+                                newItem.destinationRect.Y + destination.sourceRect.Height);
+                        }
+                        else
+                        {
+                            newItem.destinationRect = newItem.destinationRect.WithY(
+                                newItem.destinationRect.Y - newItem.sourceRect.Height);
+                        }
+                    }
+                    else
+                    {
+                        if (forward)
+                        {
+                            newItem.destinationRect = newItem.destinationRect.WithX(
+                                newItem.destinationRect.X + destination.sourceRect.Width);
+                        }
+                        else
+                        {
+                            newItem.destinationRect = newItem.destinationRect.WithX(
+                                newItem.destinationRect.X - newItem.sourceRect.Width);
+                        }
+                    }
+                }
+
+                // set the width and height to its original size
+                newItem.destinationRect = new Rect(newItem.destinationRect.X,
+                    newItem.destinationRect.Y,
+                    newItem.sourceRect.Width, newItem.sourceRect.Height);
+
+                // add the item to the lists of items to be moved
+                newItemsToMove.Add(newItem);
+                // Just ensure we keep the lists accurate incase we need this later
+                // since this is a struct in a list
+                newItems[i] = newItem;
+            }
+
+            _items.Add(newItem);
+        }
+    }
+
+    public void Clear()
+    {
+        _items.Clear();
+    }
+
+    public ReadOnlySpan<MovedItem> AsSpan() =>
+        CollectionsMarshal.AsSpan(_items);
+
+    public IEnumerator<MovedItem> GetEnumerator() =>
+        _items.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() =>
+        _items.GetEnumerator();
+
+    private readonly List<MovedItem> _items = new List<MovedItem>();
+}

--- a/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/LiveReorderHelper.cs
@@ -129,7 +129,28 @@ internal class LiveReorderHelper
         }
     }
 
-    public int GetInsertionIndexForLiveReorder()
+    public void ResetAllItemsForLiveReorder()
+    {
+        StopLiveReorderTimer();
+
+        foreach (var item in _movedItems.AsSpan())
+        {
+            if (item.destinationIndex != -1)
+            {
+                var cont = _owner.ContainerFromIndex(item.sourceIndex);
+                if (cont is Control c)
+                {
+                    c.Arrange(item.sourceRect);
+                }
+            }
+        }
+
+        _movedItems.Clear();
+        _liveReorderIndices = new LiveReorderIndices(-1, -1, -1);
+        ClearContainerBoundsCache();
+    }
+
+    private int GetInsertionIndexForLiveReorder()
     {
         var draggedIndex = _liveReorderIndices.draggedItemIndex;
         var insertIndex = _liveReorderIndices.draggedOverIndex;
@@ -146,7 +167,7 @@ internal class LiveReorderHelper
         return insertIndex;
     }
 
-    public int GetClosestElement(Point dragPoint, bool requestingInsertionIndex = false)
+    private int GetClosestElement(Point dragPoint, bool requestingInsertionIndex = false)
     {
         // This estimates the container index given the current pointer position
         var panel = ItemsPanelRoot;
@@ -255,7 +276,7 @@ internal class LiveReorderHelper
         //}
     }
 
-    public void StartLiveReorderTimer()
+    private void StartLiveReorderTimer()
     {
         StopLiveReorderTimer();
 
@@ -265,7 +286,7 @@ internal class LiveReorderHelper
         _liveReorderTimer.Start();
     }
 
-    public void EnsureLiveReorderTimer()
+    private void EnsureLiveReorderTimer()
     {
         if (_liveReorderTimer == null)
         {
@@ -274,7 +295,7 @@ internal class LiveReorderHelper
         }
     }
 
-    public void LiveReorderTimerTickHandler(object sender, EventArgs e)
+    private void LiveReorderTimerTickHandler(object sender, EventArgs e)
     {
         StopLiveReorderTimer();
 
@@ -300,7 +321,7 @@ internal class LiveReorderHelper
         }
     }
 
-    public void GetNewMovedItemsForLiveReorder(IList<MovedItem> newItems)
+    private void GetNewMovedItemsForLiveReorder(IList<MovedItem> newItems)
     {
         int startIndex = _liveReorderIndices.draggedItemIndex;
         int endIndex = _liveReorderIndices.draggedOverIndex;
@@ -359,7 +380,7 @@ internal class LiveReorderHelper
         }
     }
 
-    public void MoveItemsForLiveReorder(bool areNewItems, PooledList<MovedItem> newItemsToMove)
+    private void MoveItemsForLiveReorder(bool areNewItems, PooledList<MovedItem> newItemsToMove)
     {
         Rect rc;
         foreach (var item in newItemsToMove.AsSpan())
@@ -382,38 +403,16 @@ internal class LiveReorderHelper
         }
     }
 
-    public void ResetAllItemsForLiveReorder()
-    {
-        StopLiveReorderTimer();
-
-        foreach (var item in _movedItems.AsSpan())
-        {
-            if (item.destinationIndex != -1)
-            {
-                var cont = _owner.ContainerFromIndex(item.sourceIndex);
-                if (cont is Control c)
-                {
-                    c.Arrange(item.sourceRect);
-                }
-            }
-        }
-
-        _movedItems.Clear();
-        _liveReorderIndices = new LiveReorderIndices(-1, -1, -1);
-        ClearContainerBoundsCache();
-    }
-
-    public void StopLiveReorderTimer()
+    private void StopLiveReorderTimer()
     {
         _liveReorderTimer?.Stop();
     }
 
-    public bool ShouldCacheContainerBounds() =>
+    private bool ShouldCacheContainerBounds() =>
         _cachedContainerBounds == null || _cachedContainerBounds.Count == 0;
 
-    public void CacheContainerBounds()
+    private void CacheContainerBounds()
     {
-        Debug.WriteLine("CACHING CONTAINER BOUNDS");
         // Because reorder will arrange the containers in new places
         // the Bounds on the container may not actually reflect where
         // the item actually is. In WinUI, ModernCollectionBasePanel's 

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -70,6 +70,7 @@ public partial class TabView : TemplatedControl
         });
 
         _tabCloseButtonTooltipText = FALocalizationHelper.Instance.GetLocalizedStringResource(SR_TabViewCloseButtonTooltipWithKA);
+        PseudoClasses.Set(s_pcTop, true);
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -85,10 +86,17 @@ public partial class TabView : TemplatedControl
         _rightContentPresenter = e.NameScope.Find<ContentPresenter>(s_tpRightContentPresenter);
 
         _tabContainerGrid = e.NameScope.Get<Grid>(s_tpTabContainerGrid);
+        if (_tabContainerGrid.ColumnDefinitions.Count > 0)
+        {
         _leftContentColumn = _tabContainerGrid.ColumnDefinitions[0];
         _tabColumn = _tabContainerGrid.ColumnDefinitions[1];
         _addButtonColumn = _tabContainerGrid.ColumnDefinitions[2];
         _rightContentColumn = _tabContainerGrid.ColumnDefinitions[3];
+        }
+        else
+        {
+            _tabContainerGrid.SizeChanged += HandleTabContainerGridSizeChangedForVerticalTabView;
+        }
 
         _tabContainerGrid.PointerEntered += OnTabStripPointerEnter;
         _tabContainerGrid.PointerExited += OnTabStripPointerLeave;
@@ -137,6 +145,16 @@ public partial class TabView : TemplatedControl
             _addButton.KeyDown += OnAddButtonKeyDown;
         }
 
+        var handle = e.NameScope.Get<Border>(s_tpPaneResizeHandle);
+        if (handle != null) // Null in Top/Bottom modes
+        {
+            handle.PointerPressed += OnPaneResizeHandlePointerPressed;
+            handle.PointerMoved += OnPaneResizeHandlePointerMoved;
+            handle.PointerReleased += OnPaneResizeHandlePointerReleased;
+            handle.PointerCaptureLost += OnPaneResizeHandlePointerCaptureLost;
+            _verticalPaneResizeHandle = handle;
+        }
+
         //UpdateListViewItemContainerTransitions();
     }
 
@@ -180,6 +198,10 @@ public partial class TabView : TemplatedControl
         {
             OnTabWidthModePropertyChanged(change);
         }
+        else if (change.Property == TabStripLocationProperty)
+        {
+            OnTabStripLocationPropertyChanged(change);
+    }
     }
 
     internal void SetTabSeparatorOpacity(int index, int opacityValue)
@@ -212,6 +234,48 @@ public partial class TabView : TemplatedControl
         }
     }
 
+    protected virtual void OnTabStripLocationPropertyChanged(AvaloniaPropertyChangedEventArgs args)
+    {
+        var (oldValue, newValue) = args.GetOldAndNewValue<TabViewTabStripLocation>();
+
+        //if ((IsHorizontal(oldValue) && !IsHorizontal(newValue)) ||
+        //    (!IsHorizontal(oldValue) && IsHorizontal(newValue)) &&
+        //    _listView != null && _listView.ItemsSource == null)
+        //{
+        //    // We're switching from vertical to horizontal or horizontal to vertical
+        //    // If we're not using the TabItemsSource, we need to make a copy of the
+        //    // TabItems to unhook them from the ItemsControl
+        //    var l = new List<object>();
+        //    foreach (var item in TabItems)
+        //        l.Add(item);
+
+        //    _listView.Items.Clear();
+        //    TabItems = l;
+        //}
+
+
+        _isSwitchingTabLocation = true;
+
+        if ((IsHorizontal(oldValue) && !IsHorizontal(newValue)) ||
+            (!IsHorizontal(oldValue) && IsHorizontal(newValue)))
+        {
+            // Only set TabContent to null if we're truly switching orientations
+            UpdateTabContent();
+        }
+
+
+        var oldClass = GetClassForStripLocation(args.GetOldValue<TabViewTabStripLocation>());
+        var newClass = GetClassForStripLocation(args.GetNewValue<TabViewTabStripLocation>());
+        PseudoClasses.Remove(oldClass);
+        PseudoClasses.Add(newClass);
+
+        _listView?.HandleTabStripLocationChanged(args.GetNewValue<TabViewTabStripLocation>(), oldClass, newClass);
+        
+        UpdateTabWidths();
+
+        static bool IsHorizontal(TabViewTabStripLocation loc) =>
+            loc == TabViewTabStripLocation.Top || loc == TabViewTabStripLocation.Bottom;
+    }
 
     private void OnListViewDraggingPropertyChanged()
     {
@@ -371,17 +435,38 @@ public partial class TabView : TemplatedControl
     {
         UpdateTabViewWithTearOutList();
     }
-    internal TabViewListView AListView => _listView;
+
     private void OnListViewLoaded(object sender, RoutedEventArgs args)
     {
         var lv = _listView;
 
         // Now that ListView exists, we can start using its Items collection.
         var lvItems = lv.Items;
-        if (lvItems != null)
+        // 2nd condition added, if TabItems is already the ListView's ItemCollection, we just swapped in the same
+        // orientation (top - bottom / left - right), so the ListView was reloaded, but its still the same one
+        if (lvItems != null && lvItems != TabItems)
         {
             if (lv.ItemsSource == null)
             {
+                if (_isSwitchingTabLocation)
+                {
+                    // Unhook the TabItems from the old ItemCollection
+                    var tabItems = TabItems;
+
+                    foreach (var item in tabItems)
+                    {
+                        if (item is TabViewItem tvi && tvi.GetVisualParent() is Panel p)
+                        {
+                            p.Children.Remove(tvi);
+                        }
+
+                        lvItems.Add(item);
+                    }
+
+                    TabItems.Clear();
+                }
+                else
+                {
                 // copy the list, because clearing lvItems may also clear TabItems
                 using var l = new PooledList<object>(lvItems.Count);
 
@@ -393,9 +478,16 @@ public partial class TabView : TemplatedControl
                 foreach (var item in l.AsSpan())
                     lvItems.Add(item);
             }
+            }
 
             TabItems = lvItems;
         }
+
+
+        // Ensure the ListView is configured correctly when it loads
+        var stripLocation = TabStripLocation;
+        lv.HandleTabStripLocationChanged(stripLocation, null, GetClassForStripLocation(stripLocation));
+
 
         if (SelectedItem != null)
         {
@@ -410,10 +502,21 @@ public partial class TabView : TemplatedControl
         SelectedIndex = lv.SelectedIndex;
         SelectedItem = lv.SelectedItem;
 
-        _itemsPresenter = _listView.Presenter as ItemsPresenter;
+        if (_isSwitchingTabLocation)
+        {
+            _isSwitchingTabLocation = false;
+            UpdateTabContent();
+        }
+
+        if (_itemsPresenter != null)
+        {
+            _itemsPresenter = _listView.Presenter;
         _itemsPresenter.SizeChanged += OnItemsPresenterSizeChanged;
+        }
+
 
         var scrollViewer = _listView.Scroller;
+        _scrollViewer = scrollViewer;
         if (scrollViewer != null)
         {
             if (scrollViewer.IsLoaded)
@@ -426,6 +529,7 @@ public partial class TabView : TemplatedControl
             }
         }
         _scrollViewer = scrollViewer;
+
 
         UpdateBottomBorderLineVisualStates();
         UpdateNonClientRegion();
@@ -487,11 +591,16 @@ public partial class TabView : TemplatedControl
     private void OnScrollViewerViewChanged(AvaloniaPropertyChangedEventArgs args)
     {
         UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
+
+        // Another case where we have to do something WinUI doesn't. Scrolling (recycling) tabs
+        // doesn't ensure their widths are set correctly and so some will autosize to their
+        // content and be just slightly bigger. Ensure that doesn't happen
+        UpdateTabWidths();
     }
 
     private void UpdateScrollViewerDecreaseAndIncreaseButtonsViewState()
     {
-        if (_scrollViewer != null)
+        if (_scrollViewer != null && _scrollDecreaseButton != null && _scrollIncreaseButton != null)
         {
             const double minThreshold = 0.1d;
             var hOffset = _scrollViewer.Offset.X;
@@ -525,6 +634,11 @@ public partial class TabView : TemplatedControl
             // Make sure that the selected tab is fully in view and not cut off
             BringSelectedTabIntoView();
         }
+    }
+
+    private void HandleTabContainerGridSizeChangedForVerticalTabView(object sender, SizeChangedEventArgs e)
+    {
+        UpdateTabWidths();
     }
 
     private void BringSelectedTabIntoView()
@@ -606,18 +720,12 @@ public partial class TabView : TemplatedControl
                 // Posting to Dispatcher so delay calling this until after next layout pass
                 // when items are all realized and ContainerFromIndex works
                 // TODO: Do we still need to post to dispatcher
+                
+                Dispatcher.UIThread.Post(() =>
+                {
                 UpdateTabWidths();
                 SetTabSeparatorOpacity(numItems - 1);
             }
-        }
-        else
-        {
-            // TODO: Needed still?
-            //// Added this for full collection change - Set content to first item
-            //if (lvSelIndex == -1 && numItems > 0)
-            //{
-            //    SelectedIndex = 0;
-            //}
         }
 
         UpdateBottomBorderLineVisualStates();
@@ -625,6 +733,12 @@ public partial class TabView : TemplatedControl
 
     private void OnListViewSelectionChanged(object sender, SelectionChangedEventArgs args)
     {
+        // If we're currently switching TabLocation, ignore this selected item change
+        // because it just got set to -1. We'll set it back to the correct index
+        // when the ListView loaded handler is called
+        if (_isSwitchingTabLocation)
+            return;
+
         SelectedIndex = _listView.SelectedIndex;
         SelectedItem = _listView.SelectedItem;
 
@@ -739,7 +853,7 @@ public partial class TabView : TemplatedControl
         if (_tabContentPresenter == null)
             return;
 
-        if (SelectedItem == null)
+        if (SelectedItem == null || _isSwitchingTabLocation)
         {
             _tabContentPresenter.Content = null;
             _tabContentPresenter.ContentTemplate = null;
@@ -864,8 +978,9 @@ public partial class TabView : TemplatedControl
         {
             tabCount++;
         }
-
-        if (_tabContainerGrid != null)
+        var stripLocation = TabStripLocation;
+        var isHorizontal = (stripLocation == TabViewTabStripLocation.Top || stripLocation == TabViewTabStripLocation.Bottom);
+        if (_tabContainerGrid != null && isHorizontal)
         {
             // Add up width taken by custom content and + button
             double widthTaken = 0.0;
@@ -1017,14 +1132,43 @@ public partial class TabView : TemplatedControl
             }
         }
 
+        if (!isHorizontal)
+        {
+            if (_listView != null)
+            {
+                // If not in Horizontal, ensure we let the scrollviewer work correctly
+                _listView.SetValue(ScrollViewer.HorizontalScrollBarVisibilityProperty, ScrollBarVisibility.Disabled);
+                _listView.SetValue(ScrollViewer.VerticalScrollBarVisibilityProperty, ScrollBarVisibility.Auto);
+            }
+            
+            if (_tabContainerGrid != null)
+            {
+                var rows = _tabContainerGrid.RowDefinitions;
+                // Calcuate the height of the rows without the TabView
+                double height = 0;
+                foreach (var item in _tabContainerGrid.Children)
+                {
+                    if (item is TabViewListView)
+                        continue;
+
+                    height += item.DesiredSize.Height;
+                }    
+                var maxSpace = _tabContainerGrid.Bounds.Height;
+
+                _scrollViewer?.MaxHeight = double.Clamp(maxSpace - height, 0, double.PositiveInfinity);
+            }
+        }
+        else if (_scrollViewer != null)
+        {
+            _scrollViewer.MaxHeight = double.PositiveInfinity;
+        }
+
         if (shouldUpdateWidths || TabWidthMode != TabViewWidthMode.Equal)
         {
             foreach (var item in TabItems)
             {
                 var tvi = item as TabViewItem ?? ContainerFromItem(item) as TabViewItem;
-
-                if (tvi != null)
-                    tvi.Width = tabWidth;
+                tvi?.Width = tabWidth;
             }
         }
     }
@@ -1058,6 +1202,79 @@ public partial class TabView : TemplatedControl
 
     public object ItemFromContainer(Control container) =>
         _listView?.ItemFromContainer(container);
+
+    private void OnPaneResizeHandlePointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.Handled)
+            return;
+
+        var pt = e.GetCurrentPoint(null);
+        if (e.Properties.IsLeftButtonPressed)
+        {
+            _initDragPanePoint = pt.Position;
+            _startingPaneSize = VerticalOpenPaneLength;
+        }
+    }
+
+    private void OnPaneResizeHandlePointerMoved(object sender, PointerEventArgs e)
+    {
+        if (e.Handled)
+            return;
+
+        if (_initDragPanePoint.HasValue)
+        {
+            var point = e.GetCurrentPoint(null);
+            var delta = (point.Position - _initDragPanePoint.Value).X;
+            if (!_isDraggingPane)
+            {
+                FAUISettings.GetSystemDragSize(TopLevel.GetTopLevel(this).RenderScaling, out var cxDrag, out _);
+                
+                if (double.Abs(delta) < cxDrag)
+                {
+                    return;
+                }
+
+                _isDraggingPane = true;
+            }
+
+            var min = MinimumVerticalOpenPaneLength;
+            var max = MaximumVerticalOpenPaneLength;
+
+            if (TabStripLocation == TabViewTabStripLocation.Right)
+                delta *= -1;
+
+            var paneLength = _startingPaneSize;
+            var length = double.Clamp(paneLength + delta, min, max);
+
+            SetCurrentValue(VerticalOpenPaneLengthProperty, length);
+        }
+    }
+
+    private void OnPaneResizeHandlePointerReleased(object sender, PointerReleasedEventArgs e)
+    {
+        if (e.Handled)
+            return;
+
+        if (_initDragPanePoint.HasValue)
+        {
+            var point = e.GetCurrentPoint(null);
+            if (point.Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonReleased)
+            {
+                _initDragPanePoint = null;
+                _isDraggingPane = false;
+            }
+        }
+    }
+
+
+    private void OnPaneResizeHandlePointerCaptureLost(object sender, PointerCaptureLostEventArgs e)
+    {
+        if (e.Handled)
+            return;
+
+        _initDragPanePoint = null;
+        _isDraggingPane = false;
+    }
 
     private int GetItemCount()
     {
@@ -1235,6 +1452,13 @@ public partial class TabView : TemplatedControl
 
         _scrollViewerViewChangedRevoker?.Dispose();
 
+        if (_verticalPaneResizeHandle != null) // Null in Top/Bottom modes
+        {
+            _verticalPaneResizeHandle.PointerPressed -= OnPaneResizeHandlePointerPressed;
+            _verticalPaneResizeHandle.PointerMoved -= OnPaneResizeHandlePointerMoved;
+            _verticalPaneResizeHandle.PointerReleased -= OnPaneResizeHandlePointerReleased;
+            _verticalPaneResizeHandle.PointerCaptureLost -= OnPaneResizeHandlePointerCaptureLost;
+        }
 
         _leftContentColumn = null;
         _tabColumn = null;
@@ -1286,8 +1510,15 @@ public partial class TabView : TemplatedControl
     private RepeatButton _scrollIncreaseButton;
     private Button _addButton;
     private ItemsPresenter _itemsPresenter;
+    private Border _verticalPaneResizeHandle;
+    private SplitView _splitView;
 
-    // private Grid _shadowReceiver
+    private bool _isDraggingPane;
+    private Point? _initDragPanePoint;
+    private double _startingPaneSize;
+
+    private bool _isSwitchingTabLocation;
+    private int _selectedIndexBeforeTabSwitch = -1;
 
     // A bunch of event revokers
     private IDisposable _scrollViewerViewChangedRevoker;

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Specialized;
-using System.Reflection.Metadata;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Automation.Peers;
@@ -10,7 +9,6 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Logging;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FluentAvalonia.Collections;
@@ -18,14 +16,6 @@ using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls.Primitives;
 
 namespace FluentAvalonia.UI.Controls;
-
-public enum TabViewTabStripLocation
-{
-    Top,
-    Left,
-    Right,
-    Bottom
-}
 
 /// <summary>
 /// A control used to display a set of tabs and their respective content
@@ -238,6 +228,7 @@ public partial class TabView : TemplatedControl
     {
         var (oldValue, newValue) = args.GetOldAndNewValue<TabViewTabStripLocation>();
 
+        // TODO v3: Is this needed or left over from my testing?
         //if ((IsHorizontal(oldValue) && !IsHorizontal(newValue)) ||
         //    (!IsHorizontal(oldValue) && IsHorizontal(newValue)) &&
         //    _listView != null && _listView.ItemsSource == null)
@@ -488,7 +479,6 @@ public partial class TabView : TemplatedControl
         var stripLocation = TabStripLocation;
         lv.HandleTabStripLocationChanged(stripLocation, null, GetClassForStripLocation(stripLocation));
 
-
         if (SelectedItem != null)
         {
             UpdateSelectedItem();
@@ -514,7 +504,6 @@ public partial class TabView : TemplatedControl
             _itemsPresenter.SizeChanged += OnItemsPresenterSizeChanged;
         }
         
-
         var scrollViewer = _listView.Scroller;
         _scrollViewer = scrollViewer;
         if (scrollViewer != null)
@@ -527,8 +516,7 @@ public partial class TabView : TemplatedControl
             {
                 scrollViewer.Loaded += OnScrollViewerLoaded;
             }
-        }
-        
+        }        
 
         UpdateBottomBorderLineVisualStates();
         UpdateNonClientRegion();
@@ -1155,6 +1143,12 @@ public partial class TabView : TemplatedControl
                     height += item.DesiredSize.Height;
                 }    
                 var maxSpace = _tabContainerGrid.Bounds.Height;
+                
+                if (_isItemDraggedOver)
+                {
+                    // Add the dragging space in vertical view by using the avg. item height
+                    height += (height / _tabContainerGrid.Children.Count);
+                }
 
                 _scrollViewer?.MaxHeight = double.Clamp(maxSpace - height, 0, double.PositiveInfinity);
             }
@@ -1267,7 +1261,6 @@ public partial class TabView : TemplatedControl
         }
     }
 
-
     private void OnPaneResizeHandlePointerCaptureLost(object sender, PointerCaptureLostEventArgs e)
     {
         if (e.Handled)
@@ -1367,13 +1360,14 @@ public partial class TabView : TemplatedControl
 
     private void UpdateIsItemDraggedOver(bool isItemDraggedOver)
     {
-        // TODO: How do we want to handle this?
         if (_isItemDraggedOver != isItemDraggedOver)
         {
             _isItemDraggedOver = isItemDraggedOver;
             UpdateTabWidths();
         }
     }
+
+    // ----------- TABVIEW TEAROUT - The following is left while I investigate adding this
 
     private void UpdateTabViewWithTearOutList()
     {
@@ -1414,6 +1408,7 @@ public partial class TabView : TemplatedControl
 
     private nint GetAppWindowId() => 0;
 
+    // ---------------- END TABVIEW TEAROUT
 
     private void UnhookEventsAndClearFields()
     {
@@ -1572,12 +1567,5 @@ public partial class TabView : TemplatedControl
         CtrlF4,
         CtrlTab,
         CtrlShftTab
-    }
-}
-
-public class TabViewAutomationPeer : ControlAutomationPeer
-{
-    public TabViewAutomationPeer(Control owner) : base(owner)
-    {
     }
 }

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Specialized;
 using System.Windows.Input;
 using Avalonia;
+using Avalonia.Automation.Peers;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
@@ -11,10 +12,19 @@ using Avalonia.Interactivity;
 using Avalonia.Logging;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using FluentAvalonia.Collections;
 using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls.Primitives;
 
 namespace FluentAvalonia.UI.Controls;
+
+public enum TabViewTabStripLocation
+{
+    Top,
+    Left,
+    Right,
+    Bottom
+}
 
 /// <summary>
 /// A control used to display a set of tabs and their respective content
@@ -26,6 +36,10 @@ public partial class TabView : TemplatedControl
         TabItems = new AvaloniaList<object>();
 
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+
+        // Get the current platform's Command Modifier instead of just assuming Control
+        var ctrl = Application.Current.PlatformSettings.HotkeyConfiguration.CommandModifiers;
 
         // Keyboard Accelerators (KeyBindings in Avalonia)
         // Require a Command, so we wire this up *slightly* differently
@@ -33,7 +47,9 @@ public partial class TabView : TemplatedControl
 
         _keyboardAcceleratorHandler = new TabViewCommand(OnKeyboardAcceleratorInvoked);
 
-        var closeTabGesture = new KeyGesture(Key.F4, KeyModifiers.Control);
+        // TODO v3: Be sure to grab these key strokes from Platform settings to ensure
+        // we're using the correct key (Control vs Meta)
+        var closeTabGesture = new KeyGesture(Key.F4, ctrl);
         KeyBindings.Add(new KeyBinding
         {
             Gesture = closeTabGesture,
@@ -42,13 +58,13 @@ public partial class TabView : TemplatedControl
         });
         KeyBindings.Add(new KeyBinding
         {
-            Gesture = new KeyGesture(Key.Tab, KeyModifiers.Control),
+            Gesture = new KeyGesture(Key.Tab, ctrl),
             Command = _keyboardAcceleratorHandler,
             CommandParameter = TabViewCommandType.CtrlTab
         });
         KeyBindings.Add(new KeyBinding
         {
-            Gesture = new KeyGesture(Key.Tab, KeyModifiers.Control | KeyModifiers.Shift),
+            Gesture = new KeyGesture(Key.Tab, ctrl | KeyModifiers.Shift),
             Command = _keyboardAcceleratorHandler,
             CommandParameter = TabViewCommandType.CtrlShftTab
         });
@@ -59,39 +75,44 @@ public partial class TabView : TemplatedControl
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         UnhookEventsAndClearFields();
+        _isItemBeingDragged = false;
+        _isItemDraggedOver = false;
+        _expandedWidthForDragOver = null;
 
         base.OnApplyTemplate(e);
 
         _tabContentPresenter = e.NameScope.Find<ContentPresenter>(s_tpTabContentPresenter);
         _rightContentPresenter = e.NameScope.Find<ContentPresenter>(s_tpRightContentPresenter);
 
-        _tabContainerGrid = e.NameScope.Find<Grid>(s_tpTabContainerGrid);
-        if (_tabContainerGrid != null)
-        {
-            _leftContentColumn = _tabContainerGrid.ColumnDefinitions[0];
-            _tabColumn = _tabContainerGrid.ColumnDefinitions[1];
-            _addButtonColumn = _tabContainerGrid.ColumnDefinitions[2];
-            _rightContentColumn = _tabContainerGrid.ColumnDefinitions[3];
+        _tabContainerGrid = e.NameScope.Get<Grid>(s_tpTabContainerGrid);
+        _leftContentColumn = _tabContainerGrid.ColumnDefinitions[0];
+        _tabColumn = _tabContainerGrid.ColumnDefinitions[1];
+        _addButtonColumn = _tabContainerGrid.ColumnDefinitions[2];
+        _rightContentColumn = _tabContainerGrid.ColumnDefinitions[3];
 
-            _tabContainerGrid.PointerEntered += OnTabStripPointerEnter;
-            _tabContainerGrid.PointerExited += OnTabStripPointerLeave;
+        _tabContainerGrid.PointerEntered += OnTabStripPointerEnter;
+        _tabContainerGrid.PointerExited += OnTabStripPointerLeave;
 
-            // Adding this to mimic XYFocusKeyboardNavigation in the tabstrip
-            _tabContainerGrid.KeyDown += OnTabContainerGridKeyDown;
-        }
-
-        _listView = e.NameScope.Find<TabViewListView>(s_tpTabListView);
+        _listView = e.NameScope.Get<TabViewListView>(s_tpTabListView);
 
         if (_listView != null)
         {
             LogicalChildren.Add(_listView);
+            _listView.Loaded += OnListViewLoaded;
             _listView.SelectionChanged += OnListViewSelectionChanged;
+            _listView.SizeChanged += OnListViewSizeChanged;
 
             _listView.DragItemsStarting += OnListViewDragItemsStarting;
             _listView.DragItemsCompleted += OnListViewDragItemsCompleted;
-            _listView.DragOver += OnListViewDragOver;
-            _listView.Drop += OnListViewDrop;
 
+            _listView.AddHandler(DragDrop.DragOverEvent, OnListViewDragOver);
+
+            _listView.AddHandler(DragDrop.DropEvent, OnListViewDrop);
+            _listView.AddHandler(DragDrop.DragEnterEvent, OnListViewDragEnter);
+            _listView.AddHandler(DragDrop.DragLeaveEvent, OnListViewDragLeave);
+
+            // TODO: v3
+            //_listView.GettingFocus += OnListViewGettingFocus();
             _listView.GotFocus += OnListViewGettingFocus;
 
             _listViewCanReorderItemsPropertyChangedRevoker =
@@ -99,19 +120,7 @@ public partial class TabView : TemplatedControl
                 .Subscribe(_ => OnListViewDraggingPropertyChanged());
             _listViewAllowDropPropertyChangedRevoker =
                 _listView.GetPropertyChangedObservable(DragDrop.AllowDropProperty)
-                .Subscribe(_ => OnListViewDraggingPropertyChanged());
-
-            // Since we don't have the loaded event, and the ListView is already in the tree
-            // we can't use AttachedToVisualTree, which is the suggested replacement
-            // We also can't call loaded now because the ItemsPresenter and Panel haven't been
-            // established yet so the Loaded logic will fail. What we'll do instead is listen
-            // for the first bounds change of the ListView as at that point all will be 
-            // established - we'll then revoke the listener
-            //_listViewLoadedRevoker = _listView.GetPropertyChangedObservable(BoundsProperty)
-            //    .Subscribe(_ => OnListViewLoaded());
-
-            // v2 - We now have the Loaded event, use it
-            _listView.Loaded += OnListViewLoaded;
+                .Subscribe(_ => OnListViewDraggingPropertyChanged());            
         }
 
         _addButton = e.NameScope.Find<Button>(s_tpAddButton);
@@ -125,17 +134,14 @@ public partial class TabView : TemplatedControl
             }
 
             _addButton.Click += OnAddButtonClick;
+            _addButton.KeyDown += OnAddButtonKeyDown;
         }
 
-        // Ignore ThemeShadow
-
-        UpdateListViewItemContainerTransitions();
+        //UpdateListViewItemContainerTransitions();
     }
 
     protected override Size MeasureOverride(Size availableSize)
     {
-        _ = base.MeasureOverride(availableSize);
-
         if (_previousAvailableSize.Width != availableSize.Width)
         {
             _previousAvailableSize = availableSize;
@@ -143,6 +149,11 @@ public partial class TabView : TemplatedControl
         }
 
         return base.MeasureOverride(availableSize);
+    }
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new TabViewAutomationPeer(this);
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -161,7 +172,7 @@ public partial class TabView : TemplatedControl
         {
             OnSelectedItemPropertyChanged(change);
         }
-        else if (change.Property == TabItemsProperty)
+        else if (change.Property == TabItemsSourceProperty)
         {
             OnTabItemsSourcePropertyChanged(change);
         }
@@ -171,8 +182,7 @@ public partial class TabView : TemplatedControl
         }
     }
 
-
-    internal void SetTabSeparatorOpacity(int index, double opacity)
+    internal void SetTabSeparatorOpacity(int index, int opacityValue)
     {
         if (ContainerFromIndex(index) is TabViewItem tvi)
         {
@@ -182,8 +192,7 @@ public partial class TabView : TemplatedControl
             // must hide the tab separator at all times.
             // It causes two visual states to modify the same property
             // what leads to undesired behaviour.
-            if (tvi.TabSeparator != null)
-                tvi.TabSeparator.Opacity = opacity;
+            tvi.TabSeparator?.Opacity = opacityValue;
         }
     }
 
@@ -203,14 +212,13 @@ public partial class TabView : TemplatedControl
         }
     }
 
+
     private void OnListViewDraggingPropertyChanged()
     {
-        // Callback from LV prop changed for canreorder and allow drop
-        UpdateListViewItemContainerTransitions();
+        //UpdateListViewItemContainerTransitions();
     }
 
-
-    private void OnListViewGettingFocus(object sender, GotFocusEventArgs e)
+    private void OnListViewGettingFocus(object sender, GotFocusEventArgs args)
     {
         // TabViewItems overlap each other by one pixel in order to get the desired visuals for the separator.
         // This causes problems with 2d focus navigation. Because the items overlap, pressing Down or Up from a
@@ -222,22 +230,21 @@ public partial class TabView : TemplatedControl
         // For GamePad, we want to move focus to something in the direction of movement (other than the overlapping item)
         // For Keyboard, we cancel the focus movement.
 
-        // Can ignore this...we don't have GettingFocus event, and no gamepad support
-        // so there's nothing we can actually do here
+        // TODO: v3
     }
 
-    private void OnSelectedIndexPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    private void OnSelectedIndexPropertyChanged(AvaloniaPropertyChangedEventArgs args)
     {
         // We update previous selected and adjacent on the left tab
         // as well as current selected and adjacent on the left tab
         // to show/hide tabSeparator accordingly.
         UpdateSelectedIndex();
-        SetTabSeparatorOpacity(change.GetOldValue<int>());
-        SetTabSeparatorOpacity(change.GetOldValue<int>() - 1);
-        SetTabSeparatorOpacity(change.GetNewValue<int>() - 1);
-        SetTabSeparatorOpacity(change.GetNewValue<int>());
+        SetTabSeparatorOpacity(args.GetOldValue<int>());
+        SetTabSeparatorOpacity(args.GetOldValue<int>() - 1);
+        SetTabSeparatorOpacity(args.GetNewValue<int>() - 1);
+        SetTabSeparatorOpacity(args.GetNewValue<int>());
 
-        UpdateTabBottomBorderLineVisualStates();
+        UpdateBottomBorderLineVisualStates();
     }
 
     private void UpdateTabBottomBorderLineVisualStates()
@@ -308,9 +315,13 @@ public partial class TabView : TemplatedControl
         UpdateListViewItemContainerTransitions();
     }
 
-    private void UpdateListViewItemContainerTransitions()
+    private void UpdateListViewItemContainerTransitions() { }
+
+    private void OnCanTearOutTabsPropertyChanged(AvaloniaPropertyChangedEventArgs args)
     {
-        // IGNORE
+        UpdateTabViewWithTearOutList();
+        AttachMoveSizeLoopEvents();
+        UpdateNonClientRegion();
     }
 
     private void OnTabWidthModePropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -319,7 +330,7 @@ public partial class TabView : TemplatedControl
 
         var newValue = change.GetNewValue<TabViewWidthMode>();
         // Switch the visual states of all tab items to the correct TabViewWidthMode
-        int itemCount = TabItems.Count();
+        int itemCount = TabItems.Count;
         for (int i = 0; i < itemCount; i++)
         {
             if (ContainerFromIndex(i) is TabViewItem tvi)
@@ -333,7 +344,7 @@ public partial class TabView : TemplatedControl
     {
         var newValue = change.GetNewValue<TabViewCloseButtonOverlayMode>();
         // Switch the visual states of all tab items to the correct TabViewWidthMode
-        int itemCount = TabItems.Count();
+        int itemCount = TabItems.Count;
         for (int i = 0; i < itemCount; i++)
         {
             if (ContainerFromIndex(i) is TabViewItem tvi)
@@ -351,15 +362,40 @@ public partial class TabView : TemplatedControl
     private void OnLoaded(object sender, RoutedEventArgs args)
     {
         UpdateTabContent();
+        UpdateTabViewWithTearOutList();
+        AttachMoveSizeLoopEvents();
+        UpdateNonClientRegion();
     }
 
+    private void OnUnloaded(object sender, RoutedEventArgs args)
+    {
+        UpdateTabViewWithTearOutList();
+    }
+    internal TabViewListView AListView => _listView;
     private void OnListViewLoaded(object sender, RoutedEventArgs args)
     {
-        // WinUI does a bunch of weirdness here to add the items to the ListView
-        // Probably because of the TabItems vs TabItemsSource thing
-        // We can skip most of that and just assign the items to the ListView
+        var lv = _listView;
 
-        //_listView.Items = TabItems;
+        // Now that ListView exists, we can start using its Items collection.
+        var lvItems = lv.Items;
+        if (lvItems != null)
+        {
+            if (lv.ItemsSource == null)
+            {
+                // copy the list, because clearing lvItems may also clear TabItems
+                using var l = new PooledList<object>(lvItems.Count);
+
+                foreach (var item in TabItems)
+                    l.Add(item);
+
+                lvItems.Clear();
+
+                foreach (var item in l.AsSpan())
+                    lvItems.Add(item);
+            }
+
+            TabItems = lvItems;
+        }
 
         if (SelectedItem != null)
         {
@@ -371,22 +407,28 @@ public partial class TabView : TemplatedControl
             UpdateSelectedIndex();
         }
 
-        SelectedIndex = _listView.SelectedIndex;
-        SelectedItem = _listView.SelectedItem;
+        SelectedIndex = lv.SelectedIndex;
+        SelectedItem = lv.SelectedItem;
 
         _itemsPresenter = _listView.Presenter as ItemsPresenter;
+        _itemsPresenter.SizeChanged += OnItemsPresenterSizeChanged;
 
-        _itemsPresenterSizeChangedRevoker = _itemsPresenter.GetPropertyChangedObservable(BoundsProperty).Subscribe(OnItemsPresenterSizeChanged);
-
-        _scrollViewer = _listView.Scroller;
-        if (_scrollViewer != null)
+        var scrollViewer = _listView.Scroller;
+        if (scrollViewer != null)
         {
-            // Since we don't have loaded event and it's already in the tree, we'll 
-            // just call Loaded here
-            OnScrollViewerLoaded();
+            if (scrollViewer.IsLoaded)
+            {
+                OnScrollViewerLoaded(null, null);
+            }
+            else
+            {
+                scrollViewer.Loaded += OnScrollViewerLoaded;
+            }
         }
+        _scrollViewer = scrollViewer;
 
-        UpdateTabBottomBorderLineVisualStates();
+        UpdateBottomBorderLineVisualStates();
+        UpdateNonClientRegion();
     }
 
     private void OnTabStripPointerLeave(object sender, PointerEventArgs e)
@@ -410,7 +452,7 @@ public partial class TabView : TemplatedControl
         _pointerInTabstrip = true;
     }
 
-    private void OnScrollViewerLoaded()
+    private void OnScrollViewerLoaded(object sender, RoutedEventArgs args)
     {
         var buttons = _scrollViewer.GetTemplateChildren()
             .Where(x => x is RepeatButton);
@@ -420,14 +462,14 @@ public partial class TabView : TemplatedControl
             if (button.Name == s_tpScrollDecreaseButton)
             {
                 _scrollDecreaseButton = button;
-                ToolTip.SetTip(_scrollDecreaseButton, 
+                ToolTip.SetTip(_scrollDecreaseButton,
                     FALocalizationHelper.Instance.GetLocalizedStringResource(SR_TabViewScrollDecreaseButtonTooltip));
                 _scrollDecreaseButton.Click += OnScrollDecreaseClick;
             }
             else if (button.Name == s_tpScrollIncreaseButton)
             {
                 _scrollIncreaseButton = button;
-                ToolTip.SetTip(_scrollIncreaseButton, 
+                ToolTip.SetTip(_scrollIncreaseButton,
                     FALocalizationHelper.Instance.GetLocalizedStringResource(SR_TabViewScrollIncreaseButtonTooltip));
                 _scrollIncreaseButton.Click += OnScrollIncreaseClick;
             }
@@ -438,6 +480,8 @@ public partial class TabView : TemplatedControl
             _scrollViewer.GetPropertyChangedObservable(ScrollViewer.ExtentProperty).Subscribe(OnScrollViewerViewChanged),
             _scrollViewer.GetPropertyChangedObservable(ScrollViewer.ViewportProperty).Subscribe(OnScrollViewerViewChanged)
             );
+
+        UpdateTabWidths();
     }
 
     private void OnScrollViewerViewChanged(AvaloniaPropertyChangedEventArgs args)
@@ -453,50 +497,26 @@ public partial class TabView : TemplatedControl
             var hOffset = _scrollViewer.Offset.X;
             var scrollableWidth = (_scrollViewer.Extent.Width - _scrollViewer.Viewport.Width);
 
-            if (Math.Abs(hOffset - scrollableWidth) < minThreshold)
+            if (double.Abs(hOffset - scrollableWidth) < minThreshold)
             {
-                if (_scrollDecreaseButton != null)
-                {
-                    _scrollDecreaseButton.IsEnabled = true;
-                }
-                if (_scrollIncreaseButton != null)
-                {
-                    _scrollIncreaseButton.IsEnabled = false;
-                }
+                _scrollDecreaseButton?.IsEnabled = true;
+                _scrollIncreaseButton?.IsEnabled = false;
             }
-            else if (Math.Abs(hOffset) < minThreshold)
+            else if (double.Abs(hOffset) < minThreshold)
             {
-                if (_scrollDecreaseButton != null)
-                {
-                    _scrollDecreaseButton.IsEnabled = false;
-                }
-                if (_scrollIncreaseButton != null)
-                {
-                    _scrollIncreaseButton.IsEnabled = true;
-                }
+                _scrollDecreaseButton.IsEnabled = false;
+                _scrollIncreaseButton.IsEnabled = true;
             }
             else
             {
-                if (_scrollDecreaseButton != null)
-                {
-                    _scrollDecreaseButton.IsEnabled = true;
-                }
-                if (_scrollIncreaseButton != null)
-                {
-                    _scrollIncreaseButton.IsEnabled = true;
-                }
+                _scrollDecreaseButton.IsEnabled = true;
+                _scrollIncreaseButton.IsEnabled = true;
             }
         }
     }
 
-    private void OnItemsPresenterSizeChanged(AvaloniaPropertyChangedEventArgs args)
+    private void OnItemsPresenterSizeChanged(object sender, SizeChangedEventArgs args)
     {
-        var newValue = (Rect)args.NewValue;
-        // We're observing bounds, make sure we only do this on size changed
-        if (_lastItemsPresenterSize == newValue.Size)
-            return;
-
-        _lastItemsPresenterSize = newValue.Size;
         if (!_updateTabWidthOnPointerLeave)
         {
             // Presenter size didn't change because of item being removed, so update manually
@@ -511,46 +531,37 @@ public partial class TabView : TemplatedControl
     {
         if (SelectedItem != null)
         {
-            var tvi = SelectedItem as TabViewItem;
-            if (tvi == null)
-                tvi = ContainerFromItem(SelectedItem) as TabViewItem;
-
-            tvi.StartBringTabIntoView();
+            var tvi = SelectedItem as TabViewItem ?? ContainerFromItem(SelectedItem) as TabViewItem;            
+            tvi?.StartBringTabIntoView();
         }
     }
 
-    internal void OnItemsChanged(NotifyCollectionChangedEventArgs args)
+    internal void OnItemsChanged(object item)
     {
-        if (_isDragging)
-            return;
-
-        // Change from WinUI b/c we don't have TabItems and TabItemsSource
-        // if args is null, it was full items refresh
-
-        int numItems = TabItems.Count();
-        var lvSelIndex = _listView.SelectedIndex;
-        var selIndex = SelectedIndex;
-
-        if (selIndex != lvSelIndex && lvSelIndex != -1)
+        if (item is NotifyCollectionChangedEventArgs args)
         {
-            SelectedIndex = lvSelIndex;
-            selIndex = lvSelIndex;
-        }
+            TabItemsChanged?.Invoke(this, args);
 
-        if (args is NotifyCollectionChangedEventArgs incc)
-        {
-            TabItemsChanged?.Invoke(this, incc);
+            int numItems = TabItems.Count;
+            var listViewInnerSelectedIndex = _listView.SelectedIndex;
+            var selectedIndex = SelectedIndex;
 
-            if (incc.Action == NotifyCollectionChangedAction.Remove)
+            if (selectedIndex != listViewInnerSelectedIndex && listViewInnerSelectedIndex != -1)
+            {
+                SelectedIndex = listViewInnerSelectedIndex;
+                selectedIndex = listViewInnerSelectedIndex;
+            }
+
+            if (args.Action == NotifyCollectionChangedAction.Remove)
             {
                 _updateTabWidthOnPointerLeave = true;
                 if (numItems > 0)
                 {
                     // SelectedIndex might also already be -1
-                    if (selIndex == -1 || selIndex == incc.OldStartingIndex)
+                    if (selectedIndex == -1 || selectedIndex == args.OldStartingIndex)
                     {
                         // Find the closest tab to select instead
-                        int startIndex = incc.OldStartingIndex;
+                        int startIndex = args.OldStartingIndex;
                         if (startIndex >= numItems)
                         {
                             startIndex = numItems - 1;
@@ -581,7 +592,7 @@ public partial class TabView : TemplatedControl
 
                 if (TabWidthMode == TabViewWidthMode.Equal)
                 {
-                    if (!_pointerInTabstrip || args.OldStartingIndex == TabItems.Count())
+                    if (!_pointerInTabstrip || args.OldStartingIndex == TabItems.Count)
                     {
                         UpdateTabWidths(true, false);
                     }
@@ -594,23 +605,22 @@ public partial class TabView : TemplatedControl
                 // materialized yet in the panel so UpdateTabWidths using the old previous item
                 // Posting to Dispatcher so delay calling this until after next layout pass
                 // when items are all realized and ContainerFromIndex works
-                Dispatcher.UIThread.Post(() =>
-                {
-                    UpdateTabWidths();
-                    SetTabSeparatorOpacity(numItems - 1);
-                }, DispatcherPriority.Render);                
+                // TODO: Do we still need to post to dispatcher
+                UpdateTabWidths();
+                SetTabSeparatorOpacity(numItems - 1);
             }
         }
         else
         {
-            // Added this for full collection change - Set content to first item
-            if (lvSelIndex == -1 && numItems > 0)
-            {
-                SelectedIndex = 0;
-            }
+            // TODO: Needed still?
+            //// Added this for full collection change - Set content to first item
+            //if (lvSelIndex == -1 && numItems > 0)
+            //{
+            //    SelectedIndex = 0;
+            //}
         }
 
-        UpdateTabBottomBorderLineVisualStates();
+        UpdateBottomBorderLineVisualStates();
     }
 
     private void OnListViewSelectionChanged(object sender, SelectionChangedEventArgs args)
@@ -623,24 +633,42 @@ public partial class TabView : TemplatedControl
         SelectionChanged?.Invoke(this, args);
     }
 
+    private void OnListViewSizeChanged(object sender, SizeChangedEventArgs args)
+    {
+        UpdateNonClientRegion();
+    }
+
     private TabViewItem FindTabViewItemFromDragItem(object item)
     {
-        // This *should* always work for us and we don't need the WinUI fallbacks
-        // because we only have TabItems - and everything, regardless of binding
-        // or direct items, goes through the ICG
-        return ContainerFromItem(item) as TabViewItem;
+        var tab = ContainerFromItem(item) as TabViewItem;
+        tab ??= tab.FindAncestorOfType<TabViewItem>();
+        
+        if (tab == null)
+        {
+            // This is a fallback scenario for tabs without a data context
+            var numItems = TabItems.Count;
+            for (int i = 0; i < numItems; i++)
+            {
+                var tabItem = ContainerFromIndex(i) as TabViewItem;
+                if (tabItem.Content == item)
+                {
+                    tab = tabItem;
+                    break;
+                }
+            }
+        }
+
+        return tab;
     }
 
     private void OnListViewDragItemsStarting(object sender, DragItemsStartingEventArgs args)
     {
-        _isDragging = true;
+        _isItemBeingDragged = true;
 
         var item = args.Items[0];
         var tab = FindTabViewItemFromDragItem(item);
         var myArgs = new TabViewTabDragStartingEventArgs(args, item, tab);
-
         TabDragStarting?.Invoke(this, myArgs);
-
         UpdateBottomBorderLineVisualStates();
     }
 
@@ -651,24 +679,49 @@ public partial class TabView : TemplatedControl
 
     private void OnListViewDrop(object sender, DragEventArgs args)
     {
-        TabStripDrop?.Invoke(this, args);
+        if (!args.Handled)
+        {
+            TabStripDrop?.Invoke(this, args);
+        }
+
+        UpdateIsItemDraggedOver(false);
     }
 
-    private void OnListViewDragItemsCompleted(TabViewListView sender, DragItemsCompletedEventArgs args)
+    private void OnListViewDragEnter(object sender, DragEventArgs args)
     {
-        _isDragging = false;
+        foreach (var item in TabItems)
+        {
+            if (ContainerFromItem(item) is TabViewItem tvi)
+            {
+                if (tvi.IsBeingDragged)
+                    return;
+            }
+        }
 
-        // Selection change was disabled during drag, update SelectedIndex now
+        UpdateIsItemDraggedOver(true);
+    }
+
+    private void OnListViewDragLeave(object sender, DragEventArgs args)
+    {
+        UpdateIsItemDraggedOver(false);
+    }
+
+    private void OnListViewDragItemsCompleted(object sender, DragItemsCompletedEventArgs args)
+    {
+        _isItemBeingDragged = false;
+
+        // Selection may have changed during drag if dragged outside, so we update SelectedIndex again.
         if (_listView != null)
         {
             SelectedIndex = _listView.SelectedIndex;
             SelectedItem = _listView.SelectedItem;
+
+            BringSelectedTabIntoView();
         }
 
         var item = args.Items[0];
         var tab = FindTabViewItemFromDragItem(item);
         var myArgs = new TabViewTabDragCompletedEventArgs(args, item, tab);
-
         TabDragCompleted?.Invoke(this, myArgs);
 
         // None means it's outside of the tab strip area
@@ -702,6 +755,7 @@ public partial class TabView : TemplatedControl
                 // The new tab content is not available at the time of the LosingFocus event, so we need to
                 // move focus later.
                 bool shouldMoveFocusToNewTab = false;
+                // TODO: v3: Switch to LosingFocus
                 _tabContentPresenter.LostFocus += (s, e) =>
                 {
                     shouldMoveFocusToNewTab = true;
@@ -712,11 +766,11 @@ public partial class TabView : TemplatedControl
 
                 // It is not ideal to call UpdateLayout here, but it is necessary to ensure that the ContentPresenter has expanded its content
                 // into the live visual tree.
-                InvalidateMeasure();
-                InvalidateArrange();
+                
 
                 if (shouldMoveFocusToNewTab)
                 {
+                    // TODO: v3 - Update to new FocusManager API
                     var focusable = KeyboardNavigationHandler.GetNext(_tabContentPresenter, NavigationDirection.Next);
                     if (focusable == null)
                     {
@@ -735,6 +789,32 @@ public partial class TabView : TemplatedControl
 
     internal void RequestCloseTab(TabViewItem container, bool updateTabWidths)
     {
+        // If the tab being closed is the currently focused tab, we'll move focus to the next tab
+        // when the tab closes.
+        bool tabIsFocused = false;
+        var focusedObject = TopLevel.GetTopLevel(this).FocusManager.GetFocusedElement();
+        var focusedElement = focusedObject as Visual;
+
+        while (focusedElement != null)
+        {
+            if (focusedElement == container)
+            {
+                tabIsFocused = true;
+                break;
+            }
+
+            focusedElement = focusedElement.GetVisualParent();
+        }
+
+        if (tabIsFocused)
+        {
+            // TODO: v3
+            container.LostFocus += (s, args) =>
+            {
+                // TODO
+            };
+        }
+
         if (_listView != null)
         {
             var args = new TabViewTabCloseRequestedEventArgs(ItemFromContainer(container), container);
@@ -767,7 +847,23 @@ public partial class TabView : TemplatedControl
 
     private void UpdateTabWidths(bool shouldUpdateWidths = true, bool fillAllAvailableSpace = true)
     {
-        var tabWidth = double.NaN;
+        // Don't update any tab widths when we're in the middle of a tab tear-out loop -
+        // we'll update tab widths when it's done.
+        if (_isInTabTearOutLoop)
+        {
+            return;
+        }
+
+        var maxTabWidth = this.TryFindResource(c_tabViewItemMaxWidthName, out var mtw) ? (double)mtw : c_tabMaximumWidth;
+        double tabWidth = double.NaN;
+        int tabCount = TabItems.Count;
+
+        // If an item is being dragged over this TabView, then we'll want to act like there's an extra item
+        // when updating tab widths, which will create a hole into which the item can be dragged.
+        if (_isItemDraggedOver)
+        {
+            tabCount++;
+        }
 
         if (_tabContainerGrid != null)
         {
@@ -802,20 +898,17 @@ public partial class TabView : TemplatedControl
                     if (TabWidthMode == TabViewWidthMode.Equal)
                     {
                         var minTabWidth = this.TryFindResource(c_tabViewItemMinWidthName, out var value) ? (double)value : c_tabMinimumWidth;
-                        var maxTabWidth = this.TryFindResource(c_tabViewItemMaxWidthName, out value) ? (double)value : c_tabMaximumWidth;
-
-                        // If we should fill all of the available space, use scrollviewer dimensions
                         var padding = Padding;
 
-                        double headerWidth = 0.0;
-                        double footerWidth = 0.0;
-                        // don't have header/footer so skip
+                        // We don't have this, so skip what WinUI does, but to avoid messing up the math
+                        // just keep these variables around
+                        double headerWidth = 0, footerWidth = 0;
 
                         if (fillAllAvailableSpace)
                         {
                             // Calculate the proportional width of each tab given the width of the ScrollViewer.
-                            var tabWidthForScroller = (availableWidth - (padding.Horizontal() + headerWidth + footerWidth)) / (double)TabItems.Count();
-                            tabWidth = MathHelpers.Clamp(tabWidthForScroller, minTabWidth, maxTabWidth);
+                            var tabWidthForScroller = (availableWidth - (padding.Horizontal() + headerWidth + footerWidth)) / (double)tabCount;
+                            tabWidth = double.Clamp(tabWidthForScroller, minTabWidth, maxTabWidth);
                         }
                         else
                         {
@@ -837,62 +930,81 @@ public partial class TabView : TemplatedControl
                             }
 
                             // Use current size to update items to fill the currently occupied space
-                            var tabWidthUnclamped = availableTabViewSpace / (double)TabItems.Count();
-                            tabWidth = MathHelpers.Clamp(tabWidthUnclamped, minTabWidth, maxTabWidth);
+                            var tabWidthUnclamped = availableTabViewSpace / (double)tabCount;
+                            tabWidth = double.Clamp(tabWidthUnclamped, minTabWidth, maxTabWidth);
                         }
 
-                        // Size tab column to needed size
                         _tabColumn.MaxWidth = availableWidth + headerWidth + footerWidth;
-                        var requiredWidth = tabWidth * TabItems.Count() + headerWidth + footerWidth;
-                        if (requiredWidth > availableWidth - padding.Horizontal())
+                        var requiredWidth = tabWidth * tabCount + headerWidth + footerWidth + padding.Horizontal();
+                        if (requiredWidth > availableWidth)
                         {
-                            _tabColumn.Width = new GridLength(availableWidth);
+                            _tabColumn.Width = new GridLength(availableWidth, GridUnitType.Pixel);
                             if (_listView != null)
                             {
-                                ScrollViewer.SetHorizontalScrollBarVisibility(_listView,
-                                        ScrollBarVisibility.Visible);
+                                _listView.SetValue(ScrollViewer.HorizontalScrollBarVisibilityProperty, ScrollBarVisibility.Visible);
                                 UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
                             }
                         }
                         else
                         {
-                            _tabColumn.Width = new GridLength(1, GridUnitType.Auto);
+                            // If we're dragging over the TabView, we need to set the width to a specific value,
+                            // since we want it to be larger than the items actually in it in order to accommodate
+                            // the item being dragged into the TabView.  Otherwise, we can just set its width to Auto.
+                            _tabColumn.Width = _isItemDraggedOver ?
+                                new GridLength(requiredWidth, GridUnitType.Pixel) :
+                                new GridLength(1, GridUnitType.Auto);
+
                             if (_listView != null)
                             {
                                 if (shouldUpdateWidths && fillAllAvailableSpace)
                                 {
-                                    ScrollViewer.SetHorizontalScrollBarVisibility(_listView,
-                                        ScrollBarVisibility.Hidden);
+                                    _listView.SetValue(ScrollViewer.HorizontalScrollBarVisibilityProperty, ScrollBarVisibility.Hidden);
                                 }
                                 else
                                 {
-                                    if (_scrollDecreaseButton != null)
-                                    {
-                                        _scrollDecreaseButton.IsEnabled = false;
-                                    }
-
-                                    if (_scrollIncreaseButton != null)
-                                    {
-                                        _scrollIncreaseButton.IsEnabled = false;
-                                    }
+                                    _scrollDecreaseButton?.IsEnabled = false;
+                                    _scrollIncreaseButton?.IsEnabled = false;
                                 }
                             }
                         }
                     }
                     else
                     {
+                        // Case: TabWidthMode "Compact" or "SizeToContent"
                         _tabColumn.MaxWidth = availableWidth;
-                        _tabColumn.Width = new GridLength(1, GridUnitType.Auto);
 
                         if (_listView != null)
                         {
+                            // When an item is being dragged over, we need to reserve extra space for the potential new tab,
+                            // so we can't rely on auto sizing in that case.  However, the ListView expands to the size of the column,
+                            // so we need to store the value lest we keep expanding the width of the column every time we call this method.
+                            if (_isItemDraggedOver)
+                            {
+                                if (!_expandedWidthForDragOver.HasValue)
+                                {
+                                    _expandedWidthForDragOver = _listView.Bounds.Width + maxTabWidth;
+                                }
+
+                                _tabColumn.Width = new GridLength(_expandedWidthForDragOver.Value, GridUnitType.Pixel);
+                            }
+                            else
+                            {
+                                if (_expandedWidthForDragOver.HasValue)
+                                {
+                                    _expandedWidthForDragOver = null;
+                                }
+
+                                _tabColumn.Width = new GridLength(1, GridUnitType.Auto);
+                            }
+
                             _listView.MaxWidth = availableWidth;
 
-                            if (_itemsPresenter != null)
+                            var ip = _itemsPresenter;
+                            if (ip != null)
                             {
-                                var visible = _itemsPresenter.Bounds.Width > availableWidth;
-                                ScrollViewer.SetHorizontalScrollBarVisibility(_listView,
-                                    visible ? ScrollBarVisibility.Visible : ScrollBarVisibility.Hidden);
+                                var visible = ip.Bounds.Width > availableWidth;
+                                _listView.SetValue(ScrollViewer.HorizontalScrollBarVisibilityProperty, visible ?
+                                    ScrollBarVisibility.Visible : ScrollBarVisibility.Hidden);
 
                                 if (visible)
                                 {
@@ -901,24 +1013,18 @@ public partial class TabView : TemplatedControl
                             }
                         }
                     }
-                }
+                }                
             }
         }
 
-#if DEBUG
-        Logger.TryGet(LogEventLevel.Debug, "TabView")?
-            .Log("TabView", $"TabView UpdateTabWidths: \nShould Update:{shouldUpdateWidths} Fill:{fillAllAvailableSpace} - TabWidth: {tabWidth}\n");
-#endif
-
         if (shouldUpdateWidths || TabWidthMode != TabViewWidthMode.Equal)
         {
-            var count = TabItems.Count();
-            for (int i = 0; i < count; i++)
+            foreach (var item in TabItems)
             {
-                if (ContainerFromIndex(i) is TabViewItem tvi)
-                {
+                var tvi = item as TabViewItem ?? ContainerFromItem(item) as TabViewItem;
+
+                if (tvi != null)
                     tvi.Width = tabWidth;
-                }
             }
         }
     }
@@ -942,7 +1048,7 @@ public partial class TabView : TemplatedControl
     }
 
     public Control ContainerFromItem(object item) =>
-        _listView?.ContainerFromItem(item);
+       _listView?.ContainerFromItem(item);
 
     public Control ContainerFromIndex(int index) =>
         _listView?.ContainerFromIndex(index);
@@ -953,21 +1059,29 @@ public partial class TabView : TemplatedControl
     public object ItemFromContainer(Control container) =>
         _listView?.ItemFromContainer(container);
 
-    private int GetItemCount() => TabItems.Count();
-
-    private bool SelectNextTab(int increment)
+    private int GetItemCount()
     {
-        bool handled = false;
-        int itemSize = GetItemCount();
-        if (itemSize > 1)
+        var src = TabItemsSource;
+        if (src != null)
         {
-            var index = SelectedIndex;
-            index = (index + increment + itemSize) % itemSize;
-            SelectedIndex = index;
-            handled = true;
+            return src.Count();
         }
+        else
+        {
+            return TabItems.Count;
+        }
+    }
 
-        return handled;
+    internal bool MoveFocus(bool moveForward)
+    {
+        // TODO: v3
+        return false;
+    }
+
+    private bool MoveSelection(bool moveForward)
+    {
+        // TODO: v3
+        return false;
     }
 
     private bool RequestCloseCurrentTab()
@@ -985,9 +1099,6 @@ public partial class TabView : TemplatedControl
         return handled;
     }
 
-    internal string GetTabCloseButtonTooltipText() =>
-        _tabCloseButtonTooltipText;
-
     protected virtual void OnKeyboardAcceleratorInvoked(object parameter)
     {
         switch ((TabViewCommandType)parameter)
@@ -997,75 +1108,93 @@ public partial class TabView : TemplatedControl
                 break;
 
             case TabViewCommandType.CtrlTab:
-                SelectNextTab(1);
+                MoveSelection(true);
                 break;
 
             case TabViewCommandType.CtrlShftTab:
-                SelectNextTab(-1);
+                MoveSelection(false);
                 break;
         }
     }
 
-    private void OnTabContainerGridKeyDown(object sender, KeyEventArgs e)
+    private void OnAddButtonKeyDown(object sender, KeyEventArgs args)
     {
-        if (e.Key == Key.Left || e.Key == Key.Right)
+        var ab = _addButton;
+        if (args.Key == Key.Right)
         {
-            var direction = e.Key == Key.Left ? NavigationDirection.Previous : NavigationDirection.Next;
-
-            var current = TopLevel.GetTopLevel(this).FocusManager.GetFocusedElement();
-
-            if (current is Control c && _tabContainerGrid.IsVisualAncestorOf(c))
-            {
-                if (_listView != null)
-                {
-                    if (current is TabViewItem tvi)
-                    {
-                        var index = _listView.IndexFromContainer(tvi);
-
-                        if (index == -1)
-                            return;
-
-                        index = direction == NavigationDirection.Previous ? index - 1 : index + 1;
-
-                        if (index >= 0 && index < _listView.ItemCount)
-                        {
-                            var container = _listView.ContainerFromIndex(index);
-                            if (container != null)
-                            {
-                                container.Focus(NavigationMethod.Directional);
-                            }
-                        }
-                        else if (index == _listView.ItemCount && _addButton != null)
-                        {
-                            _addButton.Focus(NavigationMethod.Directional);
-                        }
-                    }
-                    else if (current == _addButton)
-                    {
-                        if (direction == NavigationDirection.Previous && _listView.ItemCount > 0)
-                        {
-                            var container = _listView.ContainerFromIndex(_listView.ItemCount - 1);
-                            if (container != null)
-                            {
-                                container.Focus(NavigationMethod.Directional);
-                            }
-                        }
-                    }
-                }
-            }
-            else
-            {
-                if (_listView != null && _listView.ItemCount > 0 && direction == NavigationDirection.Next)
-                {
-                    _listView.ContainerFromIndex(0).Focus(NavigationMethod.Directional);
-                }
-                else if (_addButton != null)
-                {
-                    _addButton.Focus(NavigationMethod.Directional);
-                }
-            }
+            args.Handled = MoveFocus(ab.FlowDirection == Avalonia.Media.FlowDirection.LeftToRight);
+        }
+        else if (args.Key == Key.Left)
+        {
+            args.Handled = MoveFocus(ab.FlowDirection == Avalonia.Media.FlowDirection.RightToLeft);
         }
     }
+
+    // Note that the parameter is a DependencyObject for convenience to allow us to call this on the return value of ContainerFromIndex.
+    // There are some non-control elements that can take focus - e.g. a hyperlink in a RichTextBlock - but those aren't relevant for our purposes here.
+    private bool IsFocusable(InputElement obj, bool checkTabStop)
+    {
+        if (obj == null)
+            return false;
+
+        if (obj is Control c)
+        {
+            return c.IsEffectivelyVisible &&
+                (c.IsEffectivelyEnabled) && // AllowFocusWhenDisabled (TODO v3)
+                (c.IsTabStop || !checkTabStop);
+        }
+
+        return false;
+    }
+
+    private void UpdateIsItemDraggedOver(bool isItemDraggedOver)
+    {
+        if (_isItemDraggedOver != isItemDraggedOver)
+        {
+            _isItemDraggedOver = isItemDraggedOver;
+            UpdateTabWidths();
+        }
+    }
+
+    private void UpdateTabViewWithTearOutList()
+    {
+        //var list = GetTabViewWithTearOutList();
+    }
+
+    private void AttachMoveSizeLoopEvents() { }
+
+    private void OnEnteringMoveSize() { }
+
+    private void OnEnteredMoveSize() { }
+
+    private void OnWindowRectChanging() { }
+
+    private void DragTabWithinTabView() { }
+
+    private void UpdateTabIndex() { }
+
+    private void TearOutTab() { }
+
+    private void DragTornOutTab() { }
+
+    private int GetTabInsertionIndex() => -1;
+
+    private void OnExitedMoveSize() { }
+
+    private TabViewItem GetTabAtPoint(Point point) => null;
+
+    private void PopulateTabViewList() { }
+
+    // MutexLockedResource
+
+    // GetInputNonClientPointerSource
+
+    // GetAppWindowCoordinateConverter
+
+    private void UpdateNonClientRegion() { }
+
+    private nint GetAppWindowId() => 0;
+
 
     private void UnhookEventsAndClearFields()
     {
@@ -1080,28 +1209,29 @@ public partial class TabView : TemplatedControl
             _listView.Loaded -= OnListViewLoaded;
             LogicalChildren.Remove(_listView);
             _listView.SelectionChanged -= OnListViewSelectionChanged;
+            // TODO: v3
+            // _listView.GettingFocus -= OnListViewGettingFocus;
             _listView.GotFocus -= OnListViewGettingFocus;
 
             _listView.DragItemsStarting -= OnListViewDragItemsStarting;
             _listView.DragItemsCompleted -= OnListViewDragItemsCompleted;
-            _listView.DragOver -= OnListViewDragOver;
-            _listView.Drop -= OnListViewDrop;
+            _listView.RemoveHandler(DragDrop.DragOverEvent, OnListViewDragOver);
+            _listView.RemoveHandler(DragDrop.DropEvent, OnListViewDrop);
+            _listView.RemoveHandler(DragDrop.DragEnterEvent, OnListViewDragEnter);
+            _listView.RemoveHandler(DragDrop.DragLeaveEvent, OnListViewDragLeave);
+
             _listViewAllowDropPropertyChangedRevoker?.Dispose();
             _listViewCanReorderItemsPropertyChangedRevoker?.Dispose();
         }
 
-        if (_addButton != null)
-        {
-            _addButton.Click -= OnAddButtonClick;
-        }
+        _addButton?.Click -= OnAddButtonClick;
+        _addButton?.KeyDown -= OnAddButtonKeyDown;
 
-        _itemsPresenterSizeChangedRevoker?.Dispose();
+        _itemsPresenter?.SizeChanged -= OnItemsPresenterSizeChanged;
 
-        if (_scrollDecreaseButton != null)
-            _scrollDecreaseButton.Click -= OnScrollDecreaseClick;
+        _scrollDecreaseButton?.Click -= OnScrollDecreaseClick;
 
-        if (_scrollIncreaseButton != null)
-            _scrollIncreaseButton.Click -= OnScrollIncreaseClick;
+        _scrollIncreaseButton?.Click -= OnScrollIncreaseClick;
 
         _scrollViewerViewChangedRevoker?.Dispose();
 
@@ -1122,15 +1252,19 @@ public partial class TabView : TemplatedControl
         _itemsPresenter = null;
     }
 
-    //bool IContentPresenterHost.RegisterContentPresenter(IContentPresenter presenter)
-    //{
-    //    if (presenter.Name == s_tpTabContentPresenter)
-    //        return true;
+    internal static string GetClassForStripLocation(TabViewTabStripLocation loc)
+    {
+        return loc switch
+        {
+            TabViewTabStripLocation.Left => s_pcLeft,
+            TabViewTabStripLocation.Bottom => s_pcBottom,
+            TabViewTabStripLocation.Right => s_pcRight,
+            _ => s_pcTop
+        };
+    }
 
-    //    return false;
-    //}
-
-    //IAvaloniaList<ILogical> IContentPresenterHost.LogicalChildren => LogicalChildren;
+    internal string GetTabCloseButtonTooltipText() =>
+       _tabCloseButtonTooltipText;
 
 
     private TabViewCommand _keyboardAcceleratorHandler;
@@ -1164,6 +1298,10 @@ public partial class TabView : TemplatedControl
     private Size _previousAvailableSize;
 
     private bool _isDragging = false;
+    private bool _isItemBeingDragged;
+    private bool _isItemDraggedOver;
+    private double? _expandedWidthForDragOver;
+    private bool _isInTabTearOutLoop;
 
     private Size _lastItemsPresenterSize;
 
@@ -1173,6 +1311,10 @@ public partial class TabView : TemplatedControl
     // (WinUI) TODO: what is the right number and should this be customizable?
     private static double c_scrollAmount = 50d;
 
+    private const string s_pcTop = ":top";
+    private const string s_pcLeft = ":left";
+    private const string s_pcRight = ":right";
+    private const string s_pcBottom = ":bottom";
 
     class TabViewCommand : ICommand
     {
@@ -1201,5 +1343,12 @@ public partial class TabView : TemplatedControl
         CtrlF4,
         CtrlTab,
         CtrlShftTab
+    }
+}
+
+public class TabViewAutomationPeer : ControlAutomationPeer
+{
+    public TabViewAutomationPeer(Control owner) : base(owner)
+    {
     }
 }

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Specialized;
+using System.Reflection.Metadata;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Automation.Peers;
@@ -71,6 +72,7 @@ public partial class TabView : TemplatedControl
 
         _tabCloseButtonTooltipText = FALocalizationHelper.Instance.GetLocalizedStringResource(SR_TabViewCloseButtonTooltipWithKA);
         PseudoClasses.Set(s_pcTop, true);
+        DragDrop.SetAllowDrop(this, true);
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -88,21 +90,20 @@ public partial class TabView : TemplatedControl
         _tabContainerGrid = e.NameScope.Get<Grid>(s_tpTabContainerGrid);
         if (_tabContainerGrid.ColumnDefinitions.Count > 0)
         {
-        _leftContentColumn = _tabContainerGrid.ColumnDefinitions[0];
-        _tabColumn = _tabContainerGrid.ColumnDefinitions[1];
-        _addButtonColumn = _tabContainerGrid.ColumnDefinitions[2];
-        _rightContentColumn = _tabContainerGrid.ColumnDefinitions[3];
+            _leftContentColumn = _tabContainerGrid.ColumnDefinitions[0];
+            _tabColumn = _tabContainerGrid.ColumnDefinitions[1];
+            _addButtonColumn = _tabContainerGrid.ColumnDefinitions[2];
+            _rightContentColumn = _tabContainerGrid.ColumnDefinitions[3];
         }
         else
         {
             _tabContainerGrid.SizeChanged += HandleTabContainerGridSizeChangedForVerticalTabView;
         }
-
+        
         _tabContainerGrid.PointerEntered += OnTabStripPointerEnter;
         _tabContainerGrid.PointerExited += OnTabStripPointerLeave;
 
         _listView = e.NameScope.Get<TabViewListView>(s_tpTabListView);
-
         if (_listView != null)
         {
             LogicalChildren.Add(_listView);
@@ -113,11 +114,10 @@ public partial class TabView : TemplatedControl
             _listView.DragItemsStarting += OnListViewDragItemsStarting;
             _listView.DragItemsCompleted += OnListViewDragItemsCompleted;
 
-            _listView.AddHandler(DragDrop.DragOverEvent, OnListViewDragOver);
-
-            _listView.AddHandler(DragDrop.DropEvent, OnListViewDrop);
-            _listView.AddHandler(DragDrop.DragEnterEvent, OnListViewDragEnter);
-            _listView.AddHandler(DragDrop.DragLeaveEvent, OnListViewDragLeave);
+            _listView.DragOver += OnListViewDragOver;
+            _listView.Drop += OnListViewDrop;
+            _listView.DragEnter += OnListViewDragEnter;
+            _listView.DragLeave += OnListViewDragLeave;
 
             // TODO: v3
             //_listView.GettingFocus += OnListViewGettingFocus();
@@ -128,7 +128,7 @@ public partial class TabView : TemplatedControl
                 .Subscribe(_ => OnListViewDraggingPropertyChanged());
             _listViewAllowDropPropertyChangedRevoker =
                 _listView.GetPropertyChangedObservable(DragDrop.AllowDropProperty)
-                .Subscribe(_ => OnListViewDraggingPropertyChanged());            
+                .Subscribe(_ => OnListViewDraggingPropertyChanged());
         }
 
         _addButton = e.NameScope.Find<Button>(s_tpAddButton);
@@ -201,7 +201,7 @@ public partial class TabView : TemplatedControl
         else if (change.Property == TabStripLocationProperty)
         {
             OnTabStripLocationPropertyChanged(change);
-    }
+        }
     }
 
     internal void SetTabSeparatorOpacity(int index, int opacityValue)
@@ -262,7 +262,7 @@ public partial class TabView : TemplatedControl
             // Only set TabContent to null if we're truly switching orientations
             UpdateTabContent();
         }
-
+        
 
         var oldClass = GetClassForStripLocation(args.GetOldValue<TabViewTabStripLocation>());
         var newClass = GetClassForStripLocation(args.GetNewValue<TabViewTabStripLocation>());
@@ -467,17 +467,17 @@ public partial class TabView : TemplatedControl
                 }
                 else
                 {
-                // copy the list, because clearing lvItems may also clear TabItems
-                using var l = new PooledList<object>(lvItems.Count);
+                    // copy the list, because clearing lvItems may also clear TabItems
+                    using var l = new PooledList<object>(lvItems.Count);
 
-                foreach (var item in TabItems)
-                    l.Add(item);
+                    foreach (var item in TabItems)
+                        l.Add(item);
 
-                lvItems.Clear();
+                    lvItems.Clear();
 
-                foreach (var item in l.AsSpan())
-                    lvItems.Add(item);
-            }
+                    foreach (var item in l.AsSpan())
+                        lvItems.Add(item);
+                }                
             }
 
             TabItems = lvItems;
@@ -511,9 +511,9 @@ public partial class TabView : TemplatedControl
         if (_itemsPresenter != null)
         {
             _itemsPresenter = _listView.Presenter;
-        _itemsPresenter.SizeChanged += OnItemsPresenterSizeChanged;
+            _itemsPresenter.SizeChanged += OnItemsPresenterSizeChanged;
         }
-
+        
 
         var scrollViewer = _listView.Scroller;
         _scrollViewer = scrollViewer;
@@ -528,8 +528,7 @@ public partial class TabView : TemplatedControl
                 scrollViewer.Loaded += OnScrollViewerLoaded;
             }
         }
-        _scrollViewer = scrollViewer;
-
+        
 
         UpdateBottomBorderLineVisualStates();
         UpdateNonClientRegion();
@@ -579,6 +578,7 @@ public partial class TabView : TemplatedControl
             }
         }
 
+        // TODO: We now have ScrollChanged event, can probably switch to that
         _scrollViewerViewChangedRevoker = new FACompositeDisposable(
             _scrollViewer.GetPropertyChangedObservable(ScrollViewer.OffsetProperty).Subscribe(OnScrollViewerViewChanged),
             _scrollViewer.GetPropertyChangedObservable(ScrollViewer.ExtentProperty).Subscribe(OnScrollViewerViewChanged),
@@ -723,8 +723,9 @@ public partial class TabView : TemplatedControl
                 
                 Dispatcher.UIThread.Post(() =>
                 {
-                UpdateTabWidths();
-                SetTabSeparatorOpacity(numItems - 1);
+                    UpdateTabWidths();
+                    SetTabSeparatorOpacity(numItems - 1);
+                });
             }
         }
 
@@ -1366,6 +1367,7 @@ public partial class TabView : TemplatedControl
 
     private void UpdateIsItemDraggedOver(bool isItemDraggedOver)
     {
+        // TODO: How do we want to handle this?
         if (_isItemDraggedOver != isItemDraggedOver)
         {
             _isItemDraggedOver = isItemDraggedOver;
@@ -1432,10 +1434,10 @@ public partial class TabView : TemplatedControl
 
             _listView.DragItemsStarting -= OnListViewDragItemsStarting;
             _listView.DragItemsCompleted -= OnListViewDragItemsCompleted;
-            _listView.RemoveHandler(DragDrop.DragOverEvent, OnListViewDragOver);
-            _listView.RemoveHandler(DragDrop.DropEvent, OnListViewDrop);
-            _listView.RemoveHandler(DragDrop.DragEnterEvent, OnListViewDragEnter);
-            _listView.RemoveHandler(DragDrop.DragLeaveEvent, OnListViewDragLeave);
+            _listView.DragOver -= OnListViewDragOver;
+            _listView.Drop -= OnListViewDrop;
+            _listView.DragEnter -= OnListViewDragEnter;
+            _listView.DragLeave -= OnListViewDragLeave;
 
             _listViewAllowDropPropertyChangedRevoker?.Dispose();
             _listViewCanReorderItemsPropertyChangedRevoker?.Dispose();
@@ -1542,10 +1544,6 @@ public partial class TabView : TemplatedControl
     // (WinUI) TODO: what is the right number and should this be customizable?
     private static double c_scrollAmount = 50d;
 
-    private const string s_pcTop = ":top";
-    private const string s_pcLeft = ":left";
-    private const string s_pcRight = ":right";
-    private const string s_pcBottom = ":bottom";
 
     class TabViewCommand : ICommand
     {

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
@@ -130,8 +130,42 @@ public partial class TabView
         SelectingItemsControl.SelectedItemProperty.AddOwner<TabView>(x => x.SelectedItem,
             (x, v) => x.SelectedItem = v);
 
+    /// <summary>
+    /// Defines the <see cref="TabStripLocation"/> property
+    /// </summary>
     public static readonly StyledProperty<TabViewTabStripLocation> TabStripLocationProperty =
         AvaloniaProperty.Register<TabView, TabViewTabStripLocation>(nameof(TabStripLocation));
+
+    /// <summary>
+    /// Defines the <see cref="IsVerticalPaneOpen"/> property
+    /// </summary>
+    public static readonly StyledProperty<bool> IsVerticalPaneOpenProperty = 
+        AvaloniaProperty.Register<TabView, bool>(nameof(IsVerticalPaneOpen), defaultValue: true);
+
+    /// <summary>
+    /// Defines the <see cref="VerticalOpenPaneLength"/> property
+    /// </summary>
+    public static readonly StyledProperty<double> VerticalOpenPaneLengthProperty = 
+        AvaloniaProperty.Register<TabView, double>(nameof(VerticalOpenPaneLength), defaultValue: 225d);
+
+    /// <summary>
+    /// Defines the <see cref="MinimumVerticalOpenPaneLength"/> property
+    /// </summary>
+    public static readonly StyledProperty<double> MinimumVerticalOpenPaneLengthProperty = 
+        AvaloniaProperty.Register<TabView, double>(nameof(MinimumVerticalOpenPaneLength), defaultValue: 40d);
+
+    /// <summary>
+    /// Defines the <see cref="MaximumVerticalOpenPaneLength"/> property
+    /// </summary>
+    public static readonly StyledProperty<double> MaximumVerticalOpenPaneLengthProperty = 
+        AvaloniaProperty.Register<TabView, double>(nameof(MaximumVerticalOpenPaneLength), defaultValue: 700d);
+
+    /// <summary>
+    /// Defines the <see cref="VerticalPaneDisplayMode"/> property
+    /// </summary>
+    public static readonly StyledProperty<SplitViewDisplayMode> VerticalPaneDisplayModeProperty = 
+        AvaloniaProperty.Register<TabView, SplitViewDisplayMode>(nameof(VerticalPaneDisplayMode), defaultValue: SplitViewDisplayMode.Inline);
+
 
 
     /// <summary>
@@ -287,11 +321,67 @@ public partial class TabView
         set => SetAndRaise(SelectedItemProperty, ref _selectedItem, value);
     }
 
+    /// <summary>
+    /// Gets or sets the location of the tab strip for this TabView
+    /// </summary>
     public TabViewTabStripLocation TabStripLocation
     {
         get => GetValue(TabStripLocationProperty);
         set => SetValue(TabStripLocationProperty, value);
     }
+
+    /// <summary>
+    /// When the tab strip is on the left or the right, returns whether the pane is open.
+    /// If the tab strip is on the top or bottom, this has no effect
+    /// </summary>
+    public bool IsVerticalPaneOpen
+    {
+        get => GetValue(IsVerticalPaneOpenProperty);
+        set => SetValue(IsVerticalPaneOpenProperty, value);
+    }
+
+    /// <summary>
+    /// When the tab strip is on the left or the right, returns pane's open length
+    /// If the tab strip is on the top or bottom, this has no effect
+    /// </summary>
+    public double VerticalOpenPaneLength
+    {
+        get => GetValue(VerticalOpenPaneLengthProperty);
+        set => SetValue(VerticalOpenPaneLengthProperty, value);
+    }
+
+    /// <summary>
+    /// When the tab strip is on the left or the right, returns the minimum width
+    /// the pane can be opened. If the tab strip is on the top or bottom, this has no effect
+    /// </summary>
+    public double MinimumVerticalOpenPaneLength
+    {
+        get => GetValue(MinimumVerticalOpenPaneLengthProperty);
+        set => SetValue(MinimumVerticalOpenPaneLengthProperty, value);
+    }
+
+    /// <summary>
+    /// When the tab strip is on the left or the right, returns the maximum width
+    /// the pane can be opened. If the tab strip is on the top or bottom, this has no effect
+    /// </summary>
+    public double MaximumVerticalOpenPaneLength
+    {
+        get => GetValue(MaximumVerticalOpenPaneLengthProperty);
+        set => SetValue(MaximumVerticalOpenPaneLengthProperty, value);
+    }
+
+    /// <summary>
+    /// When the tab strip is on the left or the right, returns the display mode of the pane.
+    /// If the tab strip is on the top or bottom, this has no effect.
+    /// </summary>
+    public SplitViewDisplayMode VerticalPaneDisplayMode
+    {
+        get => GetValue(VerticalPaneDisplayModeProperty);
+        set => SetValue(VerticalPaneDisplayModeProperty, value);
+    }
+
+    // Internal for Unit Tests Only
+    internal TabViewListView ListView => _listView;
 
     /// <summary>
     /// Raised when the user attempts to close a Tab via clicking the x-to-close button
@@ -356,12 +446,19 @@ public partial class TabView
     // Technically these are template parts on the ScrollViewer, but we ref them here
     private const string s_tpScrollDecreaseButton = "ScrollDecreaseButton";
     private const string s_tpScrollIncreaseButton = "ScrollIncreaseButton";
-    
+
+    private const string s_tpPaneResizeHandle = "BorderResizeHandleHost";
+
     // These two come from the WinUI port, so they don't follow the normal naming convention for parity upstream
     private static string c_tabViewItemMinWidthName = "TabViewItemMinWidth";
     private static string c_tabViewItemMaxWidthName = "TabViewItemMaxWidth";
 
     private const string s_pcSingleBorder = ":singleBorder";
+
+    internal const string s_pcTop = ":top";
+    internal const string s_pcLeft = ":left";
+    internal const string s_pcRight = ":right";
+    internal const string s_pcBottom = ":bottom";
 
     private static readonly string SR_TabViewCloseButtonTooltipWithKA = "TabViewCloseButtonTooltipWithKA";
     private static readonly string SR_TabViewAddButtonTooltip = "TabViewAddButtonTooltip";

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
@@ -82,9 +82,15 @@ public partial class TabView
     /// <summary>
     /// Defines the <see cref="TabItems"/> property
     /// </summary>
-    public static readonly DirectProperty<TabView, IEnumerable> TabItemsProperty =
-        AvaloniaProperty.RegisterDirect<TabView, IEnumerable>(nameof(TabItems),
-            x => x.TabItems, (x, v) => x.TabItems = v);
+    public static readonly DirectProperty<TabView, IList> TabItemsProperty =
+        AvaloniaProperty.RegisterDirect<TabView, IList>(nameof(TabItems),
+            x => x.TabItems);
+
+    /// <summary>
+    /// Defines the <see cref="TabItemsSource"/> property
+    /// </summary>
+    public static readonly StyledProperty<IEnumerable> TabItemsSourceProperty =
+        AvaloniaProperty.Register<TabView, IEnumerable>(nameof(TabItemsSource));
 
     /// <summary>
     /// Defines the <see cref="TabItemTemplate"/> property
@@ -123,6 +129,10 @@ public partial class TabView
     public static readonly DirectProperty<TabView, object> SelectedItemProperty =
         SelectingItemsControl.SelectedItemProperty.AddOwner<TabView>(x => x.SelectedItem,
             (x, v) => x.SelectedItem = v);
+
+    public static readonly StyledProperty<TabViewTabStripLocation> TabStripLocationProperty =
+        AvaloniaProperty.Register<TabView, TabViewTabStripLocation>(nameof(TabStripLocation));
+
 
     /// <summary>
     /// Gets or sets how the tabs should be sized
@@ -209,10 +219,16 @@ public partial class TabView
     /// Gets or sets the TabItems this TabView displays
     /// </summary>
     [Content]
-    public IEnumerable TabItems
+    public IList TabItems
     {
         get => _tabItems;
-        set => SetAndRaise(TabItemsProperty, ref _tabItems, value);
+        private set => SetAndRaise(TabItemsProperty, ref _tabItems, value);
+    }
+
+    public IEnumerable TabItemsSource
+    {
+        get => GetValue(TabItemsSourceProperty);
+        set => SetValue(TabItemsSourceProperty, value);
     }
 
     /// <summary>
@@ -271,6 +287,12 @@ public partial class TabView
         set => SetAndRaise(SelectedItemProperty, ref _selectedItem, value);
     }
 
+    public TabViewTabStripLocation TabStripLocation
+    {
+        get => GetValue(TabStripLocationProperty);
+        set => SetValue(TabStripLocationProperty, value);
+    }
+
     /// <summary>
     /// Raised when the user attempts to close a Tab via clicking the x-to-close button
     /// </summary>
@@ -320,15 +342,16 @@ public partial class TabView
     public event EventHandler<DragEventArgs> TabStripDrop;
 
 
-    private IEnumerable _tabItems;
+    private IList _tabItems;
     private int _selectedIndex = 0;
     private object _selectedItem;
 
-    private const string s_tpTabContentPresenter = "TabContentPresenter";
+    // Internal for unit test access
+    internal const string s_tpTabContentPresenter = "TabContentPresenter";
     private const string s_tpRightContentPresenter = "RightContentPresenter";
     private const string s_tpTabContainerGrid = "TabContainerGrid";
     private const string s_tpTabListView = "TabListView";
-    private const string s_tpAddButton = "AddButton";
+    internal const string s_tpAddButton = "AddButton";
 
     // Technically these are template parts on the ScrollViewer, but we ref them here
     private const string s_tpScrollDecreaseButton = "ScrollDecreaseButton";

--- a/src/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabView.properties.cs
@@ -15,7 +15,15 @@ using Avalonia.Utilities;
 
 namespace FluentAvalonia.UI.Controls;
 
+// Note a Border (s_tpPaneResizeHandle) and a SplitView are not listed here because
+// they're only required in Left/Right display modes. If anyone wrote an analyzer 
+// that generates errors for missing templat parts, I don't want to cause them
+// issues. However, if you retemplate anything, left/right require these controls
+
+// Also note the custom ScrollViewer has required template parts, see below
+
 [PseudoClasses(SharedPseudoclasses.s_pcNoBorder, SharedPseudoclasses.s_pcBorderLeft, SharedPseudoclasses.s_pcBorderRight, s_pcSingleBorder)]
+[PseudoClasses(s_pcTop, s_pcLeft, s_pcBottom, s_pcRight)]
 [TemplatePart(s_tpTabContentPresenter, typeof(ContentPresenter))]
 [TemplatePart(s_tpRightContentPresenter, typeof(ContentPresenter))]
 [TemplatePart(s_tpTabContainerGrid, typeof(Grid))]
@@ -259,6 +267,9 @@ public partial class TabView
         private set => SetAndRaise(TabItemsProperty, ref _tabItems, value);
     }
 
+    /// <summary>
+    /// Gets or sets the TabItems source for this TabView
+    /// </summary>
     public IEnumerable TabItemsSource
     {
         get => GetValue(TabItemsSourceProperty);

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewAutomationPeer.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewAutomationPeer.cs
@@ -1,0 +1,38 @@
+﻿using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+
+namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Represets the <see cref="AutomationPeer"/> for a <see cref="TabView"/>
+/// </summary>
+public sealed class TabViewAutomationPeer : ControlAutomationPeer, ISelectionProvider
+{
+    public TabViewAutomationPeer(Control owner)
+        : base(owner)
+    {
+    }
+
+    public bool CanSelectMultiple => false;
+
+    public bool IsSelectionRequired => true;
+        
+    protected override string GetClassNameCore() => nameof(TabView);
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.Tab;
+
+    public IReadOnlyList<AutomationPeer> GetSelection()
+    {
+        if (Owner is TabView tv)
+        {
+            if (tv.ContainerFromIndex(tv.SelectedIndex) is TabViewItem tvi)
+            {
+                return new AutomationPeer[] { ControlAutomationPeer.CreatePeerForElement(tvi) };
+            }
+        }
+
+        return Array.Empty<AutomationPeer>();
+    }
+}

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -326,6 +326,10 @@ public partial class TabViewItem : SelectorItem
 
     private void UpdateTabGeometry()
     {
+        if (_location == TabViewTabStripLocation.Left || _location == TabViewTabStripLocation.Right)
+            return;
+
+        bool isTop = _location == TabViewTabStripLocation.Top;
         var height = Bounds.Height;
         var popupRadius = this.TryFindResource(c_overlayCornerRadiusKey, out var value) ? (CornerRadius)value : default;
         var leftCorner = popupRadius.TopLeft;
@@ -343,7 +347,14 @@ public partial class TabViewItem : SelectorItem
             rightCorner, rightCorner, rightCorner, rightCorner,
             height - (4 + rightCorner));
 
-        TabViewTemplateSettings.TabGeometry = StreamGeometry.Parse(StringBuilderCache.GetStringAndRelease(builder));
+        var geom = StreamGeometry.Parse(StringBuilderCache.GetStringAndRelease(builder));
+
+        if (!isTop)
+        {
+            geom.Transform = new RotateTransform(180, geom.Bounds.Width * 0.5, geom.Bounds.Height * 0.5);
+    }
+
+        TabViewTemplateSettings.TabGeometry = geom;
     }
 
     private void OnIsSelectedPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -392,6 +403,19 @@ public partial class TabViewItem : SelectorItem
     {
         _tabViewWidthMode = mode;
         UpdateWidthModeVisualState();
+    }
+
+    internal void HandleTabStripLocationChanged(TabViewTabStripLocation newLocation)
+    {
+        _location = newLocation;
+        PseudoClasses.Set(TabView.s_pcTop, newLocation == TabViewTabStripLocation.Top);
+        PseudoClasses.Set(TabView.s_pcBottom, newLocation == TabViewTabStripLocation.Bottom);
+        PseudoClasses.Set(TabView.s_pcRight, newLocation == TabViewTabStripLocation.Right);
+        PseudoClasses.Set(TabView.s_pcLeft, newLocation == TabViewTabStripLocation.Left);
+
+        UpdateTabGeometry();
+        if (_selectedBackgroundPath != null)
+            OnSelectedBackgroundPathSizeChanged(null, null);
     }
 
     private void UpdateCloseButton()
@@ -481,32 +505,32 @@ public partial class TabViewItem : SelectorItem
     {
         _headerContentPresenter?.Content = Header;
 
-        if (_firstTimeSettingToolTip)
-        {
-            _firstTimeSettingToolTip = false;
+        //if (_firstTimeSettingToolTip)
+        //{
+        //    _firstTimeSettingToolTip = false;
 
-            var tip = ToolTip.GetTip(this);
-            if (tip == null)
-            {
-                // App author has not specified a tooltip; use our own
+        //    var tip = ToolTip.GetTip(this);
+        //    if (tip == null)
+        //    {
+        //        // App author has not specified a tooltip; use our own
 
-                // WinUI assigns an empty ToolTip here, but since tooltips work differently
-                // we'll just mark this not null
-                _toolTip = string.Empty;
-            }
-        }
+        //        // WinUI assigns an empty ToolTip here, but since tooltips work differently
+        //        // we'll just mark this not null
+        //        _toolTip = string.Empty;
+        //    }
+        //}
         
-        if (_toolTip != null)
-        {
-            // Update tooltip text to new header text
-            var headerContent = Header;
+        //if (_toolTip != null)
+        //{
+        //    // Update tooltip text to new header text
+        //    var headerContent = Header;
 
-            if (headerContent is string s)
-            {
-                _toolTip = s;
-                ToolTip.SetTip(this, _toolTip);
-            }
-        }
+        //    if (headerContent is string s)
+        //    {
+        //        _toolTip = s;
+        //        ToolTip.SetTip(this, _toolTip);
+        //    }
+        //}
     }
 
     private void HideLeftAdjacentTabSeparator()

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -78,7 +78,7 @@ public partial class TabViewItem : SelectorItem
 
         base.OnApplyTemplate(e);
 
-        _selectedBackgroundPath = e.NameScope.Find<Path>(s_selectedBackgroundPathName);
+        _selectedBackgroundPath = e.NameScope.Find<Path>(s_tpSelectedBackgroundPathName);
         _selectedBackgroundPath?.SizeChanged += OnSelectedBackgroundPathSizeChanged;
 
         TabSeparator = e.NameScope.Find<Visual>(s_tpTabSeparator);
@@ -96,10 +96,7 @@ public partial class TabViewItem : SelectorItem
             //AutomationProperties.SetName(_closeButton, name);
         }
 
-        if (tabView != null)
-        {
-            ToolTip.SetTip(_closeButton, tabView.GetTabCloseButtonTooltipText());
-        }
+        // WinUI sets a default tooltip here, I'm removing that see OnHeaderChanged for more
 
         _closeButton?.Click += OnCloseButtonClick;
 
@@ -512,32 +509,13 @@ public partial class TabViewItem : SelectorItem
     {
         _headerContentPresenter?.Content = Header;
 
-        //if (_firstTimeSettingToolTip)
-        //{
-        //    _firstTimeSettingToolTip = false;
-
-        //    var tip = ToolTip.GetTip(this);
-        //    if (tip == null)
-        //    {
-        //        // App author has not specified a tooltip; use our own
-
-        //        // WinUI assigns an empty ToolTip here, but since tooltips work differently
-        //        // we'll just mark this not null
-        //        _toolTip = string.Empty;
-        //    }
-        //}
-        
-        //if (_toolTip != null)
-        //{
-        //    // Update tooltip text to new header text
-        //    var headerContent = Header;
-
-        //    if (headerContent is string s)
-        //    {
-        //        _toolTip = s;
-        //        ToolTip.SetTip(this, _toolTip);
-        //    }
-        //}
+        // WinUI sets an automatic ToolTip based on the header here. I am removing this
+        // for a couple of reasons:
+        // 1 - If the header isn't a simple string all we did was .ToString so that
+        //     would just make the tooltip whatever .ToString returns
+        // 2 - I found it showed too easily and got in the way of a lot of things so
+        //     it got really annoying
+        // If you want a tooltip on your TabViewItems - set it yourself :)
     }
 
     private void HideLeftAdjacentTabSeparator()
@@ -591,26 +569,28 @@ public partial class TabViewItem : SelectorItem
 
     private void OnSelectedBackgroundPathSizeChanged(object sender, SizeChangedEventArgs e)
     {
-        //if (_location == TabViewTabStripLocation.Left || _location == TabViewTabStripLocation.Right)
-        //    return;
+        // This was added upstream in WinUI to avoid a small gap that sometimes appeared underneath the
+        // tabviewitem. I never saw it in FA, but I'll keep this around
+        if (_location == TabViewTabStripLocation.Left || _location == TabViewTabStripLocation.Right)
+            return;
 
-        //bool top = _location == TabViewTabStripLocation.Top;
-        //var path = _selectedBackgroundPath;
+        bool top = _location == TabViewTabStripLocation.Top;
+        var path = _selectedBackgroundPath;
 
-        //var offset = path.Bounds.Y;
-        //var actualOffset = double.Round(offset);
+        var offset = path.Bounds.Y;
+        var actualOffset = double.Round(offset);
 
-        //if (actualOffset > offset)
-        //{
-        //    // Move the SelectedBackgroundPath element down by a fraction of a pixel to avoid a faint gap line
-        //    // between the selected TabViewItem and its content.
-        //    var tt = new TranslateTransform(0, top ? actualOffset - offset : offset - actualOffset);
-        //    path.RenderTransform = tt;
-        //}
-        //else if (path.RenderTransform != null)
-        //{
-        //    path.RenderTransform = null;
-        //}
+        if (actualOffset > offset)
+        {
+            // Move the SelectedBackgroundPath element down by a fraction of a pixel to avoid a faint gap line
+            // between the selected TabViewItem and its content.
+            var tt = new TranslateTransform(0, top ? actualOffset - offset : offset - actualOffset);
+            path.RenderTransform = tt;
+        }
+        else if (path.RenderTransform != null)
+        {
+            path.RenderTransform = null;
+        }
     }
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
@@ -633,9 +613,6 @@ public partial class TabViewItem : SelectorItem
     private TabViewWidthMode _tabViewWidthMode = TabViewWidthMode.Equal;
     private TabViewCloseButtonOverlayMode _closeButtonOverlayMode = TabViewCloseButtonOverlayMode.Auto;
     private bool _firstTimeSettingToolTip = true;
-    // Close Button click revoker
-    //TabDragStarting revoker
-    //TabDragCompleted revoker
     private FACompositeDisposable _tabDragRevoker;
     private Path _selectedBackgroundPath;
     private TabViewTabStripLocation _location;
@@ -652,16 +629,7 @@ public partial class TabViewItem : SelectorItem
 
     private const string c_overlayCornerRadiusKey = "OverlayCornerRadius";
     private const int c_targetRectWidthIncrement = 2;
-    private const string s_selectedBackgroundPathName = "SelectedBackgroundPath";
-    private const string s_pcDragging = ":dragging";
 
     private TargetWeakEventSubscriber<TabView, TabViewTabDragStartingEventArgs> _startingDragSub;
     private TargetWeakEventSubscriber<TabView, TabViewTabDragCompletedEventArgs> _completedDragSub;
-}
-
-public class TabViewItemAutomationPeer : ListItemAutomationPeer
-{
-    public TabViewItemAutomationPeer(ContentControl owner) : base(owner)
-    {
-    }
 }

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using Avalonia;
 using Avalonia.Automation;
@@ -30,7 +31,7 @@ public partial class TabViewItem : SelectorItem
         Loaded += OnLoaded;
         SizeChanged += OnSizeChanged;
     }
-
+    
     protected internal TabView ParentTabView
     {
         get
@@ -87,7 +88,7 @@ public partial class TabViewItem : SelectorItem
         var tabView = Parent as TabView ?? this.FindAncestorOfType<TabView>();
 
         _closeButton = e.NameScope.Get<Button>(s_tpCloseButton);
-       
+
         if (string.IsNullOrEmpty(AutomationProperties.GetName(_closeButton)))
         {
             // TODO: I need to remember how I made my json file and update it to include this
@@ -100,7 +101,7 @@ public partial class TabViewItem : SelectorItem
             ToolTip.SetTip(_closeButton, tabView.GetTabCloseButtonTooltipText());
         }
 
-        _closeButton.Click += OnCloseButtonClick;
+        _closeButton?.Click += OnCloseButtonClick;
 
         OnHeaderChanged();
         OnIconSourceChanged();
@@ -255,8 +256,14 @@ public partial class TabViewItem : SelectorItem
     {
         base.OnPointerCaptureLost(e);
 
-        _hasPointerCapture = false;
-        _isMiddlePointerButtonPressed = false;
+        StopCheckingForDrag(e.Pointer.Id);
+
+        if (_hasPointerCapture)
+        {
+            _hasPointerCapture = false;
+            _isMiddlePointerButtonPressed = false;
+        }
+                
         RestoreLeftAdjacentTabSeparatorVisibility();
     }
 
@@ -352,7 +359,7 @@ public partial class TabViewItem : SelectorItem
         if (!isTop)
         {
             geom.Transform = new RotateTransform(180, geom.Bounds.Width * 0.5, geom.Bounds.Height * 0.5);
-    }
+        }
 
         TabViewTemplateSettings.TabGeometry = geom;
     }
@@ -584,22 +591,26 @@ public partial class TabViewItem : SelectorItem
 
     private void OnSelectedBackgroundPathSizeChanged(object sender, SizeChangedEventArgs e)
     {
-        var path = _selectedBackgroundPath;
+        //if (_location == TabViewTabStripLocation.Left || _location == TabViewTabStripLocation.Right)
+        //    return;
 
-        var offset = path.Bounds.Y;
-        var actualOffset = double.Round(offset);
+        //bool top = _location == TabViewTabStripLocation.Top;
+        //var path = _selectedBackgroundPath;
 
-        if (actualOffset > offset)
-        {
-            // Move the SelectedBackgroundPath element down by a fraction of a pixel to avoid a faint gap line
-            // between the selected TabViewItem and its content.
-            var tt = new TranslateTransform(0, actualOffset - offset);
-            path.RenderTransform = tt;
-        }
-        else if (path.RenderTransform != null)
-        {
-            path.RenderTransform = null;
-        }
+        //var offset = path.Bounds.Y;
+        //var actualOffset = double.Round(offset);
+
+        //if (actualOffset > offset)
+        //{
+        //    // Move the SelectedBackgroundPath element down by a fraction of a pixel to avoid a faint gap line
+        //    // between the selected TabViewItem and its content.
+        //    var tt = new TranslateTransform(0, top ? actualOffset - offset : offset - actualOffset);
+        //    path.RenderTransform = tt;
+        //}
+        //else if (path.RenderTransform != null)
+        //{
+        //    path.RenderTransform = null;
+        //}
     }
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
@@ -627,6 +638,7 @@ public partial class TabViewItem : SelectorItem
     //TabDragCompleted revoker
     private FACompositeDisposable _tabDragRevoker;
     private Path _selectedBackgroundPath;
+    private TabViewTabStripLocation _location;
 
     private bool _hasPointerCapture = false;
     private bool _isMiddlePointerButtonPressed = false;

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.cs
@@ -1,10 +1,13 @@
 ﻿using System.Globalization;
 using System.Text;
 using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
 using Avalonia.Diagnostics;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -13,51 +16,26 @@ using Avalonia.Threading;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
+using FluentAvalonia.UI.Controls.Internal;
+using Path = Avalonia.Controls.Shapes.Path;
 
 namespace FluentAvalonia.UI.Controls;
 
-public partial class TabViewItem : ListBoxItem
+public partial class TabViewItem : SelectorItem
 {
     public TabViewItem()
     {
         TabViewTemplateSettings = new TabViewItemTemplateSettings();
 
-        // Use AttachedToVisualTree override for Loaded event
-
-        // Will use OnPropertyChanged for SizeChanged, IsSelectedProperty changed, and Foreground changed
-
-        // ListBoxItem uses the PressedMixin...ugh... which uses tunnel events to set :pressed
-        // The problem is that doesn't respect if you've clicked on another control
-        // So, when we click the close button, the :pressed state is activated too, we don't want that
-        // So we have to undo what the :pressed mixin does
-        // This is the easy solution, since the other involves not deriving from ListBoxItem
-        AddHandler(PointerPressedEvent, (s, e) =>
-        {
-            var hasButton = (e.Source as Visual).GetVisualAncestors()
-                .Where(x => x == _closeButton).Any();
-
-            if (hasButton)
-            {
-                PseudoClasses.Set(SharedPseudoclasses.s_pcPressed, false);
-            }
-        }, RoutingStrategies.Tunnel);
-    }
-
-    static TabViewItem()
-    {
-        FocusableProperty.OverrideDefaultValue<TabViewItem>(true);
+        Loaded += OnLoaded;
+        SizeChanged += OnSizeChanged;
     }
 
     protected internal TabView ParentTabView
     {
         get
         {
-            // AGH Stupid Mac build fails here because
-            // UsE oF uNaSsIgNeD lOcAl VaRiAbLe 'target'
-            // No Mac compiler, its fine, 'target' isn't used without assignment
-
-            TabView target = null;
-            if (_parentTabView?.TryGetTarget(out target) == true)
+            if (_parentTabView?.TryGetTarget(out var target) == true)
                 return target;
 
             return null;
@@ -67,21 +45,15 @@ public partial class TabViewItem : ListBoxItem
 
     public Visual TabSeparator { get; private set; }
 
+    internal bool IsBeingDragged { get; set; }
+
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
 
-        if (change.Property == BoundsProperty)
-        {
-            OnSizeChanged(change);
-        }
-        else if (change.Property == IsSelectedProperty)
+        if (change.Property == IsSelectedProperty)
         {
             OnIsSelectedPropertyChanged(change);
-        }
-        else if (change.Property == TextElement.ForegroundProperty)
-        {
-            OnForegroundPropertyChanged(change);
         }
         else if (change.Property == HeaderProperty)
         {
@@ -100,27 +72,35 @@ public partial class TabViewItem : ListBoxItem
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         _tabDragRevoker?.Dispose();
+        _selectedBackgroundPath?.SizeChanged -= OnSelectedBackgroundPathSizeChanged;
+        _closeButton?.Click -= OnCloseButtonClick;
 
         base.OnApplyTemplate(e);
+
+        _selectedBackgroundPath = e.NameScope.Find<Path>(s_selectedBackgroundPathName);
+        _selectedBackgroundPath?.SizeChanged += OnSelectedBackgroundPathSizeChanged;
 
         TabSeparator = e.NameScope.Find<Visual>(s_tpTabSeparator);
 
         _headerContentPresenter = e.NameScope.Find<ContentPresenter>(s_tpContentPresenter);
 
-        var tabView = this.FindAncestorOfType<TabView>();
+        var tabView = Parent as TabView ?? this.FindAncestorOfType<TabView>();
 
-        _closeButton = e.NameScope.Find<Button>(s_tpCloseButton);
-        if (_closeButton != null)
+        _closeButton = e.NameScope.Get<Button>(s_tpCloseButton);
+       
+        if (string.IsNullOrEmpty(AutomationProperties.GetName(_closeButton)))
         {
-            // Skip Automation
-
-            if (tabView != null)
-            {
-                ToolTip.SetTip(_closeButton, tabView.GetTabCloseButtonTooltipText());
-            }
-
-            _closeButton.Click += OnCloseButtonClick;
+            // TODO: I need to remember how I made my json file and update it to include this
+            //var name = FALocalizationHelper.Instance.GetLocalizedStringResource(s_TabViewCloseButtonName);
+            //AutomationProperties.SetName(_closeButton, name);
         }
+
+        if (tabView != null)
+        {
+            ToolTip.SetTip(_closeButton, tabView.GetTabCloseButtonTooltipText());
+        }
+
+        _closeButton.Click += OnCloseButtonClick;
 
         OnHeaderChanged();
         OnIconSourceChanged();
@@ -153,45 +133,48 @@ public partial class TabViewItem : ListBoxItem
             _tabDragRevoker = new FACompositeDisposable(
                 new FADisposable(() => TabView.TabDragStartingWeakEvent.Unsubscribe(tabView, _startingDragSub)),
                 new FADisposable(() => TabView.TabDragCompletedWeakEvent.Unsubscribe(tabView, _completedDragSub)));
-        }
 
-        // Add this to fix a bug that's clearly in WinUI, adding a new TabViewItem doesn't check
-        // the CloseButtonOverlay mode, thus new tabs ALWAYS initialize with 'Auto' even if the 
-        // TabView's CloseButtonOverlayMode is not Auto
-        var tv = ParentTabView;
-
-        if (tv != null)
-        {
-            _closeButtonOverlayMode = tv.CloseButtonOverlayMode;
+            // Add this to fix a bug that's clearly in WinUI, adding a new TabViewItem doesn't check
+            // the CloseButtonOverlay mode, thus new tabs ALWAYS initialize with 'Auto' even if the 
+            // TabView's CloseButtonOverlayMode is not Auto
+            _closeButtonOverlayMode = tabView.CloseButtonOverlayMode;
         }
 
         UpdateCloseButton();
-        UpdateForeground();
         UpdateWidthModeVisualState();
         UpdateTabGeometry();
-
-        // Handle TabViewItem::Loaded
-        if (tv != null)
-        {
-            tv.SetTabSeparatorOpacity(tv.IndexFromContainer(this));
-        }
     }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
-        if (IsSelected && e.Pointer.Type == PointerType.Mouse)
+        var pointer = e.Pointer;
+        var devType = e.Pointer.Type;
+        var point = e.GetCurrentPoint(this);
+
+        if (devType == PointerType.Mouse || devType == PointerType.Pen)
         {
-            var pointerPoint = e.GetCurrentPoint(this);
-            if (pointerPoint.Properties.IsLeftButtonPressed)
+            if (point.Properties.IsLeftButtonPressed)
             {
-                // TODO: Ctrl + cross-platform??
-                var isCtrlDown = (e.KeyModifiers & KeyModifiers.Control) == KeyModifiers.Control;
-                if (isCtrlDown)
+                _lastPointerPressedPosition = point.Position;
+
+                BeginCheckingForDrag(pointer.Id);
+
+                var mod = TopLevel.GetTopLevel(this).PlatformSettings.HotkeyConfiguration.CommandModifiers;
+                bool ctrlDown = (e.KeyModifiers & mod) == mod;
+
+                if (ctrlDown)
                 {
+                    IsSelected = true;
+
                     // Return here so the base class will not pick it up, but let it remain unhandled so someone else could handle it.
                     return;
                 }
             }
+        }
+        else if (devType == PointerType.Touch)
+        {
+            _lastPointerPressedPosition = point.Position;
+            BeginCheckingForDrag(pointer.Id);
         }
 
         base.OnPointerPressed(e);
@@ -204,9 +187,24 @@ public partial class TabViewItem : ListBoxItem
         }
     }
 
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+
+        if (ShouldStartDrag(e))
+        {
+            UpdateDragDropVisualState(true);
+        }
+    }
+
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
+
+        var pointer = e.Pointer;
+
+        StopCheckingForDrag(e.Pointer.Id);
+        UpdateDragDropVisualState(false);
 
         if (_hasPointerCapture)
         {
@@ -250,11 +248,8 @@ public partial class TabViewItem : ListBoxItem
         _isMiddlePointerButtonPressed = false;
 
         UpdateCloseButton();
-        UpdateForeground();
         RestoreLeftAdjacentTabSeparatorVisibility();
     }
-
-    // Don't have PointerCanceled
 
     protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
     {
@@ -263,6 +258,70 @@ public partial class TabViewItem : ListBoxItem
         _hasPointerCapture = false;
         _isMiddlePointerButtonPressed = false;
         RestoreLeftAdjacentTabSeparatorVisibility();
+    }
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new TabViewItemAutomationPeer(this);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (!e.Handled && (e.Key == Key.Left || e.Key == Key.Right))
+        {
+            // Alt+Shift+Arrow reorders tabs, so we don't want to handle that combination.
+            // ListView also handles Alt+Arrow  (no Shift) by just doing regular XY focus,
+            // same as how it handles Arrow without any modifier keys, so in that case
+            // we do want to handle things so we get the improved keyboarding experience.
+            bool isAltDown = (e.KeyModifiers & KeyModifiers.Alt) == KeyModifiers.Alt;
+            bool isShiftDown = (e.KeyModifiers & KeyModifiers.Shift) == KeyModifiers.Shift;
+
+            if (!isAltDown || !isShiftDown)
+            {
+                bool moveForward = FlowDirection == FlowDirection.LeftToRight && e.Key == Key.Right ||
+                    FlowDirection == FlowDirection.RightToLeft && e.Key == Key.Left;
+
+                e.Handled = ParentTabView?.MoveFocus(moveForward) ?? false;
+            }
+        }
+
+        if (!e.Handled)
+            base.OnKeyDown(e);
+    }
+
+    private bool IsOutsideDragRectangle(Point testPoint, Point dragRectangleCenter)
+    {
+        var dx = double.Abs(testPoint.X - dragRectangleCenter.X);
+        var dy = double.Abs(testPoint.Y - dragRectangleCenter.Y);
+
+        FAUISettings.GetSystemDragSize(TopLevel.GetTopLevel(this).RenderScaling, out var maxDx, out var maxDy);
+
+        maxDx *= 2; //c_tabViewItemMouseDragThresholdMultiplier;
+        maxDy *= 2; //c_tabViewItemMouseDragThresholdMultiplier;
+
+        return (dx > maxDx || dy > maxDy);
+    }
+
+    private bool ShouldStartDrag(PointerEventArgs args)
+    {
+        return _isCheckingForDrag &&
+            IsOutsideDragRectangle(args.GetCurrentPoint(this).Position, _lastPointerPressedPosition) &&
+            _dragPointerId == args.Pointer.Id;
+    }
+
+    private void BeginCheckingForDrag(int pointerId)
+    {
+        _dragPointerId = pointerId;
+        _isCheckingForDrag = true;
+    }
+
+    private void StopCheckingForDrag(int pointerId)
+    {
+        if (_isCheckingForDrag && _dragPointerId == pointerId)
+        {
+            _dragPointerId = 0;
+            _isCheckingForDrag = false;
+        }
     }
 
     private void UpdateTabGeometry()
@@ -274,28 +333,26 @@ public partial class TabViewItem : ListBoxItem
 
         const string data = "F1 M0,{0}  a 4,4 0 0 0 4,-4  L 4,{1}  a {2},{3} 0 0 1 {4},-{5}  l {6},0  a {7},{8} 0 0 1 {9},{10}  l 0,{11}  a 4,4 0 0 0 4,4 Z";
 
-        var builder = new StringBuilder();
+        var builder = StringBuilderCache.Acquire(data.Length * 2);
         // WinUI 6644
-        builder.AppendFormat(CultureInfo.InvariantCulture, 
-            data, 
+        builder.AppendFormat(CultureInfo.InvariantCulture,
+            data,
             height,
             leftCorner, leftCorner, leftCorner, leftCorner, leftCorner,
             Bounds.Width - (leftCorner + rightCorner),
             rightCorner, rightCorner, rightCorner, rightCorner,
             height - (4 + rightCorner));
 
-        TabViewTemplateSettings.TabGeometry = StreamGeometry.Parse(builder.ToString());
-    }
-
-    private void OnSizeChanged(AvaloniaPropertyChangedEventArgs change)
-    {
-        // WinUI #6748
-        Dispatcher.UIThread.Post(() => UpdateTabGeometry());
+        TabViewTemplateSettings.TabGeometry = StreamGeometry.Parse(StringBuilderCache.GetStringAndRelease(builder));
     }
 
     private void OnIsSelectedPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
-        // Ignore AutomationPeer
+        // Not sure what Avalonia equivalent of this is
+        //if (const auto peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(*this))
+        //{
+        //    peer.RaiseAutomationEvent(winrt::AutomationEvents::SelectionItemPatternOnElementSelected);
+        //}
 
         if (change.GetNewValue<bool>())
         {
@@ -308,49 +365,21 @@ public partial class TabViewItem : ListBoxItem
             SetValue(ZIndexProperty, 0);
         }
 
-        // UpdateShadow();
         UpdateWidthModeVisualState();
-
         UpdateCloseButton();
-        UpdateForeground();
-    }
-
-    private void OnForegroundPropertyChanged(AvaloniaPropertyChangedEventArgs change)
-    {
-        UpdateForeground();
-    }
-
-    private void UpdateForeground()
-    {
-        // We shouldn't have to do this here because Foreground is automatically inherited
-
-        bool isForegroundSet = this.GetDiagnostic(ForegroundProperty).Priority != Avalonia.Data.BindingPriority.Unset;
-        bool set = isForegroundSet && !IsSelected && !_isPointerOver;
-
-        PseudoClasses.Set(s_pcForeground, set);
-
-        // We only need to set the foreground state when the TabViewItem is in rest state and not selected.
-        // if (!IsSelected && !_isPointerOver)
-        // {
-        // If Foreground is set, then change icon and header foreground to match.
-        //winrt::VisualStateManager::GoToState(
-        //   *this,
-        //   ReadLocalValue(winrt::Control::ForegroundProperty()) == winrt::DependencyProperty::UnsetValue() ? L"ForegroundNotSet" : L"ForegroundSet",
-        //   false /*useTransitions*/);
-        //}
     }
 
     private void OnTabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)
     {
-        //_isDragging = true;
-        //UpdateShadow();
+        _isBeingDragged = true;
     }
 
     private void OnTabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)
     {
-        //_isDragging = false;
-        //UpdateShadow();
-        UpdateForeground();
+        _isBeingDragged = false;
+
+        StopCheckingForDrag(_dragPointerId);
+        UpdateDragDropVisualState(false);
     }
 
     internal void OnCloseButtonOverlayModeChanged(TabViewCloseButtonOverlayMode mode)
@@ -416,12 +445,15 @@ public partial class TabViewItem : ListBoxItem
         PseudoClasses.Set(SharedPseudoclasses.s_pcCompact, !IsSelected && _tabViewWidthMode == TabViewWidthMode.Compact);
     }
 
+    private void UpdateDragDropVisualState(bool isVisible)
+    {
+        PseudoClasses.Set(s_pcDragging, isVisible);
+    }
+
     private void RequestClose()
     {
-        if (this.FindAncestorOfType<TabView>() is TabView tabView)
-        {
-            tabView.RequestCloseTab(this, false);
-        }
+        var tabView = ParentTabView ?? this.FindAncestorOfType<TabView>();
+        tabView.RequestCloseTab(this, false);
     }
 
     internal void RaiseRequestClose(TabViewTabCloseRequestedEventArgs args)
@@ -447,10 +479,7 @@ public partial class TabViewItem : ListBoxItem
 
     private void OnHeaderChanged()
     {
-        if (_headerContentPresenter != null)
-        {
-            _headerContentPresenter.Content = Header;
-        }
+        _headerContentPresenter?.Content = Header;
 
         if (_firstTimeSettingToolTip)
         {
@@ -466,16 +495,16 @@ public partial class TabViewItem : ListBoxItem
                 _toolTip = string.Empty;
             }
         }
-
+        
         if (_toolTip != null)
         {
             // Update tooltip text to new header text
             var headerContent = Header;
 
-            if (headerContent != null)
+            if (headerContent is string s)
             {
-                _toolTip = headerContent;
-                //ToolTip.SetTip(this, _toolTip);
+                _toolTip = s;
+                ToolTip.SetTip(this, _toolTip);
             }
         }
     }
@@ -529,7 +558,39 @@ public partial class TabViewItem : ListBoxItem
         });
     }
 
+    private void OnSelectedBackgroundPathSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        var path = _selectedBackgroundPath;
 
+        var offset = path.Bounds.Y;
+        var actualOffset = double.Round(offset);
+
+        if (actualOffset > offset)
+        {
+            // Move the SelectedBackgroundPath element down by a fraction of a pixel to avoid a faint gap line
+            // between the selected TabViewItem and its content.
+            var tt = new TranslateTransform(0, actualOffset - offset);
+            path.RenderTransform = tt;
+        }
+        else if (path.RenderTransform != null)
+        {
+            path.RenderTransform = null;
+        }
+    }
+
+    private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        // WinUI #6748
+        Dispatcher.UIThread.Post(() => UpdateTabGeometry());
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (ParentTabView is TabView tv)
+        {
+            tv.SetTabSeparatorOpacity(tv.IndexFromContainer(this));
+        }
+    }
 
     private Button _closeButton;
     private object _toolTip;
@@ -541,17 +602,30 @@ public partial class TabViewItem : ListBoxItem
     //TabDragStarting revoker
     //TabDragCompleted revoker
     private FACompositeDisposable _tabDragRevoker;
+    private Path _selectedBackgroundPath;
 
     private bool _hasPointerCapture = false;
     private bool _isMiddlePointerButtonPressed = false;
-    //private bool _isDragging = false;
+    private bool _isBeingDragged = false;
     private bool _isPointerOver = false;
+    private Point _lastPointerPressedPosition;
+    private int _dragPointerId;
+    private bool _isCheckingForDrag;
 
     private WeakReference<TabView> _parentTabView;
 
     private const string c_overlayCornerRadiusKey = "OverlayCornerRadius";
     private const int c_targetRectWidthIncrement = 2;
+    private const string s_selectedBackgroundPathName = "SelectedBackgroundPath";
+    private const string s_pcDragging = ":dragging";
 
     private TargetWeakEventSubscriber<TabView, TabViewTabDragStartingEventArgs> _startingDragSub;
     private TargetWeakEventSubscriber<TabView, TabViewTabDragCompletedEventArgs> _completedDragSub;
+}
+
+public class TabViewItemAutomationPeer : ListItemAutomationPeer
+{
+    public TabViewItemAutomationPeer(ContentControl owner) : base(owner)
+    {
+    }
 }

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
@@ -14,7 +14,7 @@ namespace FluentAvalonia.UI.Controls;
 [TemplatePart(s_tpTabSeparator, typeof(Visual))]
 [TemplatePart(s_tpContentPresenter, typeof(ContentPresenter))]
 [TemplatePart(s_tpCloseButton, typeof(Button))]
-[TemplatePart(s_tpSelectedBackgroundPathName, typeof(Path))]
+[TemplatePart(s_tpSelectedBackgroundPathName, typeof(Avalonia.Controls.Shapes.Path))]
 public partial class TabViewItem
 {
     /// <summary>

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
@@ -10,9 +10,11 @@ namespace FluentAvalonia.UI.Controls;
 
 [PseudoClasses(SharedPseudoclasses.s_pcIcon, SharedPseudoclasses.s_pcCompact, s_pcCloseCollapsed)]
 [PseudoClasses(SharedPseudoclasses.s_pcBorderRight, SharedPseudoclasses.s_pcBorderLeft, SharedPseudoclasses.s_pcNoBorder)]
+[PseudoClasses(s_pcDragging)]
 [TemplatePart(s_tpTabSeparator, typeof(Visual))]
 [TemplatePart(s_tpContentPresenter, typeof(ContentPresenter))]
 [TemplatePart(s_tpCloseButton, typeof(Button))]
+[TemplatePart(s_tpSelectedBackgroundPathName, typeof(Path))]
 public partial class TabViewItem
 {
     /// <summary>
@@ -101,7 +103,9 @@ public partial class TabViewItem
 
 
     private const string s_pcCloseCollapsed = ":closeCollapsed";
+    private const string s_pcDragging = ":dragging";
 
+    private const string s_tpSelectedBackgroundPathName = "SelectedBackgroundPath";
     private const string s_tpTabSeparator = "TabSeparator";
     private const string s_tpContentPresenter = "ContentPresenter";
     internal const string s_tpCloseButton = "CloseButton";

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItem.properties.cs
@@ -8,7 +8,7 @@ using Avalonia.Controls;
 
 namespace FluentAvalonia.UI.Controls;
 
-[PseudoClasses(SharedPseudoclasses.s_pcIcon, SharedPseudoclasses.s_pcCompact, s_pcCloseCollapsed, s_pcForeground)]
+[PseudoClasses(SharedPseudoclasses.s_pcIcon, SharedPseudoclasses.s_pcCompact, s_pcCloseCollapsed)]
 [PseudoClasses(SharedPseudoclasses.s_pcBorderRight, SharedPseudoclasses.s_pcBorderLeft, SharedPseudoclasses.s_pcNoBorder)]
 [TemplatePart(s_tpTabSeparator, typeof(Visual))]
 [TemplatePart(s_tpContentPresenter, typeof(ContentPresenter))]
@@ -100,10 +100,9 @@ public partial class TabViewItem
     internal bool IsContainerFromTemplate { get; set; }
 
 
-    private const string s_pcForeground = ":foreground";
-    private const string s_pcCloseCollapsed = ":closecollapsed";
+    private const string s_pcCloseCollapsed = ":closeCollapsed";
 
     private const string s_tpTabSeparator = "TabSeparator";
     private const string s_tpContentPresenter = "ContentPresenter";
-    private const string s_tpCloseButton = "CloseButton";
+    internal const string s_tpCloseButton = "CloseButton";
 }

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewItemAutomationPeer.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewItemAutomationPeer.cs
@@ -1,0 +1,77 @@
+﻿using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+using Avalonia.VisualTree;
+
+namespace FluentAvalonia.UI.Controls;
+
+/// <summary>
+/// Represents the <see cref="AutomationPeer"/> for a <see cref="TabViewItem"/>
+/// </summary>
+public sealed class TabViewItemAutomationPeer : ListItemAutomationPeer, ISelectionItemProvider
+{
+    public TabViewItemAutomationPeer(ContentControl owner) 
+        : base(owner)
+    {
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.TabItem;
+
+    protected override string GetNameCore()
+    {
+        var name = base.GetNameCore();
+
+        if (string.IsNullOrEmpty(name))
+        {
+            if (Owner is TabViewItem tvi)
+            {
+                name = tvi.Header?.ToString() ?? "TabViewItem";
+            }
+        }
+
+        return name;
+    }
+
+    bool ISelectionItemProvider.IsSelected => (Owner as TabViewItem)?.IsSelected ?? false;
+
+    ISelectionProvider ISelectionItemProvider.SelectionContainer
+    {
+        get
+        {
+            if (GetParentTabView() is TabView tv)
+            {
+                return ControlAutomationPeer.CreatePeerForElement(tv) as ISelectionProvider;
+            }
+
+            return null;
+        }
+    }
+
+    void ISelectionItemProvider.AddToSelection()
+    {
+        ((ISelectionItemProvider)this).Select();
+    }
+
+    void ISelectionItemProvider.RemoveFromSelection()
+    {
+        // Can't unselect in a TabView without knowing the next selection
+    }
+
+    void ISelectionItemProvider.Select()
+    {
+        if (Owner is TabViewItem tvi)
+            tvi.IsSelected = true;
+    }
+
+    private TabView GetParentTabView()
+    {
+        if (Owner is TabViewItem tvi)
+        {
+            return tvi.ParentTabView ?? tvi.FindAncestorOfType<TabView>();
+        }
+
+        return null;
+    }
+
+}

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -9,13 +11,19 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Logging;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using FluentAvalonia.Collections;
 using FluentAvalonia.Core;
+using FluentAvalonia.UI.Data;
 
 namespace FluentAvalonia.UI.Controls.Primitives;
 
@@ -43,8 +51,13 @@ public sealed class TabViewListView : ListBox
                 e.Handled = true;
             }
         };
-    }
 
+        // Because of event differences in WinUI vs Avalonia, we need more control over the drag events
+        // so we are translating them into CLR events for the TabView to subscribe to
+        // See OnApplyTemplate for more info
+        AddHandler(DragDrop.DragOverEvent, OnListViewDragOver);
+        AddHandler(DragDrop.DropEvent, OnListViewDrop);
+    }
 
     /// <summary>
     /// Defines the <see cref="CanReorderItems"/> property
@@ -78,6 +91,11 @@ public sealed class TabViewListView : ListBox
 
     internal ScrollViewer Scroller { get; private set; }
 
+    internal event EventHandler<DragEventArgs> DragEnter;
+    internal event EventHandler<DragEventArgs> DragOver;
+    internal event EventHandler<DragEventArgs> DragLeave;
+    internal event EventHandler<DragEventArgs> Drop;
+
     /// <summary>
     /// Occurs when a drag operation that involves one of the items in the view is initiated.
     /// </summary>
@@ -92,6 +110,17 @@ public sealed class TabViewListView : ListBox
     {
         base.OnApplyTemplate(e);
         Scroller = e.NameScope.Find<ScrollViewer>(s_tpScrollViewer);
+
+        // HACK: DragDrop events work differently in Avalonia than WinUI. In WinUI, they aren't true
+        // routed events, so the OriginalSource parameter returns TabView or TabViewItem, etc., not
+        // template items. In Avalonia, we get template items, but only like 1 or 2. This means that
+        // we can't actually detect if we've left the TabStrip during a drag operation. As of me writing
+        // this, the only things we detect from the local Drag handlers is some template items in the
+        // TabViewItems - ABSOLUTELY NOTHING FROM TABVIEWLISTVIEW, arghhhhh...That's annoying
+        // So this seems to work - if we grab a drag enter handler on the TabView itself and do a bounds
+        // check on this, we know if the pointer left the tab strip or not. 
+        _parent = this.FindAncestorOfType<TabView>();
+        _parent.AddHandler(DragDrop.DragLeaveEvent, OnParentDragEnter);
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -102,12 +131,6 @@ public sealed class TabViewListView : ListBox
         {
             UpdateBottomBorderVisualState();
         }
-    }
-
-    private void OnItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
-    {
-        var tv = this.FindAncestorOfType<TabView>();
-        tv?.OnItemsChanged(e);
     }
 
     protected override bool NeedsContainerOverride(object item, int index, out object recycleKey)
@@ -177,6 +200,7 @@ public sealed class TabViewListView : ListBox
             tvi.HeaderTemplate = itemTemplate;
 
         base.ContainerForItemPreparedOverride(container, item, index);
+
         if (!tvi.IsSelected)
         {
             // Bug Fix: When containers are being virtualized, they may "come back online" with
@@ -219,11 +243,868 @@ public sealed class TabViewListView : ListBox
         }
     }
 
+    protected override void OnPointerPressed(PointerPressedEventArgs args)
+    {
+        if (args.Handled)
+            return;
+
+        if (CanDragItems || CanReorderItems)
+        {
+            var currentPoint = args.GetCurrentPoint(this);
+            if (currentPoint.Properties.IsLeftButtonPressed)
+            {
+                _initialPoint = currentPoint.Position;
+                _dragItem = (args.Source as Visual).FindAncestorOfType<TabViewItem>(true);
+                _dragIndex = IndexFromContainer(_dragItem);
+                _initArgs = args;
+                UpdateDragInfo();
+                // args.Handled = true;
+            }
+        }
+
+        base.OnPointerPressed(args);
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs args)
+    {
+        if (args.Handled)
+            return;
+
+        if (_initialPoint.HasValue)
+        {
+            if (!_isInDrag || !_isInReorder)
+            {
+                var currentPoint = args.GetPosition(this);
+                var delta = currentPoint - _initialPoint.Value;
+
+                if (double.Abs(delta.X) > _cxDrag || double.Abs(delta.Y) > _cyDrag)
+                {
+                    BeginDragReorder();
+                    //args.Handled = true;
+                }
+            }
+        }
+
+        base.OnPointerMoved(args);
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs args)
+    {
+        base.OnPointerReleased(args);
+        CancelDrag();
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs args)
+    {
+        base.OnPointerCaptureLost(args);
+
+        // TODO: We really need to handle this, but this fires in cases I don't think it should
+        // 1- Mouse Button Release
+        // 2- Start of DragDrop
+    }
+    
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        _parent.RemoveHandler(DragDrop.DragLeaveEvent, OnParentDragEnter);
+        _parent = null;
+    }
+
+    private async void BeginDragReorder()
+    {
+        var package = new DataPackage();
+        DragItemsStartingEventArgs dragArgs = null;
+        object[] dragItems = null;
+        IDisposable opacity = null;
+        bool canReorder = CanReorderItems;
+        bool canDrag = CanDragItems;
+
+        if (canDrag)
+        {
+            dragItems = new object[] { ItemsView.GetAt(_dragIndex) };
+            dragArgs = new DragItemsStartingEventArgs { Items = dragItems, Data = package };
+            DragItemsStarting?.Invoke(this, dragArgs);
+
+            if (dragArgs.Cancel)
+            {
+                CancelDrag();
+                return;
+            }
+
+            _isInDrag = true;
+        }
+
+        if (canReorder)
+        {
+            // This is reorder only. We will handle this case ourselves
+            // WinUI will allow you to start the drag operation even if the underlying
+            // source is not INCC, which to me doesn't seem right. So...
+            // If TabItems are in use, we'll allow it b/c that is INCC
+            // If TabItemsSource is in use, we'll check if its INCC and only allow it if it is
+            // In addition, if user has disabled this as a DropTarget, reject
+
+            if (!DragDrop.GetAllowDrop(this))
+            {
+                CancelDrag();
+                Logger.TryGet(LogEventLevel.Debug, "TabView")?
+                    .Log("TabView", "User disabled this TabView as as drop target - canceling drag");
+                return;
+            }
+
+            // Note: That Avalonia also has the restriction that INCC collections must also implement
+            // the non-generic IList, so we'll also check the IsReadOnly property
+            var src = ItemsSource;
+            if (src != null && (src is not INotifyCollectionChanged || (src is IList l && l.IsReadOnly)))
+            {
+                CancelDrag();
+                Logger.TryGet(LogEventLevel.Debug, "TabView")?
+                    .Log("TabView", "Attempted to initiate Drag/Reorder without INCC / mutable collection");
+                return;
+            }
+
+            opacity = _dragItem.SetValue(OpacityProperty, 0, BindingPriority.Animation);
+
+            // Cache the locations of all containers before we start for reorder hints
+            _isInReorder = true;
+            _isDraggingOverSelf = true;
+        }
+
+        var effects = dragArgs?.Data.RequestedOperation ?? DragDropEffects.Move;
+
+        var dropResult = await DragDrop.DoDragDropAsync(_initArgs, package, effects);
+
+        if (_isInReorder)
+        {
+            opacity?.Dispose();
+            _isInReorder = false;
+        }
+
+        if (_isInDrag)
+        {
+            var completedArgs = new DragItemsCompletedEventArgs(dropResult, dragItems);
+            DragItemsCompleted?.Invoke(this, completedArgs);
+            _isInDrag = false;
+        }
+
+        CancelDrag();
+        _liveReorderHelper?.ClearContainerBoundsCache(true);
+    }
+
+    private void OnListViewDragOver(object sender, DragEventArgs e)
+    {
+        // OLE DragDrop seems to fire on a Timer which means we get a constant stream
+        // of DragOver events. WinRT DnD doesn't do this. The issue is in the live reorder
+        // system where constant events constantly restart the timer so it never actually
+        // triggers. So to prevent that, filter the pointer and only proceed with drag
+        // if the pointer location changes
+        if (_lastDragOverPoint == null)
+        {
+            _lastDragOverPoint = e.GetPosition(this);
+        }
+        else
+        {
+            var pt = e.GetPosition(this);
+            if (double.Abs(pt.X - _lastDragOverPoint.Value.X) < 1e-5 &&
+                double.Abs(pt.Y - _lastDragOverPoint.Value.Y) < 1e-5)
+            {
+                return;
+            }
+            _lastDragOverPoint = pt;
+        }
+
+        bool canReorder = CanReorderItems;
+        bool isInReorderFromExternalSource = (!_isDraggingOverSelf && canReorder);
+
+        if (!_isDragWithinTabStrip)
+        {
+            _isDragWithinTabStrip = true;
+            DragEnter?.Invoke(this, e);
+        }
+        else
+        {
+            // According to WinUI, TabStripDragOver doesn't fire if reordering is active
+            // even if CanDragTabs is true - so only raise if we're only dragging items
+            if (!_isInReorder)
+                DragOver?.Invoke(this, e);
+
+            // If this ListView initiated drag drop, _dragItem will be set
+            _isDraggingOverSelf = _dragItem != null;            
+        }
+                
+        Process(_isInReorder, canReorder, e);
+                
+        if (_isInReorder || isInReorderFromExternalSource)
+        {
+            _liveReorderHelper ??= new LiveReorderHelper(this);
+            _liveReorderHelper.ProcessLiveReorder(e, _dragIndex);
+        }
+
+        static void Process(bool isInReorder, bool canReorder, DragEventArgs args)
+        {
+            // Let the user handle & set drag effects first, if left unhandled,
+            // set a move operation on the args if reordering
+            // See ListViewBase::OnDragOver in WinUI
+            if (!args.Handled)
+            {
+                // Reorder operations have this
+                var effects = isInReorder || canReorder ? DragDropEffects.Move : DragDropEffects.None;
+                args.DragEffects &= effects;
+            }            
+        }
+    }
+
+    // This is actually DragLeave for us
+    private void OnParentDragEnter(object sender, DragEventArgs e)
+    {
+        if (_isDragWithinTabStrip)
+        {
+            var bnds = new Rect(Bounds.Size);
+            var pt = e.GetPosition(this);
+            if (!bnds.Contains(pt))
+            {
+                _isDragWithinTabStrip = false;
+                _isDraggingOverSelf = false;
+                _liveReorderIndices = default;
+                _liveReorderHelper?.ResetAllItemsForLiveReorder();
+                DragLeave?.Invoke(this, e);
+            }
+        }        
+    }
+
+    private void OnListViewDrop(object sender, DragEventArgs e)
+    {
+        if (e.Handled)
+            return;
+
+        if (DropCausesReorder())
+        {
+            var pt = e.GetPosition(this);
+            OnReorderDrop(pt);
+
+            e.DragEffects = DragDropEffects.Move;
+            e.Handled = true;
+        }
+        else
+        {
+            _liveReorderHelper?.ResetAllItemsForLiveReorder();
+        }
+
+        Drop?.Invoke(this, e);
+    }
+
+    private void CancelDrag()
+    {
+        _initArgs = null;
+        _initialPoint = null;
+        _isInDrag = _isInReorder = false;
+        _dragIndex = -1;
+        _dragItem = null;
+        _isDraggingOverSelf = false;
+        _lastDragOverPoint = null;
+        _isDragWithinTabStrip = false;
+        _liveReorderHelper?.ResetAllItemsForLiveReorder();
+    }
+
+    private bool DropCausesReorder()
+    {
+        if (_isDraggingOverSelf)
+        {
+            return CanReorderItems && DragDrop.GetAllowDrop(this);
+        }
+
+        return false;
+    }
+
+    private void OnReorderDrop(Point dropPoint)
+    {
+        // Container & original index - TabView does not support multi-item drag
+        // so we don't need anything else here
+        var dragItem = _dragItem;
+        var dragIndex = _dragIndex;
+        bool isDragItemFocused = dragItem.IsFocused;
+        bool isDragItemSelected = dragItem.IsSelected;
+
+        var insertIndex = _liveReorderHelper.GetInsertionIndexForLiveReorder();
+        _liveReorderHelper.ResetAllItemsForLiveReorder();
+
+        if (dragIndex == insertIndex)
+            return;
+
+        if (insertIndex == -1)
+        {
+            insertIndex = _liveReorderHelper.GetClosestElement(dropPoint, true);
+        }
+        
+        // dragItem is the container, we need the actual data item here
+        var data = ItemFromContainer(dragItem);
+
+        if (dragIndex < insertIndex)
+        {
+            insertIndex--;
+        }
+
+        var itemsSource = ItemsSource;
+        // Avalonia enforces the constraint that INCC must be IList, so this is safe
+        if (itemsSource is IList l)
+        {
+            try
+            {
+                // In the event the user has a list that isn't mutable and we got to this
+                // point somehow (we check when reorder starts), don't crash the app
+                // Just silently fail here
+
+                l.RemoveAt(dragIndex);
+                l.Insert(insertIndex, data);
+            }
+            catch { }
+        }
+        else if (itemsSource == null)
+        {
+            var items = Items;
+            try
+            {
+                items.RemoveAt(dragIndex);
+                items.Insert(insertIndex, data);
+            }
+            catch { }
+        }
+
+        // Note that _dragItem is no longer valid since the container
+        // may have changed, grab the new container from insertIndex
+        
+        UpdateLayout(); // Force an update so ScrollIntoView works
+
+        ScrollIntoView(insertIndex);
+
+        if (isDragItemFocused)
+        {
+            // If the old drag item was focused, we should refocus it
+            if (ContainerFromIndex(insertIndex) is Control c)
+            {
+                c.Focus();
+            }
+        }
+
+        if (isDragItemSelected)
+        {
+            SelectedIndex = insertIndex;
+        }
+    }
+
+    //private void CacheContainerBounds()
+    //{
+    //    Debug.WriteLine("CACHING CONTAINER BOUNDS");
+    //    // Because reorder will arrange the containers in new places
+    //    // the Bounds on the container may not actually reflect where
+    //    // the item actually is. In WinUI, ModernCollectionBasePanel's 
+    //    // ContainerManager caches arrange rects and are used for estimation
+    //    // APIs. Here we are mimicing that
+    //    // This must be called at the start of drag/drop, when the auto scroll
+    //    // of the scrollviewer stops, or when we first drag onto the TabView
+    //    // if that TabView didn't start the dragdrop operation
+
+    //    var panel = ItemsPanelRoot;
+    //    if (panel is VirtualizingStackPanel vsp)
+    //    {
+    //        var firstRealized = vsp.FirstRealizedIndex;
+    //        var lastRealized = vsp.LastRealizedIndex;
+    //        _cachedContainerBounds ??= new List<Rect>((lastRealized - firstRealized) + 1);
+
+    //        for (int i = firstRealized; i <= lastRealized; i++)
+    //        {
+    //            var cont = ContainerFromIndex(i);
+    //            _cachedContainerBounds.Add(cont.Bounds);
+    //        }
+    //    }
+    //    else if (panel is StackPanel sp)
+    //    {
+    //        _cachedContainerBounds ??= new List<Rect>(ItemCount);
+    //        // Stack Panels don't virtualize and arrange in order so this is safe
+    //        for (int i = 0; i < ItemCount; i++)
+    //        {
+    //            _cachedContainerBounds.Add(panel.Children[i].Bounds);
+    //        }
+    //    }
+    //}
+
+    //private void ClearContainerBoundsCache(bool clearCompletely = false)
+    //{
+    //    // Clear container bounds
+    //    _cachedContainerBounds?.Clear();
+
+    //    // Don't keep this memory when not in use, so when drag drop operation
+    //    // ceases completely, set it to null
+    //    if (clearCompletely)
+    //        _cachedContainerBounds = null;
+    //}
+
+    //private void ProcessLiveReorder(DragEventArgs args)
+    //{
+    //    _liveReorderHelper ??= new LiveReorderHelper(this);
+
+    //    var orientation = GetLogicalOrientation();
+    //    if (orientation == null)
+    //        return; // We're in a panel we don't know how to deal with, exit out
+        
+    //    var helper = _liveReorderHelper;
+
+    //    if (helper.ShouldCacheContainerBounds())
+    //        helper.CacheContainerBounds();
+
+
+
+
+    //    // OLD --------------------------------------------------------
+    //    var orientation = GetLogicalOrientation();
+    //    if (orientation == null)
+    //        return; // We're in a panel we don't know how to deal with, exit out
+
+    //    // If we don't have a cache of the current realized container bounds,
+    //    // create it now before we start doing anything. This happens on first
+    //    // startup, but can also be reset through the drag operation (autoscroll,
+    //    // drag outside, etc). The cache is cleared on ResetAllItemsForLiveReorder()
+    //    if (_cachedContainerBounds == null || _cachedContainerBounds.Count == 0)
+    //    {
+    //        CacheContainerBounds();
+    //    }
+        
+    //    int draggedIndex = _dragIndex;
+    //    int insertionIndex = -1;
+    //    int dragOverIndex = GetClosestElement(args.GetPosition(this));// IndexFromContainer(currentItem); // The raw item index under the pointer
+    //    var previousDragOverIndex = _liveReorderIndices.draggedOverIndex;
+    //    int itemsCount = ItemCount;
+
+    //    if (draggedIndex == -1)
+    //        draggedIndex = itemsCount;
+
+    //    if (previousDragOverIndex == -1)
+    //    {
+    //        previousDragOverIndex = draggedIndex;
+    //    }
+
+    //    // The estimated insertion index in the panel
+    //    insertionIndex = GetClosestElement(args.GetPosition(this), true /*requestingInsertionIndex*/);
+
+    //    if (draggedIndex == itemsCount && insertionIndex == itemsCount - 1)
+    //    {
+    //        // If we didn't start in this TabView, see if the index is actually the end or -1
+    //        var spLastElement = ContainerFromIndex(insertionIndex);
+    //        if (spLastElement is TabViewItem tvi)
+    //        {
+    //            if (IsInBottomHalf(args.GetPosition(spLastElement), new Rect(spLastElement.Bounds.Size), orientation.Value))
+    //            {
+    //                insertionIndex = itemsCount;
+    //            }
+    //        }
+    //    }
+
+    //    //var old = dragOverIndex; // Keep this here for debug purposes, if needed
+    //    if (insertionIndex == itemsCount)
+    //    {
+    //        dragOverIndex = itemsCount;
+    //    }
+    //    else
+    //    {
+    //        // This adjusts the dragover index based on the direction of the drag
+    //        dragOverIndex = GetDragOverIndex(dragOverIndex, insertionIndex, previousDragOverIndex);
+    //    }
+
+    //    // Debug.WriteLine($"\tLive Reorder DragOverIndex: {dragOverIndex} || DragOverBeforeAdj: {old} || InsertionIndex {insertionIndex} || PrevDragOverIndex {previousDragOverIndex}");
+
+    //    _liveReorderIndices = new LiveReorderIndices(draggedIndex, dragOverIndex, itemsCount);
+
+    //    if (previousDragOverIndex == draggedIndex || previousDragOverIndex != dragOverIndex)
+    //    {
+    //        StartLiveReorderTimer();
+    //    }
+
+    //    static bool IsInBottomHalf(Point pt, Rect rc, Orientation orientation)
+    //    {
+    //        if (orientation == Orientation.Horizontal)
+    //        {
+    //            return (pt.X - rc.Left) >= rc.Width * 0.5;
+    //        }
+    //        else
+    //        {
+    //            return (pt.Y - rc.Top) >= rc.Height * 0.5;
+    //        }
+    //    }
+
+    //    static int GetDragOverIndex(int closestElementIndex, int insertionIndex, int previousDragOverIndex)
+    //    {
+    //        int dragOverIndex = closestElementIndex;
+
+    //        if (insertionIndex == closestElementIndex)
+    //        {
+    //            if (previousDragOverIndex < insertionIndex)
+    //            {
+    //                --dragOverIndex;
+    //            }
+    //        }
+    //        else
+    //        {
+    //            if (previousDragOverIndex >= insertionIndex)
+    //            {
+    //                ++dragOverIndex;
+    //            }
+    //        }
+
+    //        return dragOverIndex;
+    //    }
+    //}
+
+    //private int GetClosestElement(Point dragPoint, bool requestingInsertionIndex = false)
+    //{
+    //    // This estimates the container index given the current pointer position
+    //    var panel = ItemsPanelRoot;
+    //    if (panel is VirtualizingStackPanel vsp)
+    //    {
+    //        var firstRealized = vsp.FirstRealizedIndex;
+    //        var lastRealized = vsp.LastRealizedIndex;
+    //        var orientation = vsp.Orientation;
+    //        var movedItems = _movedItems.AsSpan();
+    //        int closestIndex = -1;
+    //        double closestDist = double.PositiveInfinity;
+    //        Rect closestItemRect = default;
+
+    //        // Loop over the currently realized items to find the closest
+    //        for (int i = firstRealized; i <= lastRealized; i++)
+    //        {
+    //            // If the item is currently in our MovedItems list, it may not be 
+    //            // where it usually is, so we can't test the actual Bounds or we'll
+    //            // estimate the wrong index, but we have the original bounds saved
+    //            Rect rc = _cachedContainerBounds[i - firstRealized];
+    //            double dist;
+
+    //            if (orientation == Orientation.Horizontal)
+    //            {
+    //                double cx = double.Clamp(dragPoint.X, rc.X, rc.Right);
+    //                dist = double.Abs(dragPoint.X - cx);
+    //            }
+    //            else
+    //            {
+    //                double cy = double.Clamp(dragPoint.Y, rc.Y, rc.Bottom);
+    //                dist = double.Abs(dragPoint.Y - cy);
+    //            }
+
+    //            if (dist < closestDist)
+    //            {
+    //                closestDist = dist;
+    //                closestIndex = i;
+    //                closestItemRect = rc;
+    //            }
+    //        }
+
+    //        if (requestingInsertionIndex)
+    //        {
+    //            if (orientation == Orientation.Horizontal)
+    //            {
+    //                if (dragPoint.X - closestItemRect.X >= closestItemRect.Width * 0.5)
+    //                {
+    //                    closestIndex++;
+    //                }
+    //            }
+    //            else if (orientation == Orientation.Vertical)
+    //            {
+    //                if (dragPoint.Y - closestItemRect.Y >= closestItemRect.Height * 0.5)
+    //                {
+    //                    closestIndex++;
+    //                }
+    //            }
+    //        }
+
+    //        return closestIndex;
+    //    }
+    //    else if (panel is StackPanel sp)
+    //    {
+    //        //var children = sp.Children;
+    //        //var orientation = sp.Orientation;
+    //        //var movedItems = _movedItems.AsSpan();
+
+    //        //for (int i = 0; i < children.Count; i++)
+    //        //{
+    //        //    // If the item is currently in our MovedItems list, it may not be 
+    //        //    // where it usually is, so we can't test the actual Bounds or we'll
+    //        //    // estimate the wrong index, but we have the original bounds saved
+    //        //    if (IsInMovedItems(movedItems, i, out var rc))
+    //        //    {
+    //        //        if (rc.Contains(dragPoint))
+    //        //        {
+    //        //            return i;
+    //        //        }
+    //        //    }
+    //        //    else
+    //        //    {
+    //        //        // The item is not in moved items, so it is safe to use the Bounds directly
+    //        //        if (children[i].Bounds.Contains(dragPoint))
+    //        //        {
+    //        //            return i;
+    //        //        }
+    //        //    }
+    //        //}
+    //    }
+
+    //    return -1;
+
+    //    //static bool IsInMovedItems(ReadOnlySpan<MovedItem> items, int sourceIndex, out Rect srcRect)
+    //    //{
+    //    //    foreach (var item in items)
+    //    //    {
+    //    //        if (item.sourceIndex == sourceIndex)
+    //    //        {
+    //    //            srcRect = item.sourceRect;
+    //    //            return true;
+    //    //        }
+    //    //    }
+
+    //    //    srcRect = default;
+    //    //    return false;
+    //    //}
+    //}
+
+    //private void StartLiveReorderTimer()
+    //{
+    //    StopLiveReorderTimer();
+
+    //    EnsureLiveReorderTimer();
+
+    //    _liveReorderTimer.Interval = TimeSpan.FromMilliseconds(200);
+    //    _liveReorderTimer.Start();
+    //}
+
+    //private void EnsureLiveReorderTimer()
+    //{
+    //    if (_liveReorderTimer == null)
+    //    {
+    //        _liveReorderTimer = new DispatcherTimer();
+    //        _liveReorderTimer.Tick += LiveReorderTimerTickHandler;
+    //    }
+    //}
+
+    //private void LiveReorderTimerTickHandler(object sender, EventArgs e)
+    //{
+    //    StopLiveReorderTimer();
+
+    //    Debug.Assert(_liveReorderIndices.draggedItemIndex != -1);
+
+    //    var orientation = GetLogicalOrientation().Value;
+
+    //    using var newItems = new PooledList<MovedItem>();
+    //    using var newItemsToMove = new PooledList<MovedItem>();
+    //    using var oldItemsToMoveBack = new PooledList<MovedItem>();
+
+    //    GetNewMovedItemsForLiveReorder(newItems);
+
+    //    _movedItems.Update(orientation == Orientation.Vertical, newItems, newItemsToMove, oldItemsToMoveBack);
+
+    //    MoveItemsForLiveReorder(false /*areNewItems*/, oldItemsToMoveBack);
+
+    //    MoveItemsForLiveReorder(true, newItemsToMove);
+
+    //    foreach (var item in _movedItems.AsSpan())
+    //    {
+    //        Debug.WriteLine($"\t MovedItems: {item.sourceIndex} -> {item.destinationIndex} || {item.sourceRect} -> {item.destinationRect}");
+    //    }
+    //}
+
+    //private void GetNewMovedItemsForLiveReorder(IList<MovedItem> newItems)
+    //{
+    //    int startIndex = _liveReorderIndices.draggedItemIndex;
+    //    int endIndex = _liveReorderIndices.draggedOverIndex;
+    //    int increment = (startIndex < endIndex) ? 1 : -1;
+
+    //    // Debug.WriteLine($"GetNewMovedItems: {startIndex} -> {endIndex}");
+
+    //    newItems.Clear();
+    //    for (int i = startIndex; i != endIndex; i += increment)
+    //    {
+    //        int targetIndex = i - increment;
+
+    //        if (i == startIndex)
+    //        {
+    //            targetIndex = -1;
+    //        }
+
+    //        AddNewItemForLiveReorder(i, targetIndex, newItems, _liveReorderIndices.itemsCount, this);
+    //    }
+
+    //    AddNewItemForLiveReorder(endIndex, endIndex - increment, newItems, _liveReorderIndices.itemsCount, this);
+
+    //   // Debug.WriteLine($"TotalNewItems: {newItems.Count}");
+
+    //    static void AddNewItemForLiveReorder(int sourceIndex, int targetIndex, IList<MovedItem> newItems, 
+    //        int itemsCount, TabViewListView host)
+    //    {
+    //        Rect src = default;
+    //        Rect target = default;
+
+    //        if (sourceIndex != targetIndex)
+    //        {
+    //            src = GetLayoutSlot(host, sourceIndex);
+    //        }
+
+    //        if (targetIndex != -1 && targetIndex != itemsCount)
+    //        {
+    //            target = GetLayoutSlot(host, targetIndex);
+    //        }
+
+    //        newItems.Add(new MovedItem(sourceIndex, targetIndex, src, target));
+    //    }
+
+    //    static Rect GetLayoutSlot(TabViewListView host, int index)
+    //    {
+    //        // make sure we grab the original bounds. If virtualizing, translate
+    //        // to index in our container cache
+    //        var adjIndex = host.ItemsPanelRoot is VirtualizingStackPanel vsp ?
+    //            index - vsp.FirstRealizedIndex : index;
+
+    //        if (adjIndex >= host._cachedContainerBounds.Count)
+    //            return default;
+
+    //        return host._cachedContainerBounds[adjIndex];
+    //        //return host.ContainerFromIndex(index)?.Bounds ?? default;
+    //    }
+    //}
+
+    //private void MoveItemsForLiveReorder(bool areNewItems, PooledList<MovedItem> newItemsToMove)
+    //{
+    //    Rect rc;
+    //    foreach (var item in newItemsToMove.AsSpan())
+    //    {
+    //        var container = ContainerFromIndex(item.sourceIndex);
+
+    //        if (container is Control c)
+    //        {
+    //            if (areNewItems)
+    //            {
+    //                rc = item.destinationRect;
+    //            }
+    //            else
+    //            {
+    //                rc = item.sourceRect;
+    //            }
+
+    //            c.Arrange(rc);
+    //        }
+    //    }
+    //}
+
+    //private void ResetAllItemsForLiveReorder()
+    //{
+    //    StopLiveReorderTimer();
+
+    //    foreach (var item in _movedItems.AsSpan())
+    //    {
+    //        if (item.destinationIndex != -1)
+    //        {
+    //            var cont = ContainerFromIndex(item.sourceIndex);
+    //            if (cont is Control c)
+    //            {
+    //                c.Arrange(item.sourceRect);
+    //            }
+    //        }
+    //    }
+
+    //    _movedItems.Clear();
+    //    _liveReorderIndices = new LiveReorderIndices(-1,-1,-1);
+    //    ClearContainerBoundsCache();
+    //}
+
+    //private void StopLiveReorderTimer()
+    //{
+    //    _liveReorderTimer?.Stop();
+    //}
+
+    internal Orientation? GetLogicalOrientation()
+    {
+        var panel = ItemsPanelRoot;
+        if (panel is VirtualizingStackPanel vsp)
+            return vsp.Orientation;
+        else if (panel is StackPanel sp)
+            return sp.Orientation;
+
+        return null;
+    }
+
+    internal void HandleTabStripLocationChanged(TabViewTabStripLocation newLocation, string oldClass, string newClass)
+    {
+        if (oldClass != null)
+            PseudoClasses.Set(oldClass, false);
+
+        PseudoClasses.Set(newClass, true);
+
+        if (Scroller != null)
+        {
+            if (oldClass != null)
+                ((IPseudoClasses)Scroller.Classes).Set(oldClass, false);
+
+            ((IPseudoClasses)Scroller.Classes).Set(newClass, true);
+        }
+
+        var panel = ItemsPanelRoot;
+        if (panel != null)
+        {
+            foreach (var item in panel.Children)
+            {
+                if (item is TabViewItem tvi)
+                {
+                    tvi.HandleTabStripLocationChanged(newLocation);
+                }
+            }
+
+            // If we have a Stacking Panel, adjust its orientation
+            // If user uses any other type of panel, do nothing & log warning
+            // User will need to monitor changes and adjust their panel accordingly
+            if (panel is VirtualizingStackPanel vsp)
+            {
+                if (vsp.Orientation == Orientation.Vertical &&
+                    (newLocation == TabViewTabStripLocation.Top || newLocation == TabViewTabStripLocation.Bottom))
+                {
+                    vsp.Orientation = Orientation.Horizontal;
+                }
+                else if (vsp.Orientation == Orientation.Horizontal &&
+                    (newLocation == TabViewTabStripLocation.Left || newLocation == TabViewTabStripLocation.Right))
+                {
+                    vsp.Orientation = Orientation.Vertical;
+                }
+            }
+            else if (panel is StackPanel sp)
+            {
+                if (sp.Orientation == Orientation.Vertical &&
+                    (newLocation == TabViewTabStripLocation.Top || newLocation == TabViewTabStripLocation.Bottom))
+                {
+                    sp.Orientation = Orientation.Horizontal;
+                }
+                else if (sp.Orientation == Orientation.Horizontal &&
+                    (newLocation == TabViewTabStripLocation.Left || newLocation == TabViewTabStripLocation.Right))
+                {
+                    sp.Orientation = Orientation.Vertical;
+                }
+            }
+            else
+            {
+                Logger.Sink?.Log(LogEventLevel.Warning, "TabView", this,
+                    "User has TabView with non-stacking panel, which may not be compatible with TabStripLocation changes");
+            }
+        }
+    }
 
     private void UpdateBottomBorderVisualState()
     {
         PseudoClasses.Set(s_pcLeftShort, SelectedIndex == 0);
         PseudoClasses.Set(s_pcRightShort, SelectedIndex == ItemsView.Count - 1);
+    }
+
+    private void OnItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        var tv = this.FindAncestorOfType<TabView>();
+        tv?.OnItemsChanged(e);
+    }
+
+    private void UpdateDragInfo()
+    {
+        FAUISettings.GetSystemDragSize(VisualRoot.RenderScaling, out _cxDrag, out _cyDrag);
     }
 
     private TabViewItem _dragItem;
@@ -234,9 +1115,25 @@ public sealed class TabViewListView : ListBox
     private Point? _initialPoint;
     private double _cxDrag = double.NaN;
     private double _cyDrag = double.NaN;
+    private Control _parent;
+    private bool _isDragWithinTabStrip;
+    // True if there is a drag drop operation started by this listview
+    private bool _isDraggingOverSelf;
 
-    //private object _currentItem;
+    private LiveReorderHelper _liveReorderHelper;
+    private LiveReorderIndices _liveReorderIndices = new LiveReorderIndices(-1,-1,-1);
+    private DispatcherTimer _liveReorderTimer;
+    private readonly MovedItems _movedItems = new MovedItems();
+    private List<Rect> _cachedContainerBounds;
+    private Point? _lastDragOverPoint;
 
+    // For 12.0/v3 - Avalonia has decided to make the decision that the lowest common denominator
+    // in the platform backends decides the entire public API. As part of this, DoDragDrop now
+    // requires the initial pressed args, so we have to store them away so we can start DragDrop.
+    // I tried to object, and failed (https://github.com/AvaloniaUI/Avalonia/pull/20988)
+    // And you guessed it, freakin' Wayland
+    private PointerPressedEventArgs _initArgs;
+    
     private static Popup _dragReorderPopup;
     private Point _popupOffset;
     private object _dragItemToolTip;
@@ -257,4 +1154,6 @@ public sealed class TabViewListView : ListBox
         ScrollStarted,
         ScrollEnded,
     }
+
+
 }

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Xml.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
@@ -10,6 +12,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using FluentAvalonia.Core;
@@ -24,28 +27,24 @@ namespace FluentAvalonia.UI.Controls.Primitives;
 /// </remarks>
 [PseudoClasses(s_pcReorder)]
 [TemplatePart(s_tpScrollViewer, typeof(ScrollViewer))]
-public class TabViewListView : ListBox
+public sealed class TabViewListView : ListBox
 {
     public TabViewListView()
     {
-        AddHandler(PointerPressedEvent, OnPointerPressedPreview, RoutingStrategies.Tunnel);
-
-        // So... Avalonia doesn't put the Drag/Drop events in a control base class like WPF/UWP does
-        // (UIElement), which means, if we take this subscription here, there is a good chance this
-        // will get the event first before anything else (in this case the TabView), which means 
-        // we have no way of knowing how the user wants the drag drop interaction to work.
-        // So, we have to handle these events here, and translate them into our own events that can
-        // then be subscribed to by the TabView - we will only make the CLR events, as we don't 
-        // need the full routed event, and we will mark these handled
-        // As the TabView only needs DragOver (the most important and Drop, we will only do those)
-        AddHandler(DragDrop.DragOverEvent, OnDragOver, RoutingStrategies.Bubble, true);
-        AddHandler(DragDrop.DropEvent, OnDrop, RoutingStrategies.Bubble, true);
-
-        AddHandler(DragDrop.DragEnterEvent, OnDragEnter, RoutingStrategies.Bubble, true);
-        AddHandler(DragDrop.DragLeaveEvent, OnDragLeave, RoutingStrategies.Bubble, true);
-
         ItemsView.CollectionChanged += OnItemsChanged;
+
+
+        Tapped += (s, e) =>
+        {
+            if (e.Source is Visual v && v.FindAncestorOfType<TabViewItem>(true) is TabViewItem tvi)
+            {
+                var index = IndexFromContainer(tvi);
+                UpdateSelection(index, true);
+                e.Handled = true;
+            }
+        };
     }
+
 
     /// <summary>
     /// Defines the <see cref="CanReorderItems"/> property
@@ -69,7 +68,7 @@ public class TabViewListView : ListBox
     }
 
     /// <summary>
-    /// Gets or sets whether dragging items is supported on this listview
+    /// Gets or sets whether dragging items is supported on this ListView
     /// </summary>
     public bool CanDragItems
     {
@@ -78,10 +77,6 @@ public class TabViewListView : ListBox
     }
 
     internal ScrollViewer Scroller { get; private set; }
-
-    // See constructor for why we have these events
-    public event EventHandler<DragEventArgs> DragOver;
-    public event EventHandler<DragEventArgs> Drop;
 
     /// <summary>
     /// Occurs when a drag operation that involves one of the items in the view is initiated.
@@ -102,21 +97,17 @@ public class TabViewListView : ListBox
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-        if (change.Property == BoundsProperty)
+
+        if (change.Property == SelectedIndexProperty)
         {
-            double viewportWidth = Scroller.Viewport.Width;
-            _noAutoScrollRect = new Rect(viewportWidth * 0.1, 0,
-                viewportWidth - (viewportWidth * 0.1), Scroller.Viewport.Height);
+            UpdateBottomBorderVisualState();
         }
     }
 
     private void OnItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
         var tv = this.FindAncestorOfType<TabView>();
-        if (tv != null)
-        {
-            tv.OnItemsChanged(e);
-        }
+        tv?.OnItemsChanged(e);
     }
 
     protected override bool NeedsContainerOverride(object item, int index, out object recycleKey)
@@ -129,7 +120,7 @@ public class TabViewListView : ListBox
     protected override Control CreateContainerForItemOverride(object item, int index, object recycleKey)
     {
         var cont = this.FindDataTemplate(item, ItemTemplate)?.Build(item);
-
+        
         if (cont is TabViewItem tvi)
         {
             tvi.IsContainerFromTemplate = true;
@@ -139,9 +130,12 @@ public class TabViewListView : ListBox
         return new TabViewItem();
     }
 
-    protected override void PrepareContainerForItemOverride(Control element, object item, int index)
+    protected override void ContainerForItemPreparedOverride(Control container, object item, int index)
     {
-        var tvi = element as TabViewItem;
+        // NOTE: BE CAREFUL HERE! Avalonia has two separate preparation events
+        // PrepareContainerForItemOverride - does not have the container connected yet
+        // This one does - I've raised an issue b/c this is dumb
+        var tvi = container as TabViewItem;
 
         // WinUI: Due to virtualization, a TabViewItem might be recycled to display a different tab data item.
         //        In that case, there is no need to set the TabWidthMode of the TabViewItem or its parent TabView
@@ -151,7 +145,7 @@ public class TabViewListView : ListBox
         //        already been set.
         if (tvi.ParentTabView == null)
         {
-            var parentTV = element.FindAncestorOfType<TabView>();
+            var parentTV = container.FindAncestorOfType<TabView>();
             if (parentTV != null)
             {
                 tvi.OnTabViewWidthModeChanged(parentTV.TabWidthMode);
@@ -161,8 +155,11 @@ public class TabViewListView : ListBox
 
         // Special b/c we use the header and not Content. Somehow this *just works* in
         // WinUI b/c they don't have to do this.
-        if (element == item || tvi.IsContainerFromTemplate)
+        if (container == item || tvi.IsContainerFromTemplate)
+        {
+            base.ContainerForItemPreparedOverride(container, item, index);
             return;
+        }
 
         tvi.Header = item;
 
@@ -171,533 +168,14 @@ public class TabViewListView : ListBox
         if (itemTemplate != null)
             tvi.HeaderTemplate = itemTemplate;
 
-        // Don't call base here, we've done everything we need
-    }
-       
-    private void OnPointerPressedPreview(object sender, PointerPressedEventArgs args)
-    {
-        if (CanDragItems || CanReorderItems)
-        {
-            if (Presenter.Panel is not TabViewStackPanel)
-                return;
-
-            var currentPoint = args.GetCurrentPoint(this);
-            if (currentPoint.Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed)
-            {
-                _initialPoint = args.GetPosition(this);
-                _dragItem = (args.Source as Visual).FindAncestorOfType<TabViewItem>(true);
-                _dragIndex = IndexFromContainer(_dragItem);
-
-                if (double.IsNaN(_cxDrag))
-                {
-                    UpdateDragInfo();
-                }
-            }
-        }
+        base.ContainerForItemPreparedOverride(container, item, index);
     }
 
-    protected override void OnPointerMoved(PointerEventArgs e)
+
+    private void UpdateBottomBorderVisualState()
     {
-        if (_initialPoint.HasValue)
-        {
-            if (!_isInReorder)
-            {
-                // We have a possible drag / reorder operation under way, we first need to see
-                // if we meet the requirements
-                var currentPoint = e.GetCurrentPoint(this);
-                var delta = _initialPoint.Value - currentPoint.Position;
-
-                if (Math.Abs(delta.X) > _cxDrag || Math.Abs(delta.Y) > _cyDrag)
-                {
-                    // Possible actions
-                    // 1 - CanDragItems && CanReorderItems
-                    //         Let DragDrop handle behavior. We can both reorder and drag. This TabView will
-                    //         give visual feedback as the item is dragged and data is sent to DragDrop
-                    // 2 - CanDragItems && !CanReorderItems
-                    //         Dragging is permitted, but we can't reorder this TabView. This TabView will not 
-                    //         accept the drop target and will give no visual feedback as the item is dragged.
-                    //         But the data is sent to DragDrop and other TabView's can pick it up
-                    // 3 - !CanDragItems && CanReorderItems
-                    //         Dragging is only permitted in the context of this TabView to reorder the tabs.
-                    //         The TabView will display visual feedback as the tab is dragged, BUT the data
-                    //         is not sent to DragDrop and other TabViews will not respond
-                    // 4 - !CanDragItems && !CanReorderItems
-                    //         This case is handled in the PreviewPointerPressed handler. No dragging actions
-                    //         are permitted on this TabView
-
-                    if (!CanDragItems)
-                    {
-                        // This is a reorder action only (case 3)
-                        // Reorder only actions we handle ourselves
-                        _processReorder = true;
-                        BeginReorder(e);
-                        e.Handled = true;
-                    }
-                    else if (!CanReorderItems)
-                    {
-                        // This is a drag action only (case 2)
-                        // We hand this over to DragDrop
-
-                        BeginDragDrop(e, false);
-                        e.Handled = true;
-                        return;
-                    }
-                    else
-                    {
-                        // This is a full drag / reorder action (case 1)
-                        // We hand this over to DragDrop & will use the DragDrop handlers
-                        // to manage everything.
-                        BeginDragDrop(e, true);
-                        e.Handled = true;
-                        return;
-                    }
-                }
-            }
-            else if (!_isInDrag) // I didn't think PointerMoved worked during Drag, but somehow it is
-            {
-                var scrollCheck = CheckAutoScroll(e.GetPosition(Scroller));
-
-                switch (scrollCheck)
-                {
-                    case AutoScrollAction.ScrollStarted:
-                        // All reorder logic is disabled when auto scrolling, so reset the panel
-                        // to draw normally
-                        (ItemsPanelRoot as TabViewStackPanel).ClearReorder();
-                        break;
-
-                    case AutoScrollAction.ScrollEnded:
-                        (ItemsPanelRoot as TabViewStackPanel).EnterReorder(_dragIndex);
-                        break;
-
-                    default:
-                        // No DragDrop, we're just reordering this ListView
-                        HandleReorder(e.GetPosition(ItemsPanelRoot));
-                        break;
-                }
-
-                e.Handled = true;
-            }
-        }
-
-        base.OnPointerMoved(e);
-    }
-
-    protected override void OnPointerReleased(PointerReleasedEventArgs e)
-    {
-        base.OnPointerReleased(e);
-
-        if (_isInReorder)
-            EndReorder();
-
-        _initialPoint = null;
-        _dragItem = null;
-        _dragIndex = -1;
-    }
-
-    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
-    {
-        base.OnPointerCaptureLost(e);
-
-        // This is called as soon as DragDrop begins, make sure we don't do this in that
-        // case because we're in the middle of doing something
-        if (!_isInDrag)
-        {
-            if (_isInReorder)
-                EndReorder();
-
-            _initialPoint = null;
-            _dragItem = null;
-            _dragIndex = -1;
-        }
-    }
-
-    private void UpdateDragInfo()
-    {
-        FAUISettings.GetSystemDragSize(VisualRoot.RenderScaling, out _cxDrag, out _cyDrag);
-    }
-
-    private void BeginReorder(PointerEventArgs args)
-    {
-        if (_dragItem == null)
-        {
-            // Invalid state, but seems to only happen if you use lightning quick reflexes 
-            // to drag an item, so no error, but don't do anything
-            return;
-        }
-
-        PseudoClasses.Set(s_pcReorder, true);
-        // This triggers the ItemsPanel to enter reorder state which will insert a blank space
-        // where the current item in measured
-        (ItemsPanelRoot as TabViewStackPanel).EnterReorder(_dragIndex);
-        _isInReorder = true;
-
-        if (_dragReorderPopup == null)
-        {
-            _dragReorderPopup = new Popup
-            {
-                WindowManagerAddShadowHint = false,
-                PlacementTarget = this,
-                Placement = PlacementMode.Pointer
-            };
-
-            ((ISetLogicalParent)_dragReorderPopup).SetParent(this);
-        }
-
-        _dragReorderPopup.Child = new Rectangle
-        {
-            Fill = new VisualBrush
-            {
-                Visual = _dragItem,
-                Stretch = Stretch.None
-            },
-            Width = _dragItem.Bounds.Width,
-            Height = _dragItem.Bounds.Height,
-            Opacity = 0.5
-        };
-
-        _popupOffset = -args.GetPosition(_dragItem);
-
-        // Seems moving a popup window while in drag drop doesn't work
-        // as despite the configure position stuff getting called,
-        // the popup either remains in place or moves to the top of the
-        // screen...TODO: File bug report, for now disabling preview popup
-        // if dragdrop manages the drag/reorder operation
-        if (!_isInDrag && FAUISettings.UseTabViewDragReorderPreview())
-        {
-            _dragReorderPopup.HorizontalOffset = _popupOffset.X;
-            _dragReorderPopup.VerticalOffset = _popupOffset.Y;
-            _dragReorderPopup.IsOpen = true;
-        }
-
-        // We need to clear the tooltip here otherwise it will end up showing
-        // during the drag operation - and that's undesirable
-        // We'll store it so we can restore it later
-        _dragItemToolTip = ToolTip.GetTip(_dragItem);
-        if (ToolTip.GetIsOpen(_dragItem))
-        {
-            ToolTip.SetIsOpen(_dragItem, false);
-        }
-
-        ToolTip.SetTip(_dragItem, null);
-
-        // Capture the drag item so pointer events are transferred and will work outside of the window
-        if (!_isInDrag)
-            args.Pointer.Capture(_dragItem);
-    }
-
-    private void HandleReorder(Point panelPoint)
-    {
-        // No Visual effect on the drag source ListView
-        if (!CanReorderItems && _isInDrag)
-            return;
-
-        int currentDragIndex = _dragIndex;
-
-        if (ItemsPanelRoot.Bounds.Contains(panelPoint))
-        {
-            currentDragIndex = (ItemsPanelRoot as TabViewStackPanel)
-                .GetInsertionIndexFromPoint(panelPoint, _dragIndex);
-        }
-
-        (ItemsPanelRoot as TabViewStackPanel).ChangeReorderIndex(currentDragIndex);
-
-        if (!_isInDrag && _initialPoint.HasValue)
-        {
-            _dragReorderPopup.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(x =>
-            {
-                x.Offset = _popupOffset;
-            });
-            //var req = PopupPositionRequest.
-            //_dragReorderPopup.Host?
-            //    .ConfigurePosition(this, PlacementMode.Pointer, _popupOffset);
-        }
-    }
-
-    private void EndReorder()
-    {
-        PseudoClasses.Set(s_pcReorder, false);
-        if (_dragReorderPopup != null && _dragReorderPopup.IsOpen)
-        {
-            _dragReorderPopup.IsOpen = false;
-        }
-        _isInReorder = false;
-        var reorderIndex = (ItemsPanelRoot as TabViewStackPanel).ClearReorder();
-
-        // if we're reordering this listview, we do that automatically - no need for the user
-        // to handle this themselves
-        if (reorderIndex != -1 && _processReorder)
-        {
-            if (ItemsSource is IList l && l.Count > 0)
-            {
-                var oldItem = l[_dragIndex];
-                l.RemoveAt(_dragIndex);
-                l.Insert(reorderIndex, oldItem);
-            }
-
-            SelectedIndex = reorderIndex;
-            _processReorder = false;
-        }
-
-        // It seems if the ToolTip is open, changing its content leads to bad things
-        // Make sure it's hidden before we do anything
-        if (ToolTip.GetIsOpen(_dragItem))
-        {
-            ToolTip.SetIsOpen(_dragItem, false);
-        }
-        ToolTip.SetTip(_dragItem, _dragItemToolTip);
-    }
-
-    private async void BeginDragDrop(PointerEventArgs args, bool hasReorder)
-    {
-        // First fire DragItemsStarting
-        var disArgs = new DragItemsStartingEventArgs
-        {
-            Items = new[] { ItemsView.GetAt(_dragIndex) },
-            Data = new Data.DataPackage()
-        };
-        DragItemsStarting?.Invoke(this, disArgs);
-
-        if (disArgs.Cancel)
-        {
-            _initialPoint = null;
-            _dragItem = null;
-            _dragIndex = -1;
-            return;
-        }
-
-        _isInDrag = true;
-
-        var effects = disArgs.Data.RequestedOperation;
-
-        if (hasReorder)
-        {
-            _processReorder = true;
-            BeginReorder(args);
-            effects |= DragDropEffects.Move;
-        }
-        else
-        {
-            // We need to clear the tooltip here otherwise it will end up showing
-            // during the drag operation - and that's undesirable
-            // We'll store it so we can restore it later
-            _dragItemToolTip = ToolTip.GetTip(_dragItem);
-            if (ToolTip.GetIsOpen(_dragItem))
-            {
-                ToolTip.SetIsOpen(_dragItem, false);
-            }
-        }
-
-        var dropResult =
-            await DragDrop.DoDragDrop(args, disArgs.Data, effects);
-
-        _isInDrag = false;
-        if (hasReorder)
-        {
-            EndReorder();
-        }
-        else
-        {
-            (ItemsPanelRoot as TabViewStackPanel).ClearReorder();
-
-            if (ToolTip.GetIsOpen(_dragItem))
-            {
-                ToolTip.SetIsOpen(_dragItem, false);
-            }
-            ToolTip.SetTip(_dragItem, _dragItemToolTip);
-        }
-
-        DragItemsCompleted?.Invoke(this, new DragItemsCompletedEventArgs(dropResult, disArgs.Items));
-
-        _initialPoint = null;
-        _dragItem = null;
-        _dragIndex = -1;
-    }
-
-    private void OnDragEnter(object sender, DragEventArgs e)
-    {
-        // If dragging over a TabView strip that didn't initialize the DragDrop, and hasn't
-        // receieved any drag interaction, this will still be null - initialize now
-        //if (ItemsPanelRoot == null)
-        //    ItemsPanelRoot = (TabViewStackPanel)Presenter.Panel;
-
-        // If this is the TabViewListView spawning the DragDrop, so long as we can do drag drop,
-        // enable it on this ListView when move over it
-        if (_isInDrag)
-        {
-            e.DragEffects = DragDropEffects.Move | DragDropEffects.Copy | DragDropEffects.Link;
-        }
-
-        if (_isInReorder)
-        {
-            e.DragEffects |= DragDropEffects.Move;
-            (ItemsPanelRoot as TabViewStackPanel).EnterReorder(_dragIndex);
-        }
-    }
-
-    private void OnDragOver(object sender, DragEventArgs e)
-    {
-        DragOver?.Invoke(this, e);
-
-        e.Handled = true;
-
-        // Don't do any reorder processing until the user tells us its ok
-        // However, if we're the drag source TabView, automatically allow
-        // assuming we can - which _isInDrag will be true
-        if (e.DragEffects == DragDropEffects.None && !_isInDrag)
-            return;
-
-        var scrollCheck = CheckAutoScroll(e.GetPosition(Scroller));
-
-        switch (scrollCheck)
-        {
-            case AutoScrollAction.ScrollStarted:
-                // All reorder logic is disabled when auto scrolling, so reset the panel
-                // to draw normally
-                (ItemsPanelRoot as TabViewStackPanel).ClearReorder();
-                break;
-
-            case AutoScrollAction.ScrollEnded:
-                (ItemsPanelRoot as TabViewStackPanel).EnterReorder(_dragIndex);
-                break;
-
-            default:
-                // No DragDrop, we're just reordering this ListView
-                HandleReorder(e.GetPosition(ItemsPanelRoot));
-                break;
-        }
-    }
-
-    private void OnDragLeave(object sender, DragEventArgs e)
-    {
-        // This is a disgusting hack but we need to make sure we reset the insertion point
-        // logic if we drag away from this ListView so we don't get left with a gap
-        // The problem is, the event is raised on template components and not the actual
-        // ListView - which means we don't actually know if we're leaving this control or
-        // just a component (like a border that makes up the TabItem or its close button)
-        // Searching the visual tree doesn't work because it will always return true to find
-        // a TabViewListView. Searching for a TabViewItem and cancelling if found only works
-        // if you drag leave over an emtpy space in the Tabstrip. If you drag over a tab and
-        // into the main content area, that test fails, and the listview doesn't reset
-        // Pointer events don't really work - and we don't even have that so we're caching 
-        // the last point from DragOver. But pointer is only working here if we test against
-        // the border, which means we slightly shrink the bounds of the listview and hit test
-        // We could solve this easily with the raw PointerEvents from InputManager but that
-        // shutsdown during drag drop, so there isn't really much we can do here. So hack it is.
-        // There still seems to be an issue along the bottom border when dragging back in, but
-        // at this point I'm done dealing with this issue...it works good enough
-        if (e.Source is StyledElement v)
-        {
-            bool isCloseButton = (v as Visual).FindAncestorOfType<Button>() != null;
-            if (isCloseButton)
-                return;
-            var pt = e.GetPosition(this);
-            var rect = new Rect(Bounds.Size);
-            rect = rect.Inflate(-2);
-            if (!rect.Contains(pt))
-            {
-                if (_isInReorder)
-                {
-                    // Keep reorder active, but return to default state
-                    (ItemsPanelRoot as TabViewStackPanel).ChangeReorderIndex(_dragIndex);
-                }
-                else
-                {
-                    (ItemsPanelRoot as TabViewStackPanel).ClearReorder();
-                }
-            }
-        }
-    }
-
-    private void OnDrop(object sender, DragEventArgs e)
-    {
-        // Don't fire this event if we're the drag source
-        if (_isInDrag)
-            return;
-
-        Drop?.Invoke(this, e);
-
-        if (!_isInDrag)
-        {
-            (ItemsPanelRoot as TabViewStackPanel).ClearReorder();
-        }
-
-        _processReorder = true;
-    }
-
-    private AutoScrollAction CheckAutoScroll(Point scrollerPoint)
-    {
-        // We're not scrolling
-        if (Scroller.HorizontalScrollBarVisibility != ScrollBarVisibility.Visible)
-            return AutoScrollAction.NoAction;
-
-        if (_scrollDirection == -1 && scrollerPoint.X > _noAutoScrollRect.X)
-        {
-            StopScrollTimer();
-            return AutoScrollAction.ScrollEnded;
-        }
-        else if (_scrollDirection == 1 && scrollerPoint.X < _noAutoScrollRect.Right)
-        {
-            StopScrollTimer();
-            return AutoScrollAction.ScrollEnded;
-        }
-        else if (!_noAutoScrollRect.Contains(scrollerPoint))
-        {
-            if (scrollerPoint.X < _noAutoScrollRect.X && Scroller.Offset.X > 0)
-            {
-                _scrollDirection = -1;
-                StartScrollTimer();
-                return AutoScrollAction.ScrollStarted;
-            }
-            else if (scrollerPoint.X > _noAutoScrollRect.Right &&
-                Scroller.Offset.X < (Scroller.Extent.Width - Scroller.Viewport.Width))
-            {
-                _scrollDirection = 1;
-                StartScrollTimer();
-                return AutoScrollAction.ScrollStarted;
-            }
-        }
-
-        // no scrolling needed
-        return AutoScrollAction.NoAction;
-    }
-
-    private void StartScrollTimer()
-    {
-        if (_scrollTimer == null)
-        {
-            _scrollTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(50),
-                DispatcherPriority.Render, OnScrollTimerTick);
-        }
-
-        _scrollTimer.Start();
-    }
-
-    private void StopScrollTimer()
-    {
-        _scrollTimer?.Stop();
-        _scrollDirection = 0;
-    }
-
-    private void OnScrollTimerTick(object sender, EventArgs e)
-    {
-        if (_scrollDirection == -1)
-        {
-            Scroller.Offset = new Vector(Scroller.Offset.X - 25, Scroller.Offset.Y);
-
-            if (Scroller.Offset.X == 0)
-            {
-                StopScrollTimer();
-            }
-        }
-        else if (_scrollDirection == 1)
-        {
-            Scroller.Offset = new Vector(Scroller.Offset.X + 25, Scroller.Offset.Y);
-
-            if (Scroller.Offset.X == (Scroller.Extent.Width - Scroller.Viewport.Width))
-            {
-                StopScrollTimer();
-            }
-        }
+        PseudoClasses.Set(s_pcLeftShort, SelectedIndex == 0);
+        PseudoClasses.Set(s_pcRightShort, SelectedIndex == ItemsView.Count - 1);
     }
 
     private TabViewItem _dragItem;
@@ -722,6 +200,8 @@ public class TabViewListView : ListBox
     private const string s_tpScrollViewer = "ScrollViewer";
 
     private const string s_pcReorder = ":reorder";
+    private const string s_pcLeftShort = ":leftShort";
+    private const string s_pcRightShort = ":rightShort";
 
     private enum AutoScrollAction
     {

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -143,6 +143,7 @@ public sealed class TabViewListView : ListBox
         //
         //        We know we are currently looking at a TabViewItem being recycled if its parent TabView has
         //        already been set.
+        var tabLocation = TabViewTabStripLocation.Top; // Default to top
         if (tvi.ParentTabView == null)
         {
             var parentTV = container.FindAncestorOfType<TabView>();
@@ -150,8 +151,15 @@ public sealed class TabViewListView : ListBox
             {
                 tvi.OnTabViewWidthModeChanged(parentTV.TabWidthMode);
                 tvi.ParentTabView = parentTV;
+                tabLocation = parentTV.TabStripLocation;
             }
         }
+        else
+        {
+            tabLocation = tvi.ParentTabView.TabStripLocation;
+        }
+
+        tvi.HandleTabStripLocationChanged(tabLocation);
 
         // Special b/c we use the header and not Content. Somehow this *just works* in
         // WinUI b/c they don't have to do this.
@@ -169,6 +177,46 @@ public sealed class TabViewListView : ListBox
             tvi.HeaderTemplate = itemTemplate;
 
         base.ContainerForItemPreparedOverride(container, item, index);
+        if (!tvi.IsSelected)
+        {
+            // Bug Fix: When containers are being virtualized, they may "come back online" with
+            // old state left over.
+            // This is also a bug in WinUI, but it materializes differently. In Avalonia, we can see
+            // this very clearly because WinUI pins and does not recycle the SelectedItem container,
+            // but Avalonia does. Thus, when the previously selected container is reused, it still
+            // has the visual state we apply to selected items, specifically the :noborder pseudoclass
+            // Because WinUI pins the container, we never see this issue
+            // HOWEVER, we can see it in in WinUI with the LeftOfSelectedTab/RightOfSelectedTab states
+            // If you select an item and then scroll away such that SelIndex-1 and Selindex+1 container
+            // are recycled, inspect them, you'll see the margin still applied to the Border line indicating
+            // the state was never cleared. If you scroll to those new containers you'll see a tiny little
+            // gap in the bottom border because of this. 
+            // Fix here by just ensuring this state get's updated. I don't want to call TabView.UpdateBottom...
+            // because that iterates over containers and that isn't great in this path. 
+            // Also added unit test to ensure this is fixed.
+
+            var selIndex = SelectedIndex;
+            int state = -1;
+            if (selIndex != -1)
+            {
+                if (index == selIndex)
+                {
+                    state = 0;
+                }
+                else if (index == selIndex - 1)
+                {
+                    state = 1;
+                }
+                else if (index == selIndex + 1)
+                {
+                    state = 2;
+                }
+            }
+
+            ((IPseudoClasses)tvi.Classes).Set(SharedPseudoclasses.s_pcNoBorder, state == 0);
+            ((IPseudoClasses)tvi.Classes).Set(SharedPseudoclasses.s_pcBorderLeft, state == 1);
+            ((IPseudoClasses)tvi.Classes).Set(SharedPseudoclasses.s_pcBorderRight, state == 2);
+        }
     }
 
 

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -307,7 +307,7 @@ public sealed class TabViewListView : ListBox
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
-        _parent.RemoveHandler(DragDrop.DragLeaveEvent, OnParentDragEnter);
+        _parent?.RemoveHandler(DragDrop.DragLeaveEvent, OnParentDragEnter);
         _parent = null;
     }
 

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewListView.cs
@@ -1,27 +1,17 @@
 ﻿using System.Collections;
 using System.Collections.Specialized;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Xml.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Primitives.PopupPositioning;
-using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
-using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Logging;
-using Avalonia.LogicalTree;
-using Avalonia.Media;
-using Avalonia.Media.Imaging;
 using Avalonia.Threading;
+using Avalonia.Utilities;
 using Avalonia.VisualTree;
-using FluentAvalonia.Collections;
 using FluentAvalonia.Core;
 using FluentAvalonia.UI.Data;
 
@@ -256,6 +246,8 @@ public sealed class TabViewListView : ListBox
                 _initialPoint = currentPoint.Position;
                 _dragItem = (args.Source as Visual).FindAncestorOfType<TabViewItem>(true);
                 _dragIndex = IndexFromContainer(_dragItem);
+                _isDragItemFocused = _dragItem.IsFocused;
+                _isDragItemSelected = _dragItem.IsSelected;
                 _initArgs = args;
                 UpdateDragInfo();
                 // args.Handled = true;
@@ -316,7 +308,6 @@ public sealed class TabViewListView : ListBox
         var package = new DataPackage();
         DragItemsStartingEventArgs dragArgs = null;
         object[] dragItems = null;
-        IDisposable opacity = null;
         bool canReorder = CanReorderItems;
         bool canDrag = CanDragItems;
 
@@ -363,7 +354,7 @@ public sealed class TabViewListView : ListBox
                 return;
             }
 
-            opacity = _dragItem.SetValue(OpacityProperty, 0, BindingPriority.Animation);
+            _dragItemOpacitySub = _dragItem.SetValue(OpacityProperty, 0, BindingPriority.Animation);
 
             // Cache the locations of all containers before we start for reorder hints
             _isInReorder = true;
@@ -374,9 +365,12 @@ public sealed class TabViewListView : ListBox
 
         var dropResult = await DragDrop.DoDragDropAsync(_initArgs, package, effects);
 
+        SetPendingAutoPanVelocity(default);
+        DestroyStartEdgeScrollTimer();
+
         if (_isInReorder)
         {
-            opacity?.Dispose();
+            _dragItemOpacitySub?.Dispose();
             _isInReorder = false;
         }
 
@@ -433,12 +427,18 @@ public sealed class TabViewListView : ListBox
         }
                 
         Process(_isInReorder, canReorder, e);
-                
-        if (_isInReorder || isInReorderFromExternalSource)
+
+        if (_scrollTimer == null)
         {
-            _liveReorderHelper ??= new LiveReorderHelper(this);
-            _liveReorderHelper.ProcessLiveReorder(e, _dragIndex);
+            if (_isInReorder || isInReorderFromExternalSource)
+            {
+                _liveReorderHelper ??= new LiveReorderHelper(this);
+                _liveReorderHelper.ProcessLiveReorder(e, _dragIndex);
+            }
         }
+
+        ComputeEdgeScrollVelocity(e.GetPosition(this), out var pVelocity);
+        SetPendingAutoPanVelocity(pVelocity);
 
         static void Process(bool isInReorder, bool canReorder, DragEventArgs args)
         {
@@ -463,9 +463,10 @@ public sealed class TabViewListView : ListBox
             var pt = e.GetPosition(this);
             if (!bnds.Contains(pt))
             {
+                SetPendingAutoPanVelocity(default);
+                DestroyStartEdgeScrollTimer();
                 _isDragWithinTabStrip = false;
                 _isDraggingOverSelf = false;
-                _liveReorderIndices = default;
                 _liveReorderHelper?.ResetAllItemsForLiveReorder();
                 DragLeave?.Invoke(this, e);
             }
@@ -500,6 +501,7 @@ public sealed class TabViewListView : ListBox
         _isInDrag = _isInReorder = false;
         _dragIndex = -1;
         _dragItem = null;
+        _isDragItemSelected = _isDragItemFocused = false;
         _isDraggingOverSelf = false;
         _lastDragOverPoint = null;
         _isDragWithinTabStrip = false;
@@ -520,10 +522,9 @@ public sealed class TabViewListView : ListBox
     {
         // Container & original index - TabView does not support multi-item drag
         // so we don't need anything else here
-        var dragItem = _dragItem;
         var dragIndex = _dragIndex;
-        bool isDragItemFocused = dragItem.IsFocused;
-        bool isDragItemSelected = dragItem.IsSelected;
+        bool isDragItemFocused = _isDragItemFocused;
+        bool isDragItemSelected = _isDragItemSelected;
 
         var insertIndex = _liveReorderHelper.GetInsertionIndexForLiveReorder();
         _liveReorderHelper.ResetAllItemsForLiveReorder();
@@ -535,9 +536,9 @@ public sealed class TabViewListView : ListBox
         {
             insertIndex = _liveReorderHelper.GetClosestElement(dropPoint, true);
         }
-        
+
         // dragItem is the container, we need the actual data item here
-        var data = ItemFromContainer(dragItem);
+        var data = ItemsView.GetAt(_dragIndex);// ItemFromContainer(dragItem);
 
         if (dragIndex < insertIndex)
         {
@@ -592,429 +593,154 @@ public sealed class TabViewListView : ListBox
         }
     }
 
-    //private void CacheContainerBounds()
-    //{
-    //    Debug.WriteLine("CACHING CONTAINER BOUNDS");
-    //    // Because reorder will arrange the containers in new places
-    //    // the Bounds on the container may not actually reflect where
-    //    // the item actually is. In WinUI, ModernCollectionBasePanel's 
-    //    // ContainerManager caches arrange rects and are used for estimation
-    //    // APIs. Here we are mimicing that
-    //    // This must be called at the start of drag/drop, when the auto scroll
-    //    // of the scrollviewer stops, or when we first drag onto the TabView
-    //    // if that TabView didn't start the dragdrop operation
-
-    //    var panel = ItemsPanelRoot;
-    //    if (panel is VirtualizingStackPanel vsp)
-    //    {
-    //        var firstRealized = vsp.FirstRealizedIndex;
-    //        var lastRealized = vsp.LastRealizedIndex;
-    //        _cachedContainerBounds ??= new List<Rect>((lastRealized - firstRealized) + 1);
-
-    //        for (int i = firstRealized; i <= lastRealized; i++)
-    //        {
-    //            var cont = ContainerFromIndex(i);
-    //            _cachedContainerBounds.Add(cont.Bounds);
-    //        }
-    //    }
-    //    else if (panel is StackPanel sp)
-    //    {
-    //        _cachedContainerBounds ??= new List<Rect>(ItemCount);
-    //        // Stack Panels don't virtualize and arrange in order so this is safe
-    //        for (int i = 0; i < ItemCount; i++)
-    //        {
-    //            _cachedContainerBounds.Add(panel.Children[i].Bounds);
-    //        }
-    //    }
-    //}
-
-    //private void ClearContainerBoundsCache(bool clearCompletely = false)
-    //{
-    //    // Clear container bounds
-    //    _cachedContainerBounds?.Clear();
-
-    //    // Don't keep this memory when not in use, so when drag drop operation
-    //    // ceases completely, set it to null
-    //    if (clearCompletely)
-    //        _cachedContainerBounds = null;
-    //}
-
-    //private void ProcessLiveReorder(DragEventArgs args)
-    //{
-    //    _liveReorderHelper ??= new LiveReorderHelper(this);
-
-    //    var orientation = GetLogicalOrientation();
-    //    if (orientation == null)
-    //        return; // We're in a panel we don't know how to deal with, exit out
-        
-    //    var helper = _liveReorderHelper;
-
-    //    if (helper.ShouldCacheContainerBounds())
-    //        helper.CacheContainerBounds();
-
-
-
-
-    //    // OLD --------------------------------------------------------
-    //    var orientation = GetLogicalOrientation();
-    //    if (orientation == null)
-    //        return; // We're in a panel we don't know how to deal with, exit out
-
-    //    // If we don't have a cache of the current realized container bounds,
-    //    // create it now before we start doing anything. This happens on first
-    //    // startup, but can also be reset through the drag operation (autoscroll,
-    //    // drag outside, etc). The cache is cleared on ResetAllItemsForLiveReorder()
-    //    if (_cachedContainerBounds == null || _cachedContainerBounds.Count == 0)
-    //    {
-    //        CacheContainerBounds();
-    //    }
-        
-    //    int draggedIndex = _dragIndex;
-    //    int insertionIndex = -1;
-    //    int dragOverIndex = GetClosestElement(args.GetPosition(this));// IndexFromContainer(currentItem); // The raw item index under the pointer
-    //    var previousDragOverIndex = _liveReorderIndices.draggedOverIndex;
-    //    int itemsCount = ItemCount;
-
-    //    if (draggedIndex == -1)
-    //        draggedIndex = itemsCount;
-
-    //    if (previousDragOverIndex == -1)
-    //    {
-    //        previousDragOverIndex = draggedIndex;
-    //    }
-
-    //    // The estimated insertion index in the panel
-    //    insertionIndex = GetClosestElement(args.GetPosition(this), true /*requestingInsertionIndex*/);
-
-    //    if (draggedIndex == itemsCount && insertionIndex == itemsCount - 1)
-    //    {
-    //        // If we didn't start in this TabView, see if the index is actually the end or -1
-    //        var spLastElement = ContainerFromIndex(insertionIndex);
-    //        if (spLastElement is TabViewItem tvi)
-    //        {
-    //            if (IsInBottomHalf(args.GetPosition(spLastElement), new Rect(spLastElement.Bounds.Size), orientation.Value))
-    //            {
-    //                insertionIndex = itemsCount;
-    //            }
-    //        }
-    //    }
-
-    //    //var old = dragOverIndex; // Keep this here for debug purposes, if needed
-    //    if (insertionIndex == itemsCount)
-    //    {
-    //        dragOverIndex = itemsCount;
-    //    }
-    //    else
-    //    {
-    //        // This adjusts the dragover index based on the direction of the drag
-    //        dragOverIndex = GetDragOverIndex(dragOverIndex, insertionIndex, previousDragOverIndex);
-    //    }
-
-    //    // Debug.WriteLine($"\tLive Reorder DragOverIndex: {dragOverIndex} || DragOverBeforeAdj: {old} || InsertionIndex {insertionIndex} || PrevDragOverIndex {previousDragOverIndex}");
-
-    //    _liveReorderIndices = new LiveReorderIndices(draggedIndex, dragOverIndex, itemsCount);
-
-    //    if (previousDragOverIndex == draggedIndex || previousDragOverIndex != dragOverIndex)
-    //    {
-    //        StartLiveReorderTimer();
-    //    }
-
-    //    static bool IsInBottomHalf(Point pt, Rect rc, Orientation orientation)
-    //    {
-    //        if (orientation == Orientation.Horizontal)
-    //        {
-    //            return (pt.X - rc.Left) >= rc.Width * 0.5;
-    //        }
-    //        else
-    //        {
-    //            return (pt.Y - rc.Top) >= rc.Height * 0.5;
-    //        }
-    //    }
-
-    //    static int GetDragOverIndex(int closestElementIndex, int insertionIndex, int previousDragOverIndex)
-    //    {
-    //        int dragOverIndex = closestElementIndex;
-
-    //        if (insertionIndex == closestElementIndex)
-    //        {
-    //            if (previousDragOverIndex < insertionIndex)
-    //            {
-    //                --dragOverIndex;
-    //            }
-    //        }
-    //        else
-    //        {
-    //            if (previousDragOverIndex >= insertionIndex)
-    //            {
-    //                ++dragOverIndex;
-    //            }
-    //        }
-
-    //        return dragOverIndex;
-    //    }
-    //}
-
-    //private int GetClosestElement(Point dragPoint, bool requestingInsertionIndex = false)
-    //{
-    //    // This estimates the container index given the current pointer position
-    //    var panel = ItemsPanelRoot;
-    //    if (panel is VirtualizingStackPanel vsp)
-    //    {
-    //        var firstRealized = vsp.FirstRealizedIndex;
-    //        var lastRealized = vsp.LastRealizedIndex;
-    //        var orientation = vsp.Orientation;
-    //        var movedItems = _movedItems.AsSpan();
-    //        int closestIndex = -1;
-    //        double closestDist = double.PositiveInfinity;
-    //        Rect closestItemRect = default;
-
-    //        // Loop over the currently realized items to find the closest
-    //        for (int i = firstRealized; i <= lastRealized; i++)
-    //        {
-    //            // If the item is currently in our MovedItems list, it may not be 
-    //            // where it usually is, so we can't test the actual Bounds or we'll
-    //            // estimate the wrong index, but we have the original bounds saved
-    //            Rect rc = _cachedContainerBounds[i - firstRealized];
-    //            double dist;
-
-    //            if (orientation == Orientation.Horizontal)
-    //            {
-    //                double cx = double.Clamp(dragPoint.X, rc.X, rc.Right);
-    //                dist = double.Abs(dragPoint.X - cx);
-    //            }
-    //            else
-    //            {
-    //                double cy = double.Clamp(dragPoint.Y, rc.Y, rc.Bottom);
-    //                dist = double.Abs(dragPoint.Y - cy);
-    //            }
-
-    //            if (dist < closestDist)
-    //            {
-    //                closestDist = dist;
-    //                closestIndex = i;
-    //                closestItemRect = rc;
-    //            }
-    //        }
-
-    //        if (requestingInsertionIndex)
-    //        {
-    //            if (orientation == Orientation.Horizontal)
-    //            {
-    //                if (dragPoint.X - closestItemRect.X >= closestItemRect.Width * 0.5)
-    //                {
-    //                    closestIndex++;
-    //                }
-    //            }
-    //            else if (orientation == Orientation.Vertical)
-    //            {
-    //                if (dragPoint.Y - closestItemRect.Y >= closestItemRect.Height * 0.5)
-    //                {
-    //                    closestIndex++;
-    //                }
-    //            }
-    //        }
-
-    //        return closestIndex;
-    //    }
-    //    else if (panel is StackPanel sp)
-    //    {
-    //        //var children = sp.Children;
-    //        //var orientation = sp.Orientation;
-    //        //var movedItems = _movedItems.AsSpan();
-
-    //        //for (int i = 0; i < children.Count; i++)
-    //        //{
-    //        //    // If the item is currently in our MovedItems list, it may not be 
-    //        //    // where it usually is, so we can't test the actual Bounds or we'll
-    //        //    // estimate the wrong index, but we have the original bounds saved
-    //        //    if (IsInMovedItems(movedItems, i, out var rc))
-    //        //    {
-    //        //        if (rc.Contains(dragPoint))
-    //        //        {
-    //        //            return i;
-    //        //        }
-    //        //    }
-    //        //    else
-    //        //    {
-    //        //        // The item is not in moved items, so it is safe to use the Bounds directly
-    //        //        if (children[i].Bounds.Contains(dragPoint))
-    //        //        {
-    //        //            return i;
-    //        //        }
-    //        //    }
-    //        //}
-    //    }
-
-    //    return -1;
-
-    //    //static bool IsInMovedItems(ReadOnlySpan<MovedItem> items, int sourceIndex, out Rect srcRect)
-    //    //{
-    //    //    foreach (var item in items)
-    //    //    {
-    //    //        if (item.sourceIndex == sourceIndex)
-    //    //        {
-    //    //            srcRect = item.sourceRect;
-    //    //            return true;
-    //    //        }
-    //    //    }
-
-    //    //    srcRect = default;
-    //    //    return false;
-    //    //}
-    //}
-
-    //private void StartLiveReorderTimer()
-    //{
-    //    StopLiveReorderTimer();
-
-    //    EnsureLiveReorderTimer();
-
-    //    _liveReorderTimer.Interval = TimeSpan.FromMilliseconds(200);
-    //    _liveReorderTimer.Start();
-    //}
-
-    //private void EnsureLiveReorderTimer()
-    //{
-    //    if (_liveReorderTimer == null)
-    //    {
-    //        _liveReorderTimer = new DispatcherTimer();
-    //        _liveReorderTimer.Tick += LiveReorderTimerTickHandler;
-    //    }
-    //}
-
-    //private void LiveReorderTimerTickHandler(object sender, EventArgs e)
-    //{
-    //    StopLiveReorderTimer();
-
-    //    Debug.Assert(_liveReorderIndices.draggedItemIndex != -1);
-
-    //    var orientation = GetLogicalOrientation().Value;
-
-    //    using var newItems = new PooledList<MovedItem>();
-    //    using var newItemsToMove = new PooledList<MovedItem>();
-    //    using var oldItemsToMoveBack = new PooledList<MovedItem>();
-
-    //    GetNewMovedItemsForLiveReorder(newItems);
-
-    //    _movedItems.Update(orientation == Orientation.Vertical, newItems, newItemsToMove, oldItemsToMoveBack);
-
-    //    MoveItemsForLiveReorder(false /*areNewItems*/, oldItemsToMoveBack);
-
-    //    MoveItemsForLiveReorder(true, newItemsToMove);
-
-    //    foreach (var item in _movedItems.AsSpan())
-    //    {
-    //        Debug.WriteLine($"\t MovedItems: {item.sourceIndex} -> {item.destinationIndex} || {item.sourceRect} -> {item.destinationRect}");
-    //    }
-    //}
-
-    //private void GetNewMovedItemsForLiveReorder(IList<MovedItem> newItems)
-    //{
-    //    int startIndex = _liveReorderIndices.draggedItemIndex;
-    //    int endIndex = _liveReorderIndices.draggedOverIndex;
-    //    int increment = (startIndex < endIndex) ? 1 : -1;
-
-    //    // Debug.WriteLine($"GetNewMovedItems: {startIndex} -> {endIndex}");
-
-    //    newItems.Clear();
-    //    for (int i = startIndex; i != endIndex; i += increment)
-    //    {
-    //        int targetIndex = i - increment;
-
-    //        if (i == startIndex)
-    //        {
-    //            targetIndex = -1;
-    //        }
-
-    //        AddNewItemForLiveReorder(i, targetIndex, newItems, _liveReorderIndices.itemsCount, this);
-    //    }
-
-    //    AddNewItemForLiveReorder(endIndex, endIndex - increment, newItems, _liveReorderIndices.itemsCount, this);
-
-    //   // Debug.WriteLine($"TotalNewItems: {newItems.Count}");
-
-    //    static void AddNewItemForLiveReorder(int sourceIndex, int targetIndex, IList<MovedItem> newItems, 
-    //        int itemsCount, TabViewListView host)
-    //    {
-    //        Rect src = default;
-    //        Rect target = default;
-
-    //        if (sourceIndex != targetIndex)
-    //        {
-    //            src = GetLayoutSlot(host, sourceIndex);
-    //        }
-
-    //        if (targetIndex != -1 && targetIndex != itemsCount)
-    //        {
-    //            target = GetLayoutSlot(host, targetIndex);
-    //        }
-
-    //        newItems.Add(new MovedItem(sourceIndex, targetIndex, src, target));
-    //    }
-
-    //    static Rect GetLayoutSlot(TabViewListView host, int index)
-    //    {
-    //        // make sure we grab the original bounds. If virtualizing, translate
-    //        // to index in our container cache
-    //        var adjIndex = host.ItemsPanelRoot is VirtualizingStackPanel vsp ?
-    //            index - vsp.FirstRealizedIndex : index;
-
-    //        if (adjIndex >= host._cachedContainerBounds.Count)
-    //            return default;
-
-    //        return host._cachedContainerBounds[adjIndex];
-    //        //return host.ContainerFromIndex(index)?.Bounds ?? default;
-    //    }
-    //}
-
-    //private void MoveItemsForLiveReorder(bool areNewItems, PooledList<MovedItem> newItemsToMove)
-    //{
-    //    Rect rc;
-    //    foreach (var item in newItemsToMove.AsSpan())
-    //    {
-    //        var container = ContainerFromIndex(item.sourceIndex);
-
-    //        if (container is Control c)
-    //        {
-    //            if (areNewItems)
-    //            {
-    //                rc = item.destinationRect;
-    //            }
-    //            else
-    //            {
-    //                rc = item.sourceRect;
-    //            }
-
-    //            c.Arrange(rc);
-    //        }
-    //    }
-    //}
-
-    //private void ResetAllItemsForLiveReorder()
-    //{
-    //    StopLiveReorderTimer();
-
-    //    foreach (var item in _movedItems.AsSpan())
-    //    {
-    //        if (item.destinationIndex != -1)
-    //        {
-    //            var cont = ContainerFromIndex(item.sourceIndex);
-    //            if (cont is Control c)
-    //            {
-    //                c.Arrange(item.sourceRect);
-    //            }
-    //        }
-    //    }
-
-    //    _movedItems.Clear();
-    //    _liveReorderIndices = new LiveReorderIndices(-1,-1,-1);
-    //    ClearContainerBoundsCache();
-    //}
-
-    //private void StopLiveReorderTimer()
-    //{
-    //    _liveReorderTimer?.Stop();
-    //}
+    private void ComputeEdgeScrollVelocity(Point dragPoint, out Vector pVelocity)
+    {
+        bool isVerticalEnabled = false;
+        bool isHorizontalEnabled = false;
+        Size extent = default;
+        Size viewport = default;
+        Vector offset = default;
+
+        if (Scroller != null)
+        {
+            var vertical = Scroller.VerticalScrollBarVisibility;
+            var horizontal = Scroller.HorizontalScrollBarVisibility;
+            extent = Scroller.Extent;
+            viewport = Scroller.Viewport;
+            offset = Scroller.Offset;
+
+            isVerticalEnabled = vertical != ScrollBarVisibility.Disabled;
+            isHorizontalEnabled = horizontal == ScrollBarVisibility.Visible;
+        }
+
+        double hVelocity = 0;
+        double vVelocity = 0;
+        if (isHorizontalEnabled)
+        {
+            // WinUI uses a hardcoded 100px as the threshold for where autoscroll starts, but that
+            // doesn't seem great with small listviews. So I'm using 20% of the width
+            var threshold = Bounds.Size.Width * 0.2;
+            double bound = 0;
+
+            // Try Scrolling Left
+            hVelocity = -ComputeEdgeScrollVelocityFromEdgeDistance(dragPoint.X, threshold);
+            if (hVelocity == 0)
+            {
+                // Try Scrolling Right
+                var width = Bounds.Size.Width;
+                hVelocity = ComputeEdgeScrollVelocityFromEdgeDistance(width - dragPoint.X, threshold);
+                bound = extent.Width - viewport.Width;
+            }
+
+            // Disable if we're right up on the edge
+            if (MathUtilities.AreClose(bound, offset.X, 0.05))
+            {
+                hVelocity = 0;
+            }
+        }
+
+        if (isVerticalEnabled && hVelocity == 0)
+        {
+            var threshold = Bounds.Size.Height * 0.2;
+            double bound = 0;
+
+            vVelocity = -ComputeEdgeScrollVelocityFromEdgeDistance(dragPoint.Y, threshold);
+            if (vVelocity == 0)
+            {
+                double height = Bounds.Size.Height;
+                vVelocity = ComputeEdgeScrollVelocityFromEdgeDistance(height - dragPoint.Y, threshold);
+                bound = extent.Height - viewport.Height;
+            }
+
+            // Disable if we're right up on the edge
+            if (MathUtilities.AreClose(bound, offset.Y, 0.05))
+            {
+                vVelocity = 0;
+            }
+        }
+
+        pVelocity = new Vector(hVelocity, vVelocity);
+    }
+
+    private static double ComputeEdgeScrollVelocityFromEdgeDistance(in double distFromEdge,
+        double edgeDistanceThreshold = 100)
+    {
+        if (distFromEdge <= edgeDistanceThreshold)
+        {
+            return 200 - (distFromEdge / edgeDistanceThreshold) * (200 - 25);
+        }
+
+        return 0;
+    }
+
+    private void SetPendingAutoPanVelocity(Vector velocity)
+    {
+        if (!IsStationary(velocity))
+        {
+            if (!IsStationary(_currentAutoPanVelocity))
+            {
+                _currentAutoPanVelocity = velocity;
+                EnsureStartEdgeScrollTimer();
+            }
+            else
+            {
+                _currentAutoPanVelocity = velocity;
+            }
+
+            // While AutoScrolling, be sure the live reorder manager isn't trying to 
+            // do anything as container bounds are constantly changing and things
+            // won't line up like it expects
+            _liveReorderHelper?.ResetAllItemsForLiveReorder();
+            // Also reset the opacity on the drag item so it doesn't affect
+            // recycled containers
+            _dragItemOpacitySub?.Dispose();
+        }
+        else
+        {
+            DestroyStartEdgeScrollTimer();
+            _currentAutoPanVelocity = default;
+            ScrollWithVelocity(default);
+
+            _dragItemOpacitySub?.Dispose();
+            var cont = ContainerFromIndex(_dragIndex);
+            if (cont != null)
+            {
+                _dragItemOpacitySub = _dragItem.SetValue(OpacityProperty, 0, BindingPriority.Animation);
+            }
+        }
+    }
+
+    private void EnsureStartEdgeScrollTimer()
+    {
+        _scrollTimer ??= new DispatcherTimer(TimeSpan.FromMilliseconds(50),
+            DispatcherPriority.Normal, StartEdgeScrollTimerTick);
+
+        _scrollTimer.Start();
+    }
+
+    private void DestroyStartEdgeScrollTimer()
+    {
+        _scrollTimer?.Stop();
+        _scrollTimer = null;
+    }
+
+    private void StartEdgeScrollTimerTick(object sender, EventArgs args)
+    {
+        ScrollWithVelocity(_currentAutoPanVelocity);
+    }
+
+    private void ScrollWithVelocity(in Vector velocity)
+    {
+        var s = Scroller;
+        var off = s.Offset;
+
+        off += velocity;
+
+        s.Offset = off;
+    }
+
+    private static bool IsStationary(Vector v) =>
+        MathUtilities.IsZero(v.X) && MathUtilities.IsZero(v.Y);
 
     internal Orientation? GetLogicalOrientation()
     {
@@ -1109,8 +835,11 @@ public sealed class TabViewListView : ListBox
 
     private TabViewItem _dragItem;
     private int _dragIndex = -1;
+    private bool _isDragItemFocused;
+    private bool _isDragItemSelected;
     private bool _isInDrag = false;
     private bool _isInReorder = false;
+    private IDisposable _dragItemOpacitySub;
     private bool _processReorder;
     private Point? _initialPoint;
     private double _cxDrag = double.NaN;
@@ -1121,10 +850,10 @@ public sealed class TabViewListView : ListBox
     private bool _isDraggingOverSelf;
 
     private LiveReorderHelper _liveReorderHelper;
-    private LiveReorderIndices _liveReorderIndices = new LiveReorderIndices(-1,-1,-1);
+    //private LiveReorderIndices _liveReorderIndices = new LiveReorderIndices(-1,-1,-1);
     private DispatcherTimer _liveReorderTimer;
-    private readonly MovedItems _movedItems = new MovedItems();
-    private List<Rect> _cachedContainerBounds;
+    //private readonly MovedItems _movedItems = new MovedItems();
+    //private List<Rect> _cachedContainerBounds;
     private Point? _lastDragOverPoint;
 
     // For 12.0/v3 - Avalonia has decided to make the decision that the lowest common denominator
@@ -1134,26 +863,12 @@ public sealed class TabViewListView : ListBox
     // And you guessed it, freakin' Wayland
     private PointerPressedEventArgs _initArgs;
     
-    private static Popup _dragReorderPopup;
-    private Point _popupOffset;
-    private object _dragItemToolTip;
-
     private DispatcherTimer _scrollTimer;
-    private int _scrollDirection;
-    private Rect _noAutoScrollRect;
+    private Vector _currentAutoPanVelocity;
 
     private const string s_tpScrollViewer = "ScrollViewer";
 
     private const string s_pcReorder = ":reorder";
     private const string s_pcLeftShort = ":leftShort";
     private const string s_pcRightShort = ":rightShort";
-
-    private enum AutoScrollAction
-    {
-        NoAction,
-        ScrollStarted,
-        ScrollEnded,
-    }
-
-
 }

--- a/src/FluentAvalonia/UI/Controls/TabView/TabViewStackPanel.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/TabViewStackPanel.cs
@@ -1,291 +1,291 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿//using Avalonia;
+//using Avalonia.Controls;
 
-namespace FluentAvalonia.UI.Controls;
+//namespace FluentAvalonia.UI.Controls;
 
-/// <summary>
-/// Special panel for a <see cref="TabViewStackPanel"/> that supports reorder/drag visual feedback
-/// </summary>
-/// <remarks>
-/// This panel should not be used outside of the TabViewListView
-/// </remarks>
-public class TabViewStackPanel : Panel
-{
-    /// <inheritdoc/>
-    protected override Size MeasureOverride(Size availableSize)
-    {
-        double width = 0;
-        double height = 0;
-        var children = Children;
-        for (int i = 0; i < children.Count; i++)
-        {
-            children[i].Measure(availableSize);
-            width += children[i].DesiredSize.Width;
-            height = Math.Max(height, children[i].DesiredSize.Height);
-        }
+///// <summary>
+///// Special panel for a <see cref="TabViewStackPanel"/> that supports reorder/drag visual feedback
+///// </summary>
+///// <remarks>
+///// This panel should not be used outside of the TabViewListView
+///// </remarks>
+//public class TabViewStackPanel : Panel
+//{
+//    /// <inheritdoc/>
+//    protected override Size MeasureOverride(Size availableSize)
+//    {
+//        double width = 0;
+//        double height = 0;
+//        var children = Children;
+//        for (int i = 0; i < children.Count; i++)
+//        {
+//            children[i].Measure(availableSize);
+//            width += children[i].DesiredSize.Width;
+//            height = Math.Max(height, children[i].DesiredSize.Height);
+//        }
 
-        return new Size(width, height);
-    }
+//        return new Size(width, height);
+//    }
 
-    /// <inheritdoc/>
-    protected override Size ArrangeOverride(Size finalSize)
-    {
-        if (_startReorderIndex == -1 && _insertionIndex == -1)
-            ArrangeNormal(finalSize);
-        else if (_startReorderIndex == -1)
-            ArrangeInsertionOnly(finalSize);
-        else
-            ArrangeWithDragReorder(finalSize);
+//    /// <inheritdoc/>
+//    protected override Size ArrangeOverride(Size finalSize)
+//    {
+//        if (_startReorderIndex == -1 && _insertionIndex == -1)
+//            ArrangeNormal(finalSize);
+//        else if (_startReorderIndex == -1)
+//            ArrangeInsertionOnly(finalSize);
+//        else
+//            ArrangeWithDragReorder(finalSize);
 
-        return finalSize;
-    }
+//        return finalSize;
+//    }
 
-    private void ArrangeNormal(Size finalSize)
-    {
-        double x = 0;
-        Rect rc;
-        var children = Children;
-        for (int i = 0; i < children.Count; i++)
-        {
-            rc = new Rect(x, 0, children[i].DesiredSize.Width, finalSize.Height);
-            children[i].Arrange(rc);
-            x += rc.Width;
-        }
-    }
+//    private void ArrangeNormal(Size finalSize)
+//    {
+//        double x = 0;
+//        Rect rc;
+//        var children = Children;
+//        for (int i = 0; i < children.Count; i++)
+//        {
+//            rc = new Rect(x, 0, children[i].DesiredSize.Width, finalSize.Height);
+//            children[i].Arrange(rc);
+//            x += rc.Width;
+//        }
+//    }
 
-    private void ArrangeWithDragReorder(Size finalSize)
-    {
-        double x = 0;
-        Rect rc;
-        var children = Children;
+//    private void ArrangeWithDragReorder(Size finalSize)
+//    {
+//        double x = 0;
+//        Rect rc;
+//        var children = Children;
 
-        if (_insertionIndex > _startReorderIndex)
-        {
-            for (int i = 0; i < children.Count; i++)
-            {
-                if (i == _startReorderIndex)
-                {
-                    // Arrange offscreen, but DONT advance the rect x
-                    rc = new Rect(x, -finalSize.Height - 100, children[i].DesiredSize.Width, finalSize.Height);
-                    children[i].Arrange(rc);
-                }
-                else
-                {
-                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
-                    children[i].Arrange(rc);
-                    x += rc.Width;
+//        if (_insertionIndex > _startReorderIndex)
+//        {
+//            for (int i = 0; i < children.Count; i++)
+//            {
+//                if (i == _startReorderIndex)
+//                {
+//                    // Arrange offscreen, but DONT advance the rect x
+//                    rc = new Rect(x, -finalSize.Height - 100, children[i].DesiredSize.Width, finalSize.Height);
+//                    children[i].Arrange(rc);
+//                }
+//                else
+//                {
+//                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
+//                    children[i].Arrange(rc);
+//                    x += rc.Width;
 
-                    if (i == _insertionIndex)
-                    {
-                        // TODO, if insert only, need width
-                        x += _startReorderIndex == -1 ? children[0].DesiredSize.Width :
-                            children[_startReorderIndex].DesiredSize.Width;
-                    }
-                }
-            }
-        }
-        else if (_insertionIndex < _startReorderIndex)
-        {
-            for (int i = 0; i < children.Count; i++)
-            {
-                if (i < _insertionIndex)
-                {
-                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
-                    children[i].Arrange(rc);
-                    x += rc.Width;
-                }
-                else if (i == _insertionIndex)
-                {
-                    // leave a space
-                    x += children[_startReorderIndex].DesiredSize.Width;
+//                    if (i == _insertionIndex)
+//                    {
+//                        // TODO, if insert only, need width
+//                        x += _startReorderIndex == -1 ? children[0].DesiredSize.Width :
+//                            children[_startReorderIndex].DesiredSize.Width;
+//                    }
+//                }
+//            }
+//        }
+//        else if (_insertionIndex < _startReorderIndex)
+//        {
+//            for (int i = 0; i < children.Count; i++)
+//            {
+//                if (i < _insertionIndex)
+//                {
+//                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
+//                    children[i].Arrange(rc);
+//                    x += rc.Width;
+//                }
+//                else if (i == _insertionIndex)
+//                {
+//                    // leave a space
+//                    x += children[_startReorderIndex].DesiredSize.Width;
 
-                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
-                    children[i].Arrange(rc);
-                    x += rc.Width;
-                }
-                else if (i == _startReorderIndex)
-                {
-                    // Arrange offscreen, but DONT advance the rect x
-                    rc = new Rect(x, -finalSize.Height - 100, children[i].DesiredSize.Width, finalSize.Height);
-                    children[i].Arrange(rc);
-                }
-                else
-                {
-                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
-                    children[i].Arrange(rc);
-                    x += rc.Width;
-                }
-            }
-        }
-        else
-        {
-            for (int i = 0; i < children.Count; i++)
-            {
-                if (i == _startReorderIndex)
-                {
-                    // Arrange offscreen
-                    rc = new Rect(x, -finalSize.Height - 100, children[i].DesiredSize.Width, finalSize.Height);
-                    children[i].Arrange(rc);
-                    x += rc.Width;
-                }
-                else
-                {
-                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
-                    children[i].Arrange(rc);
-                    x += rc.Width;
-                }
-            }
-        }
-    }
+//                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
+//                    children[i].Arrange(rc);
+//                    x += rc.Width;
+//                }
+//                else if (i == _startReorderIndex)
+//                {
+//                    // Arrange offscreen, but DONT advance the rect x
+//                    rc = new Rect(x, -finalSize.Height - 100, children[i].DesiredSize.Width, finalSize.Height);
+//                    children[i].Arrange(rc);
+//                }
+//                else
+//                {
+//                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
+//                    children[i].Arrange(rc);
+//                    x += rc.Width;
+//                }
+//            }
+//        }
+//        else
+//        {
+//            for (int i = 0; i < children.Count; i++)
+//            {
+//                if (i == _startReorderIndex)
+//                {
+//                    // Arrange offscreen
+//                    rc = new Rect(x, -finalSize.Height - 100, children[i].DesiredSize.Width, finalSize.Height);
+//                    children[i].Arrange(rc);
+//                    x += rc.Width;
+//                }
+//                else
+//                {
+//                    rc = new Rect(new Point(x, 0), children[i].DesiredSize);
+//                    children[i].Arrange(rc);
+//                    x += rc.Width;
+//                }
+//            }
+//        }
+//    }
 
-    private void ArrangeInsertionOnly(Size finalSize)
-    {
-        double x = 0;
-        Rect rc;
-        var children = Children;
-        for (int i = 0; i < children.Count; i++)
-        {
-            if (i == _insertionIndex)
-            {
-                double wid = 0;
-                if (i == 0)
-                {
-                    wid = children[0].DesiredSize.Width;
-                }
-                else
-                {
-                    wid = (children[i - 1].DesiredSize.Width + children[i].DesiredSize.Height) / 2;
-                }
+//    private void ArrangeInsertionOnly(Size finalSize)
+//    {
+//        double x = 0;
+//        Rect rc;
+//        var children = Children;
+//        for (int i = 0; i < children.Count; i++)
+//        {
+//            if (i == _insertionIndex)
+//            {
+//                double wid = 0;
+//                if (i == 0)
+//                {
+//                    wid = children[0].DesiredSize.Width;
+//                }
+//                else
+//                {
+//                    wid = (children[i - 1].DesiredSize.Width + children[i].DesiredSize.Height) / 2;
+//                }
 
-                // Leave a space at the insertion index
-                x += wid;
-            }
+//                // Leave a space at the insertion index
+//                x += wid;
+//            }
 
-            rc = new Rect(x, 0, children[i].DesiredSize.Width, finalSize.Height);
-            children[i].Arrange(rc);
-            x += rc.Width;
-        }
-    }
+//            rc = new Rect(x, 0, children[i].DesiredSize.Width, finalSize.Height);
+//            children[i].Arrange(rc);
+//            x += rc.Width;
+//        }
+//    }
 
-    internal void EnterReorder(int startIndex)
-    {
-        // We're already in a reorder operation, dragenter was probably triggered
-        // by a TabViewItem
-        if (_insertionIndex != -1)
-            return;
-        _startReorderIndex = _insertionIndex = startIndex;
-        InvalidateArrange();
-    }
+//    internal void EnterReorder(int startIndex)
+//    {
+//        // We're already in a reorder operation, dragenter was probably triggered
+//        // by a TabViewItem
+//        if (_insertionIndex != -1)
+//            return;
+//        _startReorderIndex = _insertionIndex = startIndex;
+//        InvalidateArrange();
+//    }
 
-    internal void ChangeReorderIndex(int index)
-    {
-        if (_insertionIndex != index)
-        {
-            if (index == -1)
-                _insertionIndex = _startReorderIndex;
+//    internal void ChangeReorderIndex(int index)
+//    {
+//        if (_insertionIndex != index)
+//        {
+//            if (index == -1)
+//                _insertionIndex = _startReorderIndex;
 
-            _insertionIndex = index;
-            InvalidateArrange();
-        }
-    }
+//            _insertionIndex = index;
+//            InvalidateArrange();
+//        }
+//    }
 
-    internal int ClearReorder()
-    {
-        var old = _insertionIndex;
-        _startReorderIndex = _insertionIndex = -1;
-        InvalidateArrange();
-        return old;
-    }
+//    internal int ClearReorder()
+//    {
+//        var old = _insertionIndex;
+//        _startReorderIndex = _insertionIndex = -1;
+//        InvalidateArrange();
+//        return old;
+//    }
 
-    internal int GetInsertionIndexFromPoint(Point p, int estimatedIndex = -1)
-    {
-        if (_startReorderIndex == -1)
-        {
-            // This is an insertion operation only, so each item is already at it's
-            // logical position, so simple bounds check will work
+//    internal int GetInsertionIndexFromPoint(Point p, int estimatedIndex = -1)
+//    {
+//        if (_startReorderIndex == -1)
+//        {
+//            // This is an insertion operation only, so each item is already at it's
+//            // logical position, so simple bounds check will work
 
-            if (p.X < Children[0].Bounds.Center.X)
-            {
-                return 0;
-            }
-            else if (p.X > Children[Children.Count - 1].Bounds.Center.X)
-            {
-                return Children.Count;
-            }
-            else
-            {
-                for (int i = 1; i < Children.Count; i++)
-                {
-                    var x1 = Children[i - 1].Bounds.Center.X;
-                    var x2 = Children[i].Bounds.Center.X;
+//            if (p.X < Children[0].Bounds.Center.X)
+//            {
+//                return 0;
+//            }
+//            else if (p.X > Children[Children.Count - 1].Bounds.Center.X)
+//            {
+//                return Children.Count;
+//            }
+//            else
+//            {
+//                for (int i = 1; i < Children.Count; i++)
+//                {
+//                    var x1 = Children[i - 1].Bounds.Center.X;
+//                    var x2 = Children[i].Bounds.Center.X;
 
-                    if (p.X >= x1 && p.X <= x2)
-                    {
-                        return i;
-                    }
-                }
-            }
-        }
+//                    if (p.X >= x1 && p.X <= x2)
+//                    {
+//                        return i;
+//                    }
+//                }
+//            }
+//        }
 
-        if (estimatedIndex > -1)
-        {
-            var initBounds = Children[estimatedIndex].Bounds;
+//        if (estimatedIndex > -1)
+//        {
+//            var initBounds = Children[estimatedIndex].Bounds;
 
-            for (int i = 0; i < Children.Count; i++)
-            {
-                if (i == _startReorderIndex)
-                    continue;
+//            for (int i = 0; i < Children.Count; i++)
+//            {
+//                if (i == _startReorderIndex)
+//                    continue;
 
-                var bnds = Children[i].Bounds;
+//                var bnds = Children[i].Bounds;
 
-                if (bnds.Contains(p))
-                {
-                    if (bnds.X < initBounds.X)
-                    {
-                        if (p.X < bnds.Center.X)
-                        {
-                            return TranslateIndex(i);
-                        }
-                    }
-                    else if (bnds.X > initBounds.X)
-                    {
-                        if (p.X > bnds.Center.X)
-                        {
-                            return TranslateIndex(i);
-                        }
-                    }
-                }
-            }
+//                if (bnds.Contains(p))
+//                {
+//                    if (bnds.X < initBounds.X)
+//                    {
+//                        if (p.X < bnds.Center.X)
+//                        {
+//                            return TranslateIndex(i);
+//                        }
+//                    }
+//                    else if (bnds.X > initBounds.X)
+//                    {
+//                        if (p.X > bnds.Center.X)
+//                        {
+//                            return TranslateIndex(i);
+//                        }
+//                    }
+//                }
+//            }
 
-            return _insertionIndex;// (_insertionIndex == -1) ? estimatedIndex : _insertionIndex;
-        }
-        else
-        {
-            // Don't need this now, may in the future
-            //throw new NotImplementedException();
-            return _insertionIndex;
-        }
-    }
+//            return _insertionIndex;// (_insertionIndex == -1) ? estimatedIndex : _insertionIndex;
+//        }
+//        else
+//        {
+//            // Don't need this now, may in the future
+//            //throw new NotImplementedException();
+//            return _insertionIndex;
+//        }
+//    }
 
-    private int TranslateIndex(int index)
-    {
-        if (_insertionIndex == _startReorderIndex)
-            return index;
+//    private int TranslateIndex(int index)
+//    {
+//        if (_insertionIndex == _startReorderIndex)
+//            return index;
 
-        if (_insertionIndex < _startReorderIndex)
-        {
-            if (index >= _insertionIndex && index <= _startReorderIndex)
-                return index + 1;
-        }
-        else if (_insertionIndex > _startReorderIndex)
-        {
-            if (index <= _insertionIndex && index >= _startReorderIndex)
-                return index - 1;
-        }
+//        if (_insertionIndex < _startReorderIndex)
+//        {
+//            if (index >= _insertionIndex && index <= _startReorderIndex)
+//                return index + 1;
+//        }
+//        else if (_insertionIndex > _startReorderIndex)
+//        {
+//            if (index <= _insertionIndex && index >= _startReorderIndex)
+//                return index - 1;
+//        }
 
-        return index;
-    }
+//        return index;
+//    }
 
-    private int _startReorderIndex = -1;
-    private int _insertionIndex = -1;
-}
+//    private int _startReorderIndex = -1;
+//    private int _insertionIndex = -1;
+//}

--- a/src/FluentAvalonia/UI/Data/DataPackage.cs
+++ b/src/FluentAvalonia/UI/Data/DataPackage.cs
@@ -1,48 +1,65 @@
 ﻿using Avalonia.Input;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform.Storage;
 
 namespace FluentAvalonia.UI.Data;
 
 /// <summary>
-/// This class is part of the ListView logic, which has been suspended for now
+/// Contains the data a user want to exchange
 /// </summary>
-public class DataPackage : IDataObject
+/// <remarks>This class is a wrapper around Avalonia's <see cref="IDataTransfer"/> API to
+/// keep things more inline with WinUI</remarks>
+public sealed class DataPackage : IDataTransfer, IAsyncDataTransfer
 {
+    public DataPackage()
+    {
+        _dt = new DataTransfer();
+    }
+
     /// <summary>
     /// Gets or sets the requested operation for the data object
     /// </summary>
     public DragDropEffects RequestedOperation { get; set; }
 
-    public bool Contains(string dataFormat) =>
-        _data.ContainsKey(dataFormat);
+    public void SetText(string text)
+    {
+        _dt.Add(DataTransferItem.CreateText(text));
+    }
 
-    public object Get(string dataFormat) =>
-        _data.TryGetValue(dataFormat, out var value) ? value :
-        throw new ArgumentException($"No data format of {dataFormat} was found in the data package");
+    public string GetText()
+    {
+        return _dt.TryGetText();
+    }
 
-    public IEnumerable<string> GetDataFormats() =>
-        _data.Keys;
+    public void SetStorageItems(IEnumerable<IStorageItem> items)
+    {
+        foreach (var item in items)
+        {
+            _dt.Add(DataTransferItem.CreateFile(item));
+        }
+    }
 
-    public IEnumerable<string> GetFileNames() =>
-        Get(DataFormats.Files) as IEnumerable<string>;
+    public IReadOnlyList<IStorageItem> GetStorageItems()
+    {
+        return _dt.TryGetFiles();
+    }
 
-    /// <summary>
-    /// Gets the data for the operation as a string
-    /// </summary>
-    public string GetText() =>
-        Get(DataFormats.Text) as string;
+    public void SetBitmap(Bitmap bmp)
+    {
+        throw new NotImplementedException("Avalonia doesn't currently support this");
+    }
 
-    /// <summary>
-    /// Sets string content as the data for the operation
-    /// </summary>
-    /// <param name="txt"></param>
-    public void SetText(string txt) =>
-        _data.Add(DataFormats.Text, txt);
+    IReadOnlyList<DataFormat> IDataTransfer.Formats => _dt.Formats;
 
-    /// <summary>
-    /// Sets the data for the operation with the specified format
-    /// </summary>
-    public void SetData(string format, object value) =>
-        _data.Add(format, value);
+    IReadOnlyList<IDataTransferItem> IDataTransfer.Items => _dt.Items;
 
-    private readonly Dictionary<string, object> _data = new Dictionary<string, object>();
+    public IReadOnlyList<DataFormat> Formats => _dt.Formats;
+    public IReadOnlyList<IAsyncDataTransferItem> Items => _dt.Items;
+
+    public void Dispose()
+    {
+
+    }
+
+    private readonly DataTransfer _dt;
 }

--- a/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Headless.XUnit;
@@ -21,20 +22,12 @@ using Xunit;
 
 namespace FluentAvaloniaTests.ControlTests;
 
-public class TabViewTests : IDisposable
+public class TabViewTests
 {
-    public TabViewTests()
-    {
-        _window = new Window();
-        CreateTabView();
-        _window.Show();
-    }
-
-    public TabView TabView { get; private set; }
-
     [AvaloniaFact]
     public void TabItemsChangedEventFires()
     {
+        var (w, TabView) = GetTabView();
         bool eventFired = false;
         void ItemsChanged(TabView sender, EventArgs e)
         {
@@ -43,7 +36,7 @@ public class TabViewTests : IDisposable
 
         TabView.TabItemsChanged += ItemsChanged;
 
-        (TabView.TabItems as AvaloniaList<TabViewItem>).Add(new TabViewItem());
+        TabView.TabItems.Add(new TabViewItem());
 
         Assert.True(eventFired);
 
@@ -53,6 +46,7 @@ public class TabViewTests : IDisposable
     [AvaloniaFact]
     public void AddTabButtonFiresAddTabButtonClickEvent()
     {
+        var (w, TabView) = GetTabView();
         bool eventRaised = false;
         void TabAdd(TabView sender, EventArgs e)
         {
@@ -80,6 +74,7 @@ public class TabViewTests : IDisposable
     [AvaloniaFact]
     public void TabCloseButtonFiresTabCloseRequestedEvent()
     {
+        var (w, TabView) = GetTabView();
         bool eventRaised = false;
         void TabClose(TabView sender, TabViewTabCloseRequestedEventArgs e)
         {
@@ -88,7 +83,7 @@ public class TabViewTests : IDisposable
 
         TabView.TabCloseRequested += TabClose;
 
-        var firstItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[0];
+        var firstItem = TabView.TabItems[0] as TabViewItem;
 
         var button = firstItem.GetVisualDescendants()
             .OfType<Button>()
@@ -109,6 +104,7 @@ public class TabViewTests : IDisposable
     [AvaloniaFact]
     public void EqualTabWidthModeProducesEqualWidthTabs()
     {
+        var (w, TabView) = GetTabView();
         // This is the default TabViewWidthMode, so we don't need to switch states
         if (TabView.TabItems is AvaloniaList<TabViewItem> l)
         {
@@ -121,12 +117,122 @@ public class TabViewTests : IDisposable
         }
     }
 
-    // Other TabViewWidthModes need to be tested manually
+    // Other TabViewWidthModes need to be tested manually - however
+    // we can at least check that CompactTabWidth does what it supposed to
+    [AvaloniaFact]
+    public void CompactTabWidthModeHidesContentPresentersOfNonSelectedTabs()
+    {
+        // NOTE: Only the content presenter is hidden. WinUI does not hide the close button too
+        // The only thing that should be visible is the Icon (if present)
+        var (w, TabView) = GetTabView();
+        TabView.TabWidthMode = TabViewWidthMode.Compact;
+        TabView.SelectedIndex = 0;
+        var items = TabView.TabItems;
+
+        Assert.True(IsContentPresenterVisible(items[0] as TabViewItem));
+        Assert.False(IsContentPresenterVisible(items[1] as TabViewItem));
+        Assert.False(IsContentPresenterVisible(items[2] as TabViewItem));
+
+        static bool IsContentPresenterVisible(TabViewItem item)
+        {
+            var pres = item.GetTemplateChildren()
+                .FirstOrDefault(x => x is ContentPresenter);
+
+            if (pres == null)
+                Assert.False(true, "Unable to find ContentPresenter");
+
+            return pres.IsVisible;
+        }
+    }
+
+    [AvaloniaFact]
+    public void SelectedIndexIsSetWhenItemsAreAddedBeforeInitialization()
+    {
+        // If items are attached before the first layout pass when everything is loaded,
+        // the selected index should be implicitly set to 0 (the first item)
+        // NOTE: It does not happen if items are set AFTER everything is loaded - which matches WinUI
+
+        var (w, TabView) = GetTabView();
+        Assert.Equal(0, TabView.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void SettingSelectedIndexBeforeInitializationIsRespected()
+    {
+        var (w, TabView) = GetTabView(selIndex: 2);
+        Assert.Equal(2, TabView.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void TabContentIsSetWhenTabIsSelected()
+    {
+        var (w, TabView) = GetTabView();
+
+        var presenter = TabView.GetTemplateChildren()
+            .FirstOrDefault(x => x is ContentPresenter c && c.Name.Equals(FluentAvalonia.UI.Controls.TabView.s_tpTabContentPresenter)) as ContentPresenter;
+
+        Assert.Equal((TabView.TabItems[0] as TabViewItem).Content, presenter.Content);
+
+        TabView.SelectedIndex = 1;
+        Assert.Equal((TabView.TabItems[1] as TabViewItem).Content, presenter.Content);
+    }
+
+    [AvaloniaFact]
+    public void AddTabButtonRespectVisibleProperty()
+    {
+        var (w, TabView) = GetTabView();
+
+        var button = TabView.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(x => x.Name == TabView.s_tpAddButton);
+
+        // NOTE: Use IsEffectivelyVisible b/c the Binding is on the Border that hosts the
+        // button so IsVisible is not set
+        Assert.Equal(TabView.IsAddTabButtonVisible, button.IsEffectivelyVisible);
+
+        TabView.IsAddTabButtonVisible = false;
+        Assert.Equal(TabView.IsAddTabButtonVisible, button.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void LeftClickingOnTabItemChangesSelctedItem()
+    {
+        var (w, TabView) = GetTabView();
+        var item = TabView.TabItems[1] as TabViewItem;
+
+        item.ClickControl(new Point(10, 10), MouseButton.Left);
+
+        Assert.Equal(item, TabView.SelectedItem);
+        Assert.Equal(1, TabView.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void MiddleClickingOnTabItemRequestsCloseIfClosable()
+    {
+        bool raisedEvent = false;
+        void RequestClose(object sender, TabViewTabCloseRequestedEventArgs args)
+        {
+            raisedEvent = true;
+        }
+
+        var (w, TabView) = GetTabView();
+        TabView.TabCloseRequested += RequestClose;
+        var item = TabView.TabItems[0] as TabViewItem;
+        var item2 = TabView.TabItems[1] as TabViewItem;
+        item.IsClosable = false;
+
+        item.ClickControl(new Point(10, 10), MouseButton.Middle);
+        Assert.False(raisedEvent);
+
+        item2.ClickControl(new Point(10, 10), MouseButton.Middle);
+        Assert.True(raisedEvent);
+    }
 
     [AvaloniaFact]
     public void TabViewItemCloseButtonOverlayModeWorks()
     {
-        var firstItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[0];
+        var (w, TabView) = GetTabView();
+        var firstItem = TabView.TabItems[0] as TabViewItem;
 
         var button = firstItem.GetVisualDescendants()
            .OfType<Button>()
@@ -144,7 +250,7 @@ public class TabViewTests : IDisposable
 
         // Switch to the second item, which is unselected and should hide its close button by default, if in
         // PointerOver mode
-        var secondItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[1];
+        var secondItem = TabView.TabItems[1] as TabViewItem;
         button = secondItem.GetVisualDescendants()
            .OfType<Button>()
            .FirstOrDefault(x => x.Name == "CloseButton");
@@ -162,16 +268,18 @@ public class TabViewTests : IDisposable
     [AvaloniaFact]
     public void TabViewItemIsClosableFalseHidesCloseButton()
     {
-        var firstItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[0];
+        var (w, TabView) = GetTabView();
+        var firstItem = TabView.TabItems[0] as TabViewItem;
 
-        var button = firstItem.GetVisualDescendants()
-           .OfType<Button>()
-           .FirstOrDefault(x => x.Name == "CloseButton");
+        var vd = firstItem.GetVisualDescendants();
+           var button = vd.OfType<Button>()
+           .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
 
         // Default state is for it to be visible
         Assert.NotNull(button);
 
         firstItem.IsClosable = false;
+        var pc = firstItem.Classes;
         // Even the selected tab should hide it
         Assert.False(button.IsVisible);
 
@@ -180,10 +288,10 @@ public class TabViewTests : IDisposable
         Assert.True(button.IsVisible);
 
         // Switch to the second item, just to double check unselected items
-        var secondItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[1];
+        var secondItem = TabView.TabItems[1] as TabViewItem;
         button = secondItem.GetVisualDescendants()
            .OfType<Button>()
-           .FirstOrDefault(x => x.Name == "CloseButton");
+           .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
 
         secondItem.IsClosable = false;
         Assert.False(button.IsVisible);
@@ -196,6 +304,7 @@ public class TabViewTests : IDisposable
     [AvaloniaFact]
     public void TabViewAddButtonCommandWorks()
     {
+        var (w, TabView) = GetTabView();
         bool commandInvoked = false;
         void TabAdd(object parameter)
         {
@@ -206,20 +315,19 @@ public class TabViewTests : IDisposable
 
         bool active = true;
         var testCommand = new TestCommand(TabAdd, x => active);
+       
         TabView.AddTabButtonCommand = testCommand;
         TabView.AddTabButtonCommandParameter = "Parameter";
 
         var button = TabView.GetVisualDescendants()
             .OfType<Button>()
-            .FirstOrDefault(x => x.Name == "AddButton");
+            .FirstOrDefault(x => x.Name == TabView.s_tpAddButton);
 
         Assert.NotNull(button);
 
-        Assert.True(button.IsEnabled);
-
+        Assert.True(button.IsEnabled);        
         button.ClickControl(new Point(10, 10), MouseButton.Left);
         Assert.True(commandInvoked);
-
 
         active = false;
         testCommand.Invalidate();
@@ -230,9 +338,27 @@ public class TabViewTests : IDisposable
     }
 
     [AvaloniaFact]
+    public void ClickingAddTabButtonRaisesAddTabButtonClickEvent()
+    {
+        var (w, TabView) = GetTabView();
+        bool eventRaised = false;
+        void Handler(TabView tv, EventArgs args)
+        {
+            eventRaised = true;
+        }
+        TabView.AddTabButtonClick += Handler;
+
+        var button = TabView.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(x => x.Name == TabView.s_tpAddButton);
+        button.ClickControl(new Point(10, 10), MouseButton.Left);
+        Assert.True(eventRaised);
+    }
+
+    [AvaloniaFact]
     public void BindingItemsGeneratesTabItems()
     {
-        CreateTabView(false);
+        var (w, TabView) = GetTabView(false);
         var tv = TabView;
         tv.TabItemTemplate = new FuncDataTemplate<TestTabItem>((x, ns) =>
         {
@@ -249,7 +375,7 @@ public class TabViewTests : IDisposable
             new TestTabItem { Header = "This is tab 2", Content = "Tab2 Content" },
             new TestTabItem { Header = "This is tab 3", Content = "Tab2 Content" },
         };
-        tv.TabItems = items;
+        tv.TabItemsSource = items;
 
         Dispatcher.UIThread.RunJobs();
 
@@ -258,37 +384,171 @@ public class TabViewTests : IDisposable
             var container = tv.ContainerFromIndex(i);
             Assert.IsType<TabViewItem>(container);
         }
-
-        Assert.Equal(0, tv.SelectedIndex);
-
-        CreateTabView(); // Reset it
     }
 
-    private void CreateTabView(bool addTabs = true)
+    [AvaloniaFact]
+    public void UsingTabItemsSourceSetsTabItemsToListViewItemCollection()
     {
-        TabView = new TabView();
-        if (addTabs)
-            AddTabItems();
-
-        _window.Content = TabView;
-    }
-
-    private void AddTabItems()
-    {
-        TabView.TabItems = new AvaloniaList<TabViewItem>
+        var (w, TabView) = GetTabView(false);
+        var items = new List<TestTabItem>
         {
-            new TabViewItem { Header = "Tab1" },
-            new TabViewItem { Header = "Tab2" },
-            new TabViewItem { Header = "Tab3" }
+            new TestTabItem { Header = "This is tab 1", Content = "Tab1 Content" },
+            new TestTabItem { Header = "This is tab 2", Content = "Tab2 Content" },
+            new TestTabItem { Header = "This is tab 3", Content = "Tab2 Content" },
         };
+        TabView.TabItemsSource = items;
+
+        Assert.IsType<ItemCollection>(TabView.TabItems);
+        Assert.Equal(items.Count, TabView.TabItems.Count);
     }
 
-    public void Dispose()
+    [AvaloniaFact]
+    public void SelectionChangeIsFiredWhenSelectedItemOrIndexChanges()
     {
-        _window.Close();
+        var (w, TabView) = GetTabView();
+
+        SelectionChangedEventArgs args = null;
+        void Handler(object sender, SelectionChangedEventArgs e)
+        {
+            args = e;
+        }
+
+        TabView.SelectionChanged += Handler;
+
+        TabView.SelectedIndex = 1;
+
+        Assert.NotNull(args);
+
+        Assert.Single(args.AddedItems);
+        Assert.Single(args.RemovedItems);
+
+        Assert.Equal(TabView.TabItems[1], args.AddedItems[0]);
+        Assert.Equal(TabView.TabItems[0], args.RemovedItems[0]);
     }
 
-    private Window _window;
+    [AvaloniaFact]
+    public void TabCloseRequestedEventHasCorrectInfoWithTabItemsSet()
+    {
+        TabViewTabCloseRequestedEventArgs args = null;
+        void RequestClose(object sender, TabViewTabCloseRequestedEventArgs e)
+        {
+            args = e;
+        }
+
+        var (w, TabView) = GetTabView();
+        TabView.TabCloseRequested += RequestClose;
+        var item = TabView.TabItems[0] as TabViewItem;
+
+        var vd = item.GetVisualDescendants();
+        var button = vd.OfType<Button>()
+            .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
+
+        button.ClickControl(new Point(10, 10), MouseButton.Left);
+
+        Assert.NotNull(args);
+        Assert.Equal(item, args.Item);
+        Assert.Equal(item, args.Tab);
+    }
+
+    [AvaloniaFact]
+    public void TabCloseRequestedEventHasCorrectInfoWithTabItemsSourceSet()
+    {
+        TabViewTabCloseRequestedEventArgs args = null;
+        void RequestClose(object sender, TabViewTabCloseRequestedEventArgs e)
+        {
+            args = e;
+        }
+
+        var (w, TabView) = GetTabView(false);
+        var items = new List<TestTabItem>
+        {
+            new TestTabItem { Header = "This is tab 1", Content = "Tab1 Content" },
+            new TestTabItem { Header = "This is tab 2", Content = "Tab2 Content" },
+            new TestTabItem { Header = "This is tab 3", Content = "Tab2 Content" },
+        };
+        TabView.TabItemsSource = items;
+        TabView.UpdateLayout();
+
+        TabView.TabCloseRequested += RequestClose;
+        var item = TabView.ContainerFromIndex(0) as TabViewItem;
+
+        var vd = item.GetVisualDescendants();
+        var button = vd.OfType<Button>()
+            .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
+
+        button.ClickControl(new Point(10, 10), MouseButton.Left);
+
+        Assert.NotNull(args);
+        Assert.Equal(items[0], args.Item);
+        Assert.Equal(item, args.Tab);
+    }
+
+    [AvaloniaFact]
+    public void ClosingTabAttemptsToKeepSelection()
+    {
+        var (w, TabView) = GetTabView();
+
+        void RequestClose(object sender, TabViewTabCloseRequestedEventArgs e)
+        {
+            // NOTE: Because TabItems is an IList, Remove throws an exception
+            // Hoping this gets fixed, opened issue #21046
+            TabView.TabItems.RemoveAt(TabView.TabItems.IndexOf(e.Tab));
+        }
+        
+        TabView.TabCloseRequested += RequestClose;
+        var item = TabView.TabItems[0] as TabViewItem;
+        var item1 = TabView.TabItems[1];
+
+        var vd = item.GetVisualDescendants();
+        var button = vd.OfType<Button>()
+            .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
+
+        button.ClickControl(new Point(10, 10), MouseButton.Left);
+
+        Assert.Equal(0, TabView.SelectedIndex);
+        Assert.Equal(item1, TabView.SelectedItem);
+        w.Close();
+
+        // Redo the test, but this time close the last item and it should set to the new last item
+        (w, TabView) = GetTabView();
+        TabView.SelectedIndex = 2;
+
+        TabView.TabCloseRequested += RequestClose;
+        item = TabView.TabItems[^1] as TabViewItem;
+        item1 = TabView.TabItems[^2];
+
+        vd = item.GetVisualDescendants();
+        button = vd.OfType<Button>()
+            .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
+
+        button.ClickControl(new Point(10, 10), MouseButton.Left);
+
+        Assert.Equal(TabView.TabItems.Count - 1, TabView.SelectedIndex);
+        Assert.Equal(item1, TabView.SelectedItem);
+        w.Close();
+    }
+
+    private (Window w, TabView tv) GetTabView(bool addTabs = true, int? selIndex = null)
+    {
+        var tv = new TabView();
+        if (addTabs)
+        {
+            tv.TabItems.Add(new TabViewItem { Header = "Tab1", Content = "ContentTab1" });
+            tv.TabItems.Add(new TabViewItem { Header = "Tab2", Content = "ContentTab2" });
+            tv.TabItems.Add(new TabViewItem { Header = "Tab3", Content = "ContentTab3" });
+        }
+
+        if (selIndex.HasValue)
+        {
+            tv.SelectedIndex = selIndex.Value;
+        }
+
+        var w = new Window { Content = tv };
+        w.Show();
+        tv.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (w, tv);
+    }
 }
 
 public class TestTabItem

--- a/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
@@ -7,8 +7,10 @@ using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
@@ -744,6 +746,87 @@ public class TabViewTests
             idx++;
         }
     }
+
+    [AvaloniaFact]
+    public void DragItemsStartingDoesNotFireWithReorder()
+    {
+        var (w, TabView) = GetTabViewWithItemsSource();
+        TabView.CanDragTabs = false;
+        TabView.CanReorderTabs = true;
+        DragDrop.SetAllowDrop(w, true); // Ensure the window is a drop target so we get events
+
+        Dispatcher.UIThread.RunJobs();
+
+        bool fired = false;
+        TabView.TabDragStarting += (s, e) =>
+        {
+            fired = true;
+        };
+
+        var tabItem = TabView.ContainerFromIndex(0);
+
+        tabItem.MouseDownControl(new Point(10, 10), MouseButton.Left);
+        tabItem.MoveMouseToControl(new Point(100, 10));
+        tabItem.MouseUpControl(new Point(110, 0), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(fired);
+    }
+
+    [AvaloniaFact]
+    public void DragItemsStartingFiresWhenCanDragTabsIsTrue()
+    {
+        var (w, TabView) = GetTabViewWithItemsSource();
+        TabView.CanDragTabs = true;
+        TabView.CanReorderTabs = true;
+
+        Dispatcher.UIThread.RunJobs();
+
+        TabViewTabDragStartingEventArgs args = null;
+        TabView.TabDragStarting += (s, e) =>
+        {
+            args = e;
+        };
+
+        var tabItem = TabView.ContainerFromIndex(0);
+
+        tabItem.MouseDownControl(new Point(10, 10), MouseButton.Left);
+        tabItem.MoveMouseToControl(new Point(100, 10));
+        tabItem.MouseUpControl(new Point(110, 0), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(args);
+        Assert.Equal(tabItem, args.Tab);
+        Assert.Equal(TabView.TabItemsSource.ElementAt(0), args.Item);
+    }
+
+    [AvaloniaFact]
+    public void DragItemsCompletedFiresWhenDnDIsFinished()
+    {
+        var (w, TabView) = GetTabViewWithItemsSource();
+        TabView.CanDragTabs = true;
+        TabView.CanReorderTabs = true;
+
+        Dispatcher.UIThread.RunJobs();
+
+        TabViewTabDragCompletedEventArgs args = null;
+        TabView.TabDragCompleted += (s, e) =>
+        {
+            args = e;
+        };
+
+        var tabItem = TabView.ContainerFromIndex(0);
+
+        tabItem.MouseDownControl(new Point(10, 10), MouseButton.Left);
+        tabItem.MoveMouseToControl(new Point(100, 10));
+        tabItem.MouseUpControl(new Point(110, 0), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(args);
+        Assert.Equal(tabItem, args.Tab);
+        Assert.Equal(TabView.TabItemsSource.ElementAt(0), args.Item);
+    }
+
 
 
     private (Window w, TabView tv) GetTabView(bool addTabs = true, int? selIndex = null)

--- a/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
@@ -16,11 +16,17 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using FluentAvalonia.Core;
 using FluentAvalonia.UI.Controls;
 using FluentAvaloniaTests.Helpers;
 using Xunit;
 
 namespace FluentAvaloniaTests.ControlTests;
+
+// TODO: Tests to Add
+// Check Keyboard Accelerators
+
+
 
 public class TabViewTests
 {
@@ -272,8 +278,8 @@ public class TabViewTests
         var firstItem = TabView.TabItems[0] as TabViewItem;
 
         var vd = firstItem.GetVisualDescendants();
-           var button = vd.OfType<Button>()
-           .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
+        var button = vd.OfType<Button>()
+        .FirstOrDefault(x => x.Name == TabViewItem.s_tpCloseButton);
 
         // Default state is for it to be visible
         Assert.NotNull(button);
@@ -315,7 +321,7 @@ public class TabViewTests
 
         bool active = true;
         var testCommand = new TestCommand(TabAdd, x => active);
-       
+
         TabView.AddTabButtonCommand = testCommand;
         TabView.AddTabButtonCommandParameter = "Parameter";
 
@@ -325,7 +331,7 @@ public class TabViewTests
 
         Assert.NotNull(button);
 
-        Assert.True(button.IsEnabled);        
+        Assert.True(button.IsEnabled);
         button.ClickControl(new Point(10, 10), MouseButton.Left);
         Assert.True(commandInvoked);
 
@@ -494,7 +500,7 @@ public class TabViewTests
             // Hoping this gets fixed, opened issue #21046
             TabView.TabItems.RemoveAt(TabView.TabItems.IndexOf(e.Tab));
         }
-        
+
         TabView.TabCloseRequested += RequestClose;
         var item = TabView.TabItems[0] as TabViewItem;
         var item1 = TabView.TabItems[1];
@@ -528,6 +534,218 @@ public class TabViewTests
         w.Close();
     }
 
+    [AvaloniaFact]
+    public void TabViewDefaultsToTopMode()
+    {
+        var (w, TabView) = GetTabView();
+
+        Assert.True(ClassesContains(TabView.Classes, TabView.s_pcTop));
+
+        Assert.True(ClassesContains(TabView.ListView.Classes, TabView.s_pcTop));
+        Assert.True(ClassesContains(TabView.ListView.Scroller.Classes, TabView.s_pcTop));
+
+        foreach (var item in TabView.TabItems)
+            Assert.True(ClassesContains((item as TabViewItem).Classes, TabView.s_pcTop));
+    }
+
+    [AvaloniaFact]
+    public void ChangingTabStripLocationUpdatesAllPseudoclasses()
+    {
+        var (w, TabView) = GetTabView();
+
+        // LEFT TEST
+        TabView.TabStripLocation = TabViewTabStripLocation.Left;
+        Assert.True(ClassesContains(TabView.Classes, TabView.s_pcLeft));
+
+        Assert.True(ClassesContains(TabView.ListView.Classes, TabView.s_pcLeft));
+        Assert.True(ClassesContains(TabView.ListView.Scroller.Classes, TabView.s_pcLeft));
+
+        foreach (var item in TabView.TabItems)
+            Assert.True(ClassesContains((item as TabViewItem).Classes, TabView.s_pcLeft));
+
+        // RIGHT TEST
+        TabView.TabStripLocation = TabViewTabStripLocation.Right;
+        Assert.True(ClassesContains(TabView.Classes, TabView.s_pcRight));
+
+        Assert.True(ClassesContains(TabView.ListView.Classes, TabView.s_pcRight));
+        Assert.True(ClassesContains(TabView.ListView.Scroller.Classes, TabView.s_pcRight));
+
+        foreach (var item in TabView.TabItems)
+            Assert.True(ClassesContains((item as TabViewItem).Classes, TabView.s_pcRight));
+
+        // BOTTOM TEST
+        TabView.TabStripLocation = TabViewTabStripLocation.Bottom;
+        Assert.True(ClassesContains(TabView.Classes, TabView.s_pcBottom));
+
+        Assert.True(ClassesContains(TabView.ListView.Classes, TabView.s_pcBottom));
+        Assert.True(ClassesContains(TabView.ListView.Scroller.Classes, TabView.s_pcBottom));
+
+        foreach (var item in TabView.TabItems)
+            Assert.True(ClassesContains((item as TabViewItem).Classes, TabView.s_pcBottom));
+
+        // BACK TO TOP TEST
+        TabView.TabStripLocation = TabViewTabStripLocation.Top;
+        Assert.True(ClassesContains(TabView.Classes, TabView.s_pcTop));
+
+        Assert.True(ClassesContains(TabView.ListView.Classes, TabView.s_pcTop));
+        Assert.True(ClassesContains(TabView.ListView.Scroller.Classes, TabView.s_pcTop));
+
+        foreach (var item in TabView.TabItems)
+            Assert.True(ClassesContains((item as TabViewItem).Classes, TabView.s_pcTop));        
+    }
+
+    [AvaloniaFact]
+    public void AddingNewItemsSetsStripLocationOnTab()
+    {
+        // TODO: Turn this back on when we can do this
+        //var (w, TabView) = GetTabView();
+        //TabView.TabStripLocation = TabViewTabStripLocation.Left;
+
+        //var newItem = new TabViewItem();
+        //TabView.TabItems.Add(newItem);
+        //TabView.UpdateLayout();
+        //Assert.True(ClassesContains(newItem.Classes, TabView.s_pcLeft));
+        //w.Close();
+
+        // NOW CHECK WITH TABITEMSSOURCE
+        var (w, TabView) = GetTabView(false);
+        TabView.TabStripLocation = TabViewTabStripLocation.Left;
+        var items = new AvaloniaList<TestTabItem>
+        {
+            new TestTabItem { Header = "This is tab 1", Content = "Tab1 Content" },
+            new TestTabItem { Header = "This is tab 2", Content = "Tab2 Content" },
+            new TestTabItem { Header = "This is tab 3", Content = "Tab2 Content" },
+        };
+        TabView.TabItemsSource = items;
+        TabView.UpdateLayout();
+
+        items.Add(new TestTabItem());
+        TabView.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        var panel = TabView.ListView.ItemsPanelRoot;
+        var item = TabView.ContainerFromIndex(3);
+        Assert.True(ClassesContains(item.Classes, TabView.s_pcLeft));
+    }
+
+    [AvaloniaFact]
+    public void ChangingTabStripLocationPreservesSelection()
+    {
+        var (w, TabView) = GetTabViewWithItemsSource();
+        TabView.SelectedIndex = 1;
+
+        TabView.TabStripLocation = TabViewTabStripLocation.Left;
+        TabView.UpdateLayout();
+        Assert.Equal(1, TabView.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void AddingTabsWhileVirtualizedInitializesCorrectly()
+    {
+        var (w, TabView) = GetTabView(false);
+        var l = new AvaloniaList<string>();
+        for (int i = 0; i < 100; i++)
+        {
+            l.Add($"New Tab {i + 1}");
+        }
+        TabView.TabItemsSource = l;
+        TabView.UpdateLayout();
+        TabView.SelectedIndex = 0;
+        TabView.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        // Baseline check: First item is selected, it should have the :noborder class
+        // All other items should not have it
+        var item0 = TabView.ContainerFromIndex(0);
+        Assert.True(ClassesContains(item0.Classes, SharedPseudoclasses.s_pcNoBorder));
+
+        int idx = 1;        
+        while (idx < l.Count)
+        {
+            var item = TabView.ContainerFromIndex(idx);
+            if (item == null)
+                break; // End of realized containers
+
+            Assert.False(ClassesContains(item.Classes, SharedPseudoclasses.s_pcNoBorder));
+            idx++;
+        }
+
+        // Now scroll and recheck
+        var scroller = TabView.ListView.Scroller;
+        var scrollableWidth = scroller.Extent.Width - scroller.Viewport.Width;
+        scroller.Offset = new Vector(scrollableWidth * 0.5, 0);
+        TabView.UpdateLayout();
+
+        // Recheck - first item is still selected so all other containers should
+        // not have the :noborder class
+        // Skip Item0 b/c its the "focused" item in the Panel so it will always return a container in ContainerFromIndex
+        idx = 1; 
+        bool foundFirstRealized = false;
+        while (idx < l.Count)
+        {
+            var cont = TabView.ContainerFromIndex(idx);
+            if (!foundFirstRealized && cont == null)
+            {
+                idx++;
+                continue;
+            }
+
+            foundFirstRealized = true;
+            if (cont == null)
+                break;
+
+            Assert.False(ClassesContains(cont.Classes, SharedPseudoclasses.s_pcNoBorder), $"Failed on container {idx}");
+            Assert.False(ClassesContains(cont.Classes, SharedPseudoclasses.s_pcBorderLeft), $"Failed on container {idx}");
+            Assert.False(ClassesContains(cont.Classes, SharedPseudoclasses.s_pcBorderRight), $"Failed on container {idx}");
+            idx++;
+        }
+
+        // Now go back and ensure the first 2 containers (Sel + Sel+1) have their state set correctly
+        scroller.Offset = new Vector(0, 0);
+        TabView.UpdateLayout();
+
+        // Should be :noborder only (selected)
+        item0 = TabView.ContainerFromIndex(0);
+        Assert.True(ClassesContains(item0.Classes, SharedPseudoclasses.s_pcNoBorder));
+        Assert.False(ClassesContains(item0.Classes, SharedPseudoclasses.s_pcBorderLeft));
+        Assert.False(ClassesContains(item0.Classes, SharedPseudoclasses.s_pcBorderRight));
+        
+        // Should be :borderright (selected + 1)
+        var item1 = TabView.ContainerFromIndex(1);
+        Assert.False(ClassesContains(item1.Classes, SharedPseudoclasses.s_pcNoBorder));
+        Assert.False(ClassesContains(item1.Classes, SharedPseudoclasses.s_pcBorderLeft));
+        Assert.True(ClassesContains(item1.Classes, SharedPseudoclasses.s_pcBorderRight));
+    }
+
+    [AvaloniaFact]
+    public void TabWidthsAreEqualInEqualMode()
+    {
+        var (w, TabView) = GetTabView(false);
+        w.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        var l = new AvaloniaList<string>();
+        for (int i = 0; i < 100; i++)
+        {
+            l.Add($"New Tab {i + 1}");
+        }
+        TabView.TabItemsSource = l;
+        TabView.UpdateLayout();
+        TabView.SelectedIndex = 0;
+        TabView.UpdateLayout();
+
+        var width0 = TabView.ContainerFromIndex(0).Bounds.Width;
+
+        int idx = 1;
+        while (idx < l.Count)
+        {
+            var cont = TabView.ContainerFromIndex(idx);
+            if (cont == null)
+                break;
+
+            Assert.True(width0 == cont.Bounds.Width, $"Failed on container {idx}, {cont.Bounds.Width} expecting {width0}");
+            idx++;
+        }
+    }
+
+
     private (Window w, TabView tv) GetTabView(bool addTabs = true, int? selIndex = null)
     {
         var tv = new TabView();
@@ -549,6 +767,35 @@ public class TabViewTests
         Dispatcher.UIThread.RunJobs();
         return (w, tv);
     }
+
+    private (Window w, TabView tv) GetTabViewWithItemsSource(bool addTabs = true, int? selIndex = null)
+    {
+        var tv = new TabView();
+        if (addTabs)
+        {
+            var l = new AvaloniaList<TestTabItem>
+            {
+                new TestTabItem { Header = "This is tab 1", Content = "Tab1 Content" },
+                new TestTabItem { Header = "This is tab 2", Content = "Tab2 Content" },
+                new TestTabItem { Header = "This is tab 3", Content = "Tab2 Content" },
+            };
+            tv.TabItemsSource = l;
+        }
+
+        if (selIndex.HasValue)
+        {
+            tv.SelectedIndex = selIndex.Value;
+        }
+
+        var w = new Window { Content = tv };
+        w.Show();
+        tv.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (w, tv);
+    }
+
+    private static bool ClassesContains(Classes classes, string c) =>
+            classes.Contains(c);
 }
 
 public class TestTabItem

--- a/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/TabViewTests.cs
@@ -1,342 +1,299 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
-//using Avalonia;
-//using Avalonia.Collections;
-//using Avalonia.Controls;
-//using Avalonia.Controls.Templates;
-//using Avalonia.Data;
-//using Avalonia.Input;
-//using Avalonia.Input.Raw;
-//using Avalonia.Markup.Xaml;
-//using Avalonia.Styling;
-//using Avalonia.VisualTree;
-//using FluentAvalonia.UI.Controls;
-//using FluentAvaloniaTests.Helpers;
-//using Xunit;
-
-//namespace FluentAvaloniaTests.ControlTests;
-
-//public class TabViewTestsContext : IDisposable
-//{
-//    public TabViewTestsContext()
-//    {
-//        _appDisposable = UnitTestApplication.Start();
-
-//        CreateTabView();
-//    }
-
-//    public TabView TabView { get; private set; }
-
-//    public TestRoot Root { get; private set; }
-
-//    public void Dispose()
-//    {
-//        _appDisposable.Dispose();
-//    }
-
-//    public void ResetTabView()
-//    {
-//        TabView = new TabView();
-//        AddTabItems();
-
-//        Root.Child = TabView;
-
-//        Root.LayoutManager.ExecuteInitialLayoutPass();
-//        Root.LayoutManager.ExecuteLayoutPass();
-//    }
-
-//    private void CreateTabView()
-//    {
-//        Root = new TestRoot(new Size(1280, 720));
-//        Root.StylingParent = UnitTestApplication.Current;
-
-//        //UnitTestApplication.Current.Styles.Add(
-//        //    (IStyle)AvaloniaXamlLoader.Load(new Uri("avares://FluentAvalonia/Styling/Controls/TabView/TabViewStyles.axaml")));
-
-//        TabView = new TabView();
-//        AddTabItems();
-
-//        Root.Child = TabView;
-
-//        Root.LayoutManager.ExecuteInitialLayoutPass();
-//        Root.LayoutManager.ExecuteLayoutPass();
-//    }
-
-//    private void AddTabItems()
-//    {
-//        TabView.TabItems = new AvaloniaList<TabViewItem>
-//        {
-//            new TabViewItem { Header = "Tab1" },
-//            new TabViewItem { Header = "Tab2" },
-//            new TabViewItem { Header = "Tab3" }
-//        };
-//    }
-
-//    private IDisposable _appDisposable;
-//}
-
-//public class TabViewTests : IClassFixture<TabViewTestsContext>
-//{
-//    public TabViewTests(TabViewTestsContext ctx)
-//    {
-//        Context = ctx;
-//    }
-
-//    public TabViewTestsContext Context { get; }
-
-//    [Fact]
-//    public void TabItemsChangedEventFires()
-//    {
-//        bool eventFired = false;
-//        void ItemsChanged(TabView sender, EventArgs e)
-//        {
-//            eventFired = true;
-//        }
-
-//        Context.TabView.TabItemsChanged += ItemsChanged;
-
-//        (Context.TabView.TabItems as AvaloniaList<TabViewItem>).Add(new TabViewItem());
-
-//        Assert.True(eventFired);
-
-//        Context.TabView.TabItemsChanged -= ItemsChanged;
-//    }
-
-//    [Fact]
-//    public void AddTabButtonFiresAddTabButtonClickEvent()
-//    {
-//        bool eventRaised = false;
-//        void TabAdd(TabView sender, EventArgs e)
-//        {
-//            eventRaised = true;
-//        }
-
-//        Context.TabView.AddTabButtonClick += TabAdd;
-
-//        var button = Context.TabView.GetVisualDescendants()
-//            .OfType<Button>()
-//            .Where(x => x.Name == "AddButton")
-//            .FirstOrDefault();
-
-//        Assert.NotNull(button);
-
-//        button.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs
-//        {
-//            RoutedEvent = Button.ClickEvent,
-//        });
-
-//        Assert.True(eventRaised);
-
-//        Context.TabView.AddTabButtonClick -= TabAdd;
-//    }
-
-//    [Fact]
-//    public void TabCloseButtonFiresTabCloseRequestedEvent()
-//    {
-//        bool eventRaised = false;
-//        void TabClose(TabView sender, TabViewTabCloseRequestedEventArgs e)
-//        {
-//            eventRaised = true;
-//        }
-
-//        Context.TabView.TabCloseRequested += TabClose;
-
-//        var firstItem = (Context.TabView.TabItems as AvaloniaList<TabViewItem>)[0];
-
-//        var button = firstItem.GetVisualDescendants()
-//            .OfType<Button>()
-//            .Where(x => x.Name == "CloseButton")
-//            .FirstOrDefault();
-
-//        Assert.NotNull(button);
-
-//        button.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs
-//        {
-//            RoutedEvent = Button.ClickEvent,
-//        });
-
-//        Assert.True(eventRaised);
-
-//        Context.TabView.TabCloseRequested -= TabClose;
-//    }
-
-//    [Fact]
-//    public void EqualTabWidthModeProducesEqualWidthTabs()
-//    {
-//        // This is the default TabViewWidthMode, so we don't need to switch states
-//        if (Context.TabView.TabItems is AvaloniaList<TabViewItem> l)
-//        {
-//            var firstSize = l[0].Bounds.Width;
-
-//            for (int i = 1; i < l.Count; i++)
-//            {
-//                if (l[i].Bounds.Width != firstSize)
-//                {
-//                    Assert.False(true);
-//                }
-//            }
-//        }
-
-//        Assert.True(true);
-//    }
-
-//    // Other TabViewWidthModes need to be tested manually
-
-//    [Fact]
-//    public void TabViewItemCloseButtonOverlayModeWorks()
-//    {
-//        var firstItem = (Context.TabView.TabItems as AvaloniaList<TabViewItem>)[0];
-
-//        var button = firstItem.GetVisualDescendants()
-//           .OfType<Button>()
-//           .Where(x => x.Name == "CloseButton")
-//           .FirstOrDefault();
-
-//        // Default state is for it to be visible
-//        Assert.NotNull(button);
-//        Assert.True(button.IsVisible);
-
-//        // Currently using the first item, which is selected by default...this should still display its
-//        // close button even if not pointer over
-//        Context.TabView.CloseButtonOverlayMode = TabViewCloseButtonOverlayMode.OnPointerOver;
-//        Assert.True(button.IsVisible);
-        
-//        // Switch to the second item, which is unselected and should hide its close button by default, if in
-//        // PointerOver mode
-//        var secondItem = (Context.TabView.TabItems as AvaloniaList<TabViewItem>)[1];
-//        button = secondItem.GetVisualDescendants()
-//           .OfType<Button>()
-//           .Where(x => x.Name == "CloseButton")
-//           .FirstOrDefault();
-
-//        Assert.False(button.IsVisible);
-
-//        secondItem.RaiseEvent(new PointerEventArgs(InputElement.PointerEnteredEvent, button, null, Context.Root, new Point(), 0, 
-//            new PointerPointProperties(), KeyModifiers.None));
-//        Assert.True(button.IsVisible);
-//        secondItem.RaiseEvent(new PointerEventArgs(InputElement.PointerExitedEvent, button, null, Context.Root, new Point(), 0, 
-//            new PointerPointProperties(), KeyModifiers.None));
-
-//        Context.TabView.CloseButtonOverlayMode = TabViewCloseButtonOverlayMode.Auto; //Auto is default state, same as Always
-//    }
-
-//    [Fact]
-//    public void TabViewItemIsClosableFalseHidesCloseButton()
-//    {
-//        var firstItem = (Context.TabView.TabItems as AvaloniaList<TabViewItem>)[0];
-
-//        var button = firstItem.GetVisualDescendants()
-//           .OfType<Button>()
-//           .Where(x => x.Name == "CloseButton")
-//           .FirstOrDefault();
-
-//        // Default state is for it to be visible
-//        Assert.NotNull(button);
-
-//        firstItem.IsClosable = false;
-//        // Even the selected tab should hide it
-//        Assert.False(button.IsVisible);
-
-//        // Make sure it returns
-//        firstItem.IsClosable = true;
-//        Assert.True(button.IsVisible);
-
-//        // Switch to the second item, just to double check unselected items
-//        var secondItem = (Context.TabView.TabItems as AvaloniaList<TabViewItem>)[1];
-//        button = secondItem.GetVisualDescendants()
-//           .OfType<Button>()
-//           .Where(x => x.Name == "CloseButton")
-//           .FirstOrDefault();
-
-//        secondItem.IsClosable = false;
-//        Assert.False(button.IsVisible);
-
-//        // Make sure it returns
-//        secondItem.IsClosable = true;
-//        Assert.True(button.IsVisible);
-//    }
-
-//    [Fact]
-//    public void TabViewAddButtonCommandWorks()
-//    {
-//        bool commandInvoked = false;
-//        void TabAdd(object parameter)
-//        {
-//            commandInvoked = true;
-
-//            Assert.Equal("Parameter", parameter);
-//        }
-//        var testCommand = new TestCommand(TabAdd);
-//        Context.TabView.AddTabButtonCommand = testCommand;
-//        Context.TabView.AddTabButtonCommandParameter = "Parameter";
-
-//        var button = Context.TabView.GetVisualDescendants()
-//            .OfType<Button>()
-//            .Where(x => x.Name == "AddButton")
-//            .FirstOrDefault();
-
-//        Assert.NotNull(button);
-
-//        Assert.True(button.IsEnabled);
-
-//        // Have to trigger pointer event to properly get click/command to work
-//        // But having trouble getting fake pointer events to pass the 
-//        // GetVisualsAt test Button does in PointerReleased, so will invoke via reflection
-//        var clickMethod = 
-//            button.GetType().GetMethod("OnClick", 
-//            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-
-//        clickMethod?.Invoke(button, null);
-
-//        Assert.True(commandInvoked);
-
-
-//        testCommand.SetCanExecute(false);
-//        Assert.False(button.IsEffectivelyEnabled);
-
-//        Context.TabView.AddTabButtonCommandParameter = null;
-//        Context.TabView.AddTabButtonCommand = null;
-//    }
-
-//    [Fact]
-//    public void BindingItemsGeneratesTabItems()
-//    {
-//        var tv = Context.TabView;  
-//        tv.TabItemTemplate = new FuncDataTemplate<TestTabItem>((x, ns) =>
-//        {
-//            return new TabViewItem
-//            {
-//                [!TabViewItem.HeaderProperty] = new Binding("Header"),
-//                [!TabViewItem.ContentProperty] = new Binding("Content")
-//            };
-//        });
-
-//        var items = new List<TestTabItem>
-//        {
-//            new TestTabItem { Header = "This is tab 1", Content = "Tab1 Content" },
-//            new TestTabItem { Header = "This is tab 2", Content = "Tab2 Content" },
-//            new TestTabItem { Header = "This is tab 3", Content = "Tab2 Content" },
-//        };
-//        tv.TabItems = items;
-
-//        for (int i = 0; i < items.Count; i++)
-//        {
-//            var container = tv.ContainerFromIndex(i);
-//            Assert.IsType<TabViewItem>(container);
-//        }
-
-//        Assert.Equal(0, tv.SelectedIndex);
-
-//        Context.ResetTabView();
-//    }
-//}
-
-//public class TestTabItem
-//{
-//    public string Header { get; set; }
-
-//    public string Content { get; set; }
-//}
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using FluentAvalonia.UI.Controls;
+using FluentAvaloniaTests.Helpers;
+using Xunit;
+
+namespace FluentAvaloniaTests.ControlTests;
+
+public class TabViewTests : IDisposable
+{
+    public TabViewTests()
+    {
+        _window = new Window();
+        CreateTabView();
+        _window.Show();
+    }
+
+    public TabView TabView { get; private set; }
+
+    [AvaloniaFact]
+    public void TabItemsChangedEventFires()
+    {
+        bool eventFired = false;
+        void ItemsChanged(TabView sender, EventArgs e)
+        {
+            eventFired = true;
+        }
+
+        TabView.TabItemsChanged += ItemsChanged;
+
+        (TabView.TabItems as AvaloniaList<TabViewItem>).Add(new TabViewItem());
+
+        Assert.True(eventFired);
+
+        TabView.TabItemsChanged -= ItemsChanged;
+    }
+
+    [AvaloniaFact]
+    public void AddTabButtonFiresAddTabButtonClickEvent()
+    {
+        bool eventRaised = false;
+        void TabAdd(TabView sender, EventArgs e)
+        {
+            eventRaised = true;
+        }
+
+        TabView.AddTabButtonClick += TabAdd;
+
+        var button = TabView.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(x => x.Name == "AddButton");
+
+        Assert.NotNull(button);
+
+        button.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs
+        {
+            RoutedEvent = Button.ClickEvent,
+        });
+
+        Assert.True(eventRaised);
+
+        TabView.AddTabButtonClick -= TabAdd;
+    }
+
+    [AvaloniaFact]
+    public void TabCloseButtonFiresTabCloseRequestedEvent()
+    {
+        bool eventRaised = false;
+        void TabClose(TabView sender, TabViewTabCloseRequestedEventArgs e)
+        {
+            eventRaised = true;
+        }
+
+        TabView.TabCloseRequested += TabClose;
+
+        var firstItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[0];
+
+        var button = firstItem.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(x => x.Name == "CloseButton");
+
+        Assert.NotNull(button);
+
+        button.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs
+        {
+            RoutedEvent = Button.ClickEvent,
+        });
+
+        Assert.True(eventRaised);
+
+        TabView.TabCloseRequested -= TabClose;
+    }
+
+    [AvaloniaFact]
+    public void EqualTabWidthModeProducesEqualWidthTabs()
+    {
+        // This is the default TabViewWidthMode, so we don't need to switch states
+        if (TabView.TabItems is AvaloniaList<TabViewItem> l)
+        {
+            var firstSize = l[0].Bounds.Width;
+
+            for (int i = 1; i < l.Count; i++)
+            {
+                Assert.True(l[i].Bounds.Width == firstSize);
+            }
+        }
+    }
+
+    // Other TabViewWidthModes need to be tested manually
+
+    [AvaloniaFact]
+    public void TabViewItemCloseButtonOverlayModeWorks()
+    {
+        var firstItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[0];
+
+        var button = firstItem.GetVisualDescendants()
+           .OfType<Button>()
+           .FirstOrDefault(x => x.Name == "CloseButton");
+
+        // Default state is for it to be visible
+        Assert.NotNull(button);
+        Assert.True(button.IsVisible);
+
+        // Currently using the first item, which is selected by default...this should still display its
+        // close button even if not pointer over
+        TabView.CloseButtonOverlayMode = TabViewCloseButtonOverlayMode.OnPointerOver;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(button.IsVisible);
+
+        // Switch to the second item, which is unselected and should hide its close button by default, if in
+        // PointerOver mode
+        var secondItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[1];
+        button = secondItem.GetVisualDescendants()
+           .OfType<Button>()
+           .FirstOrDefault(x => x.Name == "CloseButton");
+
+        Assert.False(button.IsVisible);
+
+        secondItem.MoveMouseToControl(new Point(10, 10));
+        Assert.True(button.IsVisible);
+        secondItem.MoveMouseToControl(new Point(-100, -100));
+        Assert.False(button.IsVisible);
+
+        TabView.CloseButtonOverlayMode = TabViewCloseButtonOverlayMode.Auto; //Auto is default state, same as Always
+    }
+
+    [AvaloniaFact]
+    public void TabViewItemIsClosableFalseHidesCloseButton()
+    {
+        var firstItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[0];
+
+        var button = firstItem.GetVisualDescendants()
+           .OfType<Button>()
+           .FirstOrDefault(x => x.Name == "CloseButton");
+
+        // Default state is for it to be visible
+        Assert.NotNull(button);
+
+        firstItem.IsClosable = false;
+        // Even the selected tab should hide it
+        Assert.False(button.IsVisible);
+
+        // Make sure it returns
+        firstItem.IsClosable = true;
+        Assert.True(button.IsVisible);
+
+        // Switch to the second item, just to double check unselected items
+        var secondItem = (TabView.TabItems as AvaloniaList<TabViewItem>)[1];
+        button = secondItem.GetVisualDescendants()
+           .OfType<Button>()
+           .FirstOrDefault(x => x.Name == "CloseButton");
+
+        secondItem.IsClosable = false;
+        Assert.False(button.IsVisible);
+
+        // Make sure it returns
+        secondItem.IsClosable = true;
+        Assert.True(button.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void TabViewAddButtonCommandWorks()
+    {
+        bool commandInvoked = false;
+        void TabAdd(object parameter)
+        {
+            commandInvoked = true;
+
+            Assert.Equal("Parameter", parameter);
+        }
+
+        bool active = true;
+        var testCommand = new TestCommand(TabAdd, x => active);
+        TabView.AddTabButtonCommand = testCommand;
+        TabView.AddTabButtonCommandParameter = "Parameter";
+
+        var button = TabView.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(x => x.Name == "AddButton");
+
+        Assert.NotNull(button);
+
+        Assert.True(button.IsEnabled);
+
+        button.ClickControl(new Point(10, 10), MouseButton.Left);
+        Assert.True(commandInvoked);
+
+
+        active = false;
+        testCommand.Invalidate();
+        Assert.False(button.IsEffectivelyEnabled);
+
+        TabView.AddTabButtonCommandParameter = null;
+        TabView.AddTabButtonCommand = null;
+    }
+
+    [AvaloniaFact]
+    public void BindingItemsGeneratesTabItems()
+    {
+        CreateTabView(false);
+        var tv = TabView;
+        tv.TabItemTemplate = new FuncDataTemplate<TestTabItem>((x, ns) =>
+        {
+            return new TabViewItem
+            {
+                [!TabViewItem.HeaderProperty] = new Binding("Header"),
+                [!TabViewItem.ContentProperty] = new Binding("Content")
+            };
+        });
+
+        var items = new List<TestTabItem>
+        {
+            new TestTabItem { Header = "This is tab 1", Content = "Tab1 Content" },
+            new TestTabItem { Header = "This is tab 2", Content = "Tab2 Content" },
+            new TestTabItem { Header = "This is tab 3", Content = "Tab2 Content" },
+        };
+        tv.TabItems = items;
+
+        Dispatcher.UIThread.RunJobs();
+
+        for (int i = 0; i < items.Count; i++)
+        {
+            var container = tv.ContainerFromIndex(i);
+            Assert.IsType<TabViewItem>(container);
+        }
+
+        Assert.Equal(0, tv.SelectedIndex);
+
+        CreateTabView(); // Reset it
+    }
+
+    private void CreateTabView(bool addTabs = true)
+    {
+        TabView = new TabView();
+        if (addTabs)
+            AddTabItems();
+
+        _window.Content = TabView;
+    }
+
+    private void AddTabItems()
+    {
+        TabView.TabItems = new AvaloniaList<TabViewItem>
+        {
+            new TabViewItem { Header = "Tab1" },
+            new TabViewItem { Header = "Tab2" },
+            new TabViewItem { Header = "Tab3" }
+        };
+    }
+
+    public void Dispose()
+    {
+        _window.Close();
+    }
+
+    private Window _window;
+}
+
+public class TestTabItem
+{
+    public string Header { get; set; }
+
+    public string Content { get; set; }
+}

--- a/tests/FluentAvaloniaTests/Helpers/MouseHelpers.cs
+++ b/tests/FluentAvaloniaTests/Helpers/MouseHelpers.cs
@@ -18,6 +18,16 @@ public static class MouseHelpers
         window.MouseUp(point, button, modifiers);
     }
 
+    public static void MouseDownControl(this Control ctrl, Point localPoint, MouseButton button, RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var window = TopLevel.GetTopLevel(ctrl);
+
+        var matrix = ctrl.TransformToVisual(window).Value;
+        var point = localPoint.Transform(matrix);
+
+        window.MouseDown(point, button, modifiers);
+    }
+
     public static void MoveMouseToControl(this Control ctrl, Point localPoint)
     {
         var window = TopLevel.GetTopLevel(ctrl);
@@ -26,5 +36,15 @@ public static class MouseHelpers
         var point = localPoint.Transform(matrix);
 
         window.MouseMove(point);
+    }
+
+    public static void MouseUpControl(this Control ctrl, Point localPoint, MouseButton button, RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var window = TopLevel.GetTopLevel(ctrl);
+
+        var matrix = ctrl.TransformToVisual(window).Value;
+        var point = localPoint.Transform(matrix);
+
+        window.MouseUp(point, button, modifiers);
     }
 }

--- a/tests/FluentAvaloniaTests/Helpers/MouseHelpers.cs
+++ b/tests/FluentAvaloniaTests/Helpers/MouseHelpers.cs
@@ -1,0 +1,30 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+
+namespace FluentAvaloniaTests.Helpers;
+
+public static class MouseHelpers
+{
+    public static void ClickControl(this Control ctrl, Point localPoint, MouseButton button, RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var window = TopLevel.GetTopLevel(ctrl);
+
+        var matrix = ctrl.TransformToVisual(window).Value;
+        var point = localPoint.Transform(matrix);
+
+        window.MouseDown(point, button, modifiers);
+        window.MouseUp(point, button, modifiers);
+    }
+
+    public static void MoveMouseToControl(this Control ctrl, Point localPoint)
+    {
+        var window = TopLevel.GetTopLevel(ctrl);
+
+        var matrix = ctrl.TransformToVisual(window).Value;
+        var point = localPoint.Transform(matrix);
+
+        window.MouseMove(point);
+    }
+}

--- a/tests/FluentAvaloniaTests/Helpers/TestCommand.cs
+++ b/tests/FluentAvaloniaTests/Helpers/TestCommand.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace FluentAvaloniaTests.Helpers;
@@ -22,6 +18,11 @@ internal class TestCommand : ICommand
 
     public void Execute(object parameter) =>
         _executeMethod.Invoke(parameter);
+
+    public void Invalidate()
+    {
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
 
     private Action<object> _executeMethod;
     private Func<object, bool> _canExecuteMethod;


### PR DESCRIPTION
I didn't realize it, but the TabView was ported into FA 4 years ago! A lot has changed since then, and it definitely needed some updates and that's exactly what has happened. Here's what is different or updated:

<h2>
1. TabItems vs TabItemsSource
</h2>
TabView now supports `TabItems` & `TabItemsSource` like regular ItemsControls and the upstream WinUI version! I finally figured out how WinUI manages these and was able to implement it. Make sure to update bindings to use `TabItemsSource` as TabItems is now a `IList<object>` and the property is read only. Internally, it will end up getting set to the ItemCollection of the underlying ListView. Note that the [Content] property of TabView remains as `TabItems` so any xaml elements added within TabView are added to the `TabItems` collection

<h2>
2. Switch to VirtualizingStackPanel
</h2>

The old implementation had a custom non-virtualizing panel. I have removed this and now use the VSP!

<h2>
3. Code updates
</h2>
I went back and made sure the code is up to date with WinUI's master branch as of now. 

Ok, these are minor things that don't seem all that exciting, ready for some things that are!

<h2>
4. Addition of `TabStripLocation` property and the ability to move the tabstrip!
</h2>

This has been a long running request on the TabView and it is now implemented*. Addition of this required several structural changes that cause some parts of the code to differ from upstream. I'll be honest, this was a huge PITA to implement and get correct so I hope some of you find this useful. Here I'll go over the API changes and what you need to know. 

Note: There is currently a major bug in Avalonia's VirtualizingStackPanel if you use `TabItems` and add TabItems directly instead of binding. I have an [issue upstream](https://github.com/AvaloniaUI/Avalonia/issues/21055) that hopefully will be addressed. If this doesn't get addressed, to use this feature you will need to use the TabView only via binding items in - as it has no issues there.


Let's look at the API changes first

```diff
public class TabView
{
+ public TabViewTabStripLocation TabStripLocation {get; set;}
+ public bool IsVerticalPaneOpen {get; set;}
+ public double VerticalOpenPaneLength {get; set;}
+ public double MinimumVerticalOpenPaneLength {get; set;}
+ public double MaximumVerticalOpenPaneLength {get; set;}
+ public SplitViewDisplayMode VerticalPaneDisplayMode {get; set;}
}
```

- `TabStripLocation` can be set to `Top`, `Bottom`, `Left`, or `Right`. Top remains the default option

`Bottom` moves the TabStrip to bottom and the TabGeometry is flipped upside down so that it still aligns with the content area. 

`Left` and `Right` have a much bigger structural change. **NOTE: Changing from horizontal to vertical (or V -> H) requires a complete template change, expect things to be detatched and reattached from the VisualTree, including your displayed TabContent**

Internally, when using Vertical Tabs, the template switches to using a SplitView and the TabItems display in a list configuration - which is similar to how Edge handles vertical tabs. To allow full customization here you can see several other properties were added to the TabView. You can control whether the pane is is open, the current open length, the minimum and maximum open pane lengths and the SplitView's display mode. The SplitView defaults to Inline, but you can change that if you want. In addition, there is a resize handle at the edge of the pane that allows you to dynamically resize it - you don't have to hook anything up - it just works!!

Note that when using vertical tabs, `TabWidthMode` property has no effect, all items are sized in a traditional list view, and conversely all the Vertical pane properties have no effect in Top/Bottom mode. 

https://github.com/user-attachments/assets/f4867761-ed90-47e9-ac90-ebbc09683ddf


<h2>
5. Improvements to Tab drag / drop
</h2>

To give you a little background on the TabView, it is internally built on WinUI's ListView control. Well, 4 years ago when I ported TabView, that was still completely closed source. Fast forward to today and MS finally made good on their promise to open source WinUI. Now, the ListView has not been ported and won't be - it is way too big and complex. However, it did allow me to dive into how it handles the reorder hint that I had to hack together in the original port. This means that tab reordering now has a much more WinUI feel to it and works better than before. This took quite a bit of work, and still need some tweaks, but it's done.

Couple of notes: 
- I have removed the drag UI from the TabView. Previously I tried to wire up a popup to "preview" the content being dragged. This will not be coming back until Avalonia finally implements the ability to attach DragUI images, if they ever do. I have 2 open issues upstream about this (one dating back 4 years). 
- Previously reorder used regular pointer events and drag operation used DnD. Everything now goes through DnD which simplifies a lot of the code and aligns with what WinUI does.
- DnD works fundamentally differently in WinUI, compared to the DnD we have (on Windows OLE DnD). As a result, it is really hard to get a grasp on when the pointer actually leaves the TabStrip, because it only fires on a few select template components and then all of a sudden its outside the TabStrip and we never get a notification. So there are some cases where the TabView won't properly reset during drag operation if the pointer leaves, simply because routed DnD events is a HORRIBLE design. 
- Just like before, reorder is handled automatically by the TabView, provided you have an IList/INCC collection attached. If not, the operation will not start. Drag operation are still handled by you.
- And yes, it works in both Horizontal & Vertical Tabs :)

Video (only showing reordering, I didn't wire up drag for this test)

https://github.com/user-attachments/assets/d25fb9e3-5df0-4ab1-a463-76046298e2c1

<h2>
Misc. Items
</h2>

- Some issues with the TabGeometry have been fixed (I think I have comments all about this in the code), which actually fixes a bug in WinUI's version.
- I am currently investigating whether or not the new WinUI TabView TearOut is possible to port. The code is not compatible as it relies on some WinUI components and Win32 code, but it might be possible to get something like it. This would only be available for desktop platforms, and only those that let you manipulate windows (so in the future when Avalonia runs on Wayland, it ain't gonna work). 
- The unit tests on TabView are improving. I can't get tests covering the DnD stuff, but I'm trying to at least get some baseline tests going. 
- This is only part 1 because there are things that will require Avalonia 12.0 to finish. That will go along side FA v3, more on that later.


And the best part...none of this was done with AI. So no AI slop, just amwx slop :)

Marking as draft as I still have work to do, but hopefully those of you that use this control will appreciate this development. Sorry this description was so long.