### PR TITLE
fix: No more ReflectionBindings to avoid AOT/Trimmer issues

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DataGrid/DataGridRowGroupHeaderStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DataGrid/DataGridRowGroupHeaderStyles.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:collections="using:Avalonia.Collections"
                     xmlns:ui="using:FluentAvalonia.UI.Controls">
 
     <ControlTheme TargetType="ToggleButton" x:Key="DataGridRowGroupHeaderButtonStyle">
@@ -31,7 +32,7 @@
         <Setter Property="FontSize" Value="15" />
         <Setter Property="MinHeight" Value="32" />
         <Setter Property="Template">
-            <ControlTemplate>
+            <ControlTemplate x:DataType="collections:DataGridCollectionViewGroup">
                 <DataGridFrozenGrid Name="PART_Root"
                                     Background="{TemplateBinding Background}"
                                     MinHeight="{TemplateBinding MinHeight}"
@@ -62,7 +63,7 @@
                                    IsVisible="{TemplateBinding IsPropertyNameVisible}"
                                    Foreground="{TemplateBinding Foreground}" />
                         <TextBlock Margin="4,0,0,0"
-                                   Text="{ReflectionBinding Key}"
+                                   Text="{Binding Key}"
                                    Foreground="{TemplateBinding Foreground}" />
                         <TextBlock Name="PART_ItemCountElement"
                                    Margin="4,0,0,0"

--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DataValidationErrorsStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/DataValidationErrorsStyles.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="using:System"
+                    xmlns:collections="clr-namespace:System.Collections;assembly=System.Runtime"
                     x:CompileBindings="True">
     <Design.PreviewWith>
         <Border Padding="20">
@@ -98,7 +99,7 @@
                         </Style>
                     </Panel.Styles>
                     <ToolTip.Tip>
-                        <ItemsControl ItemsSource="{ReflectionBinding}" />
+                        <ItemsControl ItemsSource="{Binding}" x:DataType="collections:IEnumerable" />
                     </ToolTip.Tip>
                     <Path Width="14"
                           Height="14"


### PR DESCRIPTION
## Description

Right now, when compiling FluentAvalonia, there are still trimmer warnings:

```
src\FluentAvalonia\Styling/ControlThemes/Controls.axaml(101): Trim analysis warning IL2026: CompiledAvaloniaXaml.!AvaloniaResources.XamlClosure_74.Build_91(IServiceProvider): Using member 'Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension.ReflectionBindingExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. BindingExpression and ReflectionBinding heavily use reflection. Consider using CompiledBindings instead.
src\FluentAvalonia\Styling/ControlThemes/Controls.axaml(101): AOT analysis warning IL3050: CompiledAvaloniaXaml.!AvaloniaResources.XamlClosure_74.Build_91(IServiceProvider): Using member 'Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension.ReflectionBindingExtension()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. BindingExpression and ReflectionBinding require dynamic code. Consider using CompiledBindings instead.
src\FluentAvalonia\Styling/ControlThemes/BasicControls/DataGrid/DataGridRowGroupHeaderStyles.axaml(66): Trim analysis warning IL2026: CompiledAvaloniaXaml.!AvaloniaResources.XamlClosure_19.Build_4(IServiceProvider): Using member 'Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension.ReflectionBindingExtension(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. BindingExpression and ReflectionBinding heavily use reflection. Consider using CompiledBindings instead.
src\FluentAvalonia\Styling/ControlThemes/BasicControls/DataGrid/DataGridRowGroupHeaderStyles.axaml(66): AOT analysis warning IL3050: CompiledAvaloniaXaml.!AvaloniaResources.XamlClosure_19.Build_4(IServiceProvider): Using member 'Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension.ReflectionBindingExtension(String)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. BindingExpression and ReflectionBinding require dynamic code. Consider using CompiledBindings instead.
```

They are caused by the use of `ReflectionBindings` and can lead to the DataGrid not being rendered properly.

To fix this, I updated the relevant sections to the same code used by the current Avalonia Fluent Templates:
- DataGrid: https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/blob/bb559296f4b662d61023d1b0d45f47123daad4e0/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml#L420
- DataValidation: https://github.com/AvaloniaUI/Avalonia/blob/dab62c09d29f18772b82b3933f54d1216db4ed18/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml#L102

## Screenshots

When published without AOT (or with this PR):
<img width="920" height="508" alt="image" src="https://github.com/user-attachments/assets/da76cc8d-dd2c-42bc-b3d8-9f92a230a748" />

When published with AOT before (the DataGrid is missing headers, the ToolTip of the DataValidation seems to be identical, might be preserved by some other part of the code? I did not care :D):
<img width="920" height="510" alt="image" src="https://github.com/user-attachments/assets/0ba03fba-a383-48f7-b475-1f2ef75b2b67" />


## Resolved Issues

I did not create an issue since this was such a small change and I am not aware others.
