### PR TITLE
Decouple FAFrame BackStack from CacheSize and prevent memory leaks

### DIFF
--- a/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
+++ b/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
@@ -465,7 +465,15 @@ public partial class FAFrame : ContentControl
             if (!wasPageSet)
             {
                 // Check if we already have an instance of the page in the cache
-                entry.Instance = CheckCacheAndGetPage(entry.SourcePageType);
+                // Context will not be null if NavigateCore is called from GoBack/GoForward and the entry was created from NavigateFromObject
+                if (entry.Context != null)
+                {
+                    entry.Instance = CheckCacheAndGetPage(null, entry.Context);
+                }
+                else
+                {
+                    entry.Instance = CheckCacheAndGetPage(entry.SourcePageType, null);
+                }
             }
 
             if (entry.Instance == null)

--- a/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
+++ b/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
@@ -397,6 +397,8 @@ public partial class FAFrame : ContentControl
 
             if (addCurrentEntryToBackStack)
             {
+                // Set Instance to null to allow GC to collect it
+                CurrentEntry.Instance = null;
                 BackStack.Add(CurrentEntry);
                 CurrentEntry = null;
             }
@@ -458,10 +460,9 @@ public partial class FAFrame : ContentControl
             }
 
             // Navigate to new page
-            var prevEntry = CurrentEntry;
             bool wasPageSet = entry.Instance != null;
 
-            if (mode == FANavigationMode.New && !wasPageSet)
+            if (!wasPageSet)
             {
                 // Check if we already have an instance of the page in the cache
                 entry.Instance = CheckCacheAndGetPage(entry.SourcePageType);
@@ -488,7 +489,7 @@ public partial class FAFrame : ContentControl
             CurrentEntry = entry;
 
             var navEA = new FluentAvalonia.UI.Navigation.FANavigationEventArgs(
-                CurrentEntry.Instance,
+                entry.Instance,
                 mode, entry.NavigationTransitionInfo,
                 entry.Parameter,
                 entry.SourcePageType);
@@ -498,6 +499,10 @@ public partial class FAFrame : ContentControl
             {
                 navEA.RoutedEvent = NavigatedFromEvent;
                 oldEntry.Instance.RaiseEvent(navEA);
+
+                // Set Instance to null to allow GC to collect it
+                // The page will still be retained in the cache if caching is enabled
+                oldEntry.Instance = null;
             }
 
             SetContentAndAnimate(entry);
@@ -510,20 +515,20 @@ public partial class FAFrame : ContentControl
                 {
                     case FANavigationMode.New:
                         ForwardStack.Clear();
-                        if (prevEntry != null)
+                        if (oldEntry != null)
                         {
-                            BackStack.Add(prevEntry);
+                            BackStack.Add(oldEntry);
                         }
                         break;
 
                     case FANavigationMode.Back:
-                        ForwardStack.Add(prevEntry);
-                        BackStack.Remove(CurrentEntry);
+                        ForwardStack.Add(oldEntry);
+                        BackStack.Remove(entry);
                         break;
 
                     case FANavigationMode.Forward:
-                        BackStack.Add(prevEntry);
-                        ForwardStack.Remove(CurrentEntry);
+                        BackStack.Add(oldEntry);
+                        ForwardStack.Remove(entry);
                         break;
 
                     case FANavigationMode.Refresh:

--- a/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
+++ b/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
@@ -512,14 +512,6 @@ public partial class FAFrame : ContentControl
                         ForwardStack.Clear();
                         if (prevEntry != null)
                         {
-                            if (BackStack.Count == CacheSize)
-                            {
-                                if (BackStack.Count > 0)
-                                {
-                                    BackStack.RemoveAt(0);
-                                }
-                            }
-
                             BackStack.Add(prevEntry);
                         }
                         break;

--- a/tests/FluentAvaloniaTests/ControlTests/FrameTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/FrameTests.cs
@@ -175,30 +175,35 @@ public class FrameTests
     }
 
     [AvaloniaFact]
-    public void PagesAreCachedWhenNavigatingIfUsingNavigationStack()
+    public void PagesAreDiscardedFromCacheWhenExceedingCacheSize()
     {
         var Context = GetTestContext();
 
         Assert.True(Context.Frame.IsNavigationStackEnabled);
 
+        Context.Frame.CacheSize = 2;
+
         Context.Frame.Navigate(typeof(TestPage1));
+        var page1 = Context.Frame.Content;
+
         Context.Frame.Navigate(typeof(TestPage2));
+        var page2 = Context.Frame.Content;
+
+        // Cause the cache to discard page 1
         Context.Frame.Navigate(typeof(TestPage3));
 
-        Assert.Equal(2, Context.Frame.BackStackDepth);
-
-        Assert.IsType<TestPage2>(Context.Frame.BackStack[1].Instance);
-        Assert.IsType<TestPage1>(Context.Frame.BackStack[0].Instance);
-
-        var prevPage = Context.Frame.BackStack[1].Instance;
-
+        // Test page are cached
         Context.Frame.GoBack();
+        Assert.Same(page2, Context.Frame.Content);
 
-        Assert.Equal(prevPage, Context.Frame.Content);
+        // Test cache size is respected
+        Context.Frame.GoBack();
+        Assert.NotSame(page1, Context.Frame.Content);
+        Assert.IsType<TestPage1>(Context.Frame.Content);
     }
 
     [AvaloniaFact]
-    public void DisablingNavigationStackPreventsPageCaching()
+    public void DisablingNavigationStackPreventsPageNavigation()
     {
         var Context = GetTestContext();
 


### PR DESCRIPTION
## Description

This PR removes the incorrect `BackStack` clearing logic in `FAFrame` when navigating in `FANavigationMode.New`. 

https://github.com/amwx/FluentAvalonia/blob/246e09f17e5538ca4a434a87e2676d343b8be6e0/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs#L511-L525

Previously, the code removed entries from the `BackStack` when its count reached the `CacheSize`. This logic conflated the concept of navigation history with page caching. This PR fixes the issue based on the following reasons:

1. `CacheSize` is meant to control how many page instances are kept alive in memory, not the navigation depth. Whether a user can navigate back is controlled by `IsNavigationStackEnabled`. Even if a page is evicted from the cache, it should still remain in the `BackStack` so it can be recreated upon backward navigation.
2. Truncating the `BackStack` based on cache limits prevents deep backward navigation. This behavior is inconsistent with the standard Microsoft WinUI `Frame` behavior.
3. Throughout the rest of the codebase, `CacheSize` is correctly paired with `_pageCache.Count` to manage instances. Memory management and eviction should strictly operate on `_pageCache`, leaving the logical `BackStack` intact.
4. The previous code had a logical flaw when `CacheSize` was explicitly set to `0`. On the first navigation, both `BackStack.Count` and `CacheSize` were `0`, bypassing the removal block but executing `BackStack.Add(prevEntry)`. On subsequent navigations, `BackStack.Count` would be greater than `CacheSize` (e.g., 1 != 0), meaning `BackStack.RemoveAt(0)` would never execute. Ironically, setting `CacheSize` to `0` resulted in an infinite `BackStack`.

By removing the `if (BackStack.Count == CacheSize)` block, the navigation history functions as expected, while `_pageCache` continues to handle the actual page instance memory limits.

[The `Instance` property of the `entry` added to the BackStack is set to `null`](https://github.com/chenjt2001/FluentAvalonia/blob/0d333563685abf885f723610388c4a761dfd8f0c/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs#L505-L514) to release resources; therefore, saving the entry does not cause a memory leak.

In addition, this PR addresses several other issues related to FAFrame; please refer to the commit messages and code comments for details.

