### PR TITLE
fix(ViewManager): debug assertion failure in PrunePinnedElements

### DIFF
--- a/src/FluentAvalonia/UI/Controls/Repeater/ViewManager.cs
+++ b/src/FluentAvalonia/UI/Controls/Repeater/ViewManager.cs
@@ -831,7 +831,7 @@ internal class ViewManager
 #endif
 
             _pinnedPool.Add(new PinnedElementInfo(element, virtInfo));
-            virtInfo.MoveOwnershipToLayoutFromPinnedPool();
+            virtInfo.MoveOwnershipToPinnedPool();
         }
 
         return moveToPinnedPool;


### PR DESCRIPTION
## Description
This PR fixes a debug assertion failure in `PrunePinnedElements`.

In `ClearElementToPinnedPool`, the method incorrectly called `MoveOwnershipToLayoutFromPinnedPool()` instead of  
`MoveOwnershipToPinnedPool()`. This was a simple typo that caused elements returned to the pinned pool to have the incorrect `ElementOwner` state, triggering an assertion when `PrunePinnedElements` ran.

The fix aligns the behavior with WinUI and ensures the element ownership transition logic is correct. No behavioral or visual changes are introduced.

## Screenshots
N/A – no visual changes.

## Resolved Issues
#757 
