### PR TITLE
fix(MenuItem): Bind PART_HeaderPresenter ContentTemplate to HeaderTemplate

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/MenuItemStyles.axaml
@@ -119,6 +119,7 @@
 
                             <ContentPresenter Name="PART_HeaderPresenter"
                                               Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
                                               VerticalAlignment="Center"
                                               HorizontalAlignment="Stretch"
                                               Grid.Column="2"


### PR DESCRIPTION
<!--
IMPORTANT NOTICE
1. Before submitting a PR, a corresponding issue must be opened and approved. PRs opened without an corresponding issue will be closed without warning. In the issue, indicate you would like to do the PR and be patient as it may take some time for me to respond. Exceptions: Small changes like documentation fixes/typos]

AI WARNING
All code submitted to FluentAvalonia MUST be written by a human. I have no issues with using AI to help problem solving, but please do not submit code fixes or improvements that have been authored by ChatGPT, CoPilot, Claude, Gemini, or any other AI.
If you generate a PR or issue description using AI, please review it as best you can to ensure the AI text is correct and aligns with your intentions. AI is garbage, please use it responsibly.
-->

## Description

Binds the `PART_HeaderPresenter` `ContentPresenter` in the `MenuItem` style to the `HeaderTemplate` on the `MenuItem` control.

## Screenshots

*Before:*

<img width="592" height="411" alt="image" src="https://github.com/user-attachments/assets/6a13d31e-586d-4a40-886a-5d9c93f35d96" />

*After:*

<img width="629" height="408" alt="image" src="https://github.com/user-attachments/assets/dfa2fc7b-b240-448b-96a0-0ff523848268" />

## Resolved Issues

N/A
