### PR TITLE
Add support for Opacity property in FAProgressRing

### DIFF
--- a/src/FluentAvalonia/UI/Controls/ProgressRing/FAProgressRingAnimatedVisual.cs
+++ b/src/FluentAvalonia/UI/Controls/ProgressRing/FAProgressRingAnimatedVisual.cs
@@ -136,7 +136,7 @@ public sealed class FAProgressRingAnimatedVisual : Control
             _max = (float)maximum;
             _value = (float)value;
             _active = isActive;
-            
+
             if (background is ISolidColorBrush scb)
             {
                 _background = scb.Color.ToSKColor();
@@ -155,6 +155,8 @@ public sealed class FAProgressRingAnimatedVisual : Control
                 StrokeCap = SKStrokeCap.Round
             };
 
+            _layerPaint = new SKPaint();
+
             _path = new SKPath();
         }
 
@@ -168,6 +170,17 @@ public sealed class FAProgressRingAnimatedVisual : Control
 
             var dc = lease.SkCanvas;
 
+            // Ensure opacity is clamped between 0.0 and 1.0
+            double opacity = Math.Clamp(lease.CurrentOpacity, 0d, 1d);
+            bool needsOpacityLayer = opacity < 1d;
+
+            if (needsOpacityLayer)
+            {
+                _layerPaint.Color = SKColors.White.WithAlpha((byte)(255 * opacity));
+                // Save the current canvas state and create a new layer
+                dc.SaveLayer(_layerPaint);
+            }
+
             if (_background.HasValue)
             {
                 _paint.Color = _background.Value;
@@ -176,6 +189,12 @@ public sealed class FAProgressRingAnimatedVisual : Control
             
             _paint.Color = _foreground;
             dc.DrawPath(_path, _paint);
+
+            if (needsOpacityLayer)
+            {
+                // Restore the canvas to apply the layer with the specified opacity
+                dc.Restore();
+            }
         }
 
         public override void OnAnimationFrameUpdate()
@@ -367,6 +386,7 @@ public sealed class FAProgressRingAnimatedVisual : Control
         private float _duration = 2;
         private readonly SKPaint _paint;
         private readonly SKPath _path;
+        private readonly SKPaint _layerPaint;
         private readonly SKRect _visualBounds = new SKRect(10, 10, 70, 70);
 
         private SKColor? _background;


### PR DESCRIPTION
## Description

`FAProgressRing` does not support the `Opacity` property. So, in the `OnRender` method of `CustomCompHandler`, retrieve the current opacity and perform the rendering.

## Screenshots
**Before Fix:**
<img width="1699" height="448" alt="Image1" src="https://github.com/user-attachments/assets/0a98cfbb-ad25-4b27-80a0-a1d6975f354a" />

**After Fix:**
<img width="1545" height="788" alt="Image2" src="https://github.com/user-attachments/assets/87eb3fb1-a355-479e-82c2-9cd2a4256c4b" />


## Resolved Issues
Fix: #743 
