### PR TITLE
Fix Right-clicking on the title bar of FAAppWindow may crashes the app

### DIFF
--- a/src/FluentAvalonia/Interop/Win32Interop.cs
+++ b/src/FluentAvalonia/Interop/Win32Interop.cs
@@ -40,13 +40,13 @@ internal static unsafe partial class Win32Interop
     public static partial LRESULT
         CallWindowProcW(nint lpPrevWndProc, HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
 
-    [LibraryImport(s_user32, SetLastError = true)]
+    [LibraryImport(s_user32, EntryPoint = "PostMessageW", SetLastError = true)]
     public static partial BOOL PostMessage(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
 
     [LibraryImport(s_user32, SetLastError = true)]
     public static partial HMENU GetSystemMenu(HWND hWnd, BOOL bRevert);
 
-    [LibraryImport(s_user32, SetLastError = true)]
+    [LibraryImport(s_user32, EntryPoint = "SetMenuItemInfoW", SetLastError = true)]
     public static partial BOOL SetMenuItemInfo(HMENU hMenu, uint item, BOOL fByPosition, MENUITEMINFO* lpmii);
 
     [LibraryImport(s_user32, SetLastError = true)]


### PR DESCRIPTION
<!--
IMPORTANT NOTICE
1. Before submitting a PR, a corresponding issue must be opened and approved. PRs opened without an corresponding issue will be closed without warning. In the issue, indicate you would like to do the PR and be patient as it may take some time for me to respond. Exceptions: Small changes like documentation fixes/typos]

AI WARNING
All code submitted to FluentAvalonia MUST be written by a human. I have no issues with using AI to help problem solving, but please do not submit code fixes or improvements that have been authored by ChatGPT, CoPilot, Claude, Gemini, or any other AI.
If you generate a PR or issue description using AI, please review it as best you can to ensure the AI text is correct and aligns with your intentions. AI is garbage, please use it responsibly.
-->

## Description

The P/Invoke in Win32Interop was missing the EntryPoint attribute.This caused an EntryPointNotFoundException when the system menu was invoked.

<!-- Review the contributing guidlines as FA does not fully use modern C# conventions in all cases: https://github.com/amwx/FluentAvalonia/blob/master/.github/CONTRIBUTING.md -->

## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e18dc971-97f7-4728-8df3-23a823398095" />

## Resolved Issues

Fixes #752 
