### PR TITLE
fix(focus): scope initial focus searches to their intended root

### DIFF
--- a/src/FluentAvalonia/UI/Controls/ContentDialog/FAContentDialog.cs
+++ b/src/FluentAvalonia/UI/Controls/ContentDialog/FAContentDialog.cs
@@ -434,10 +434,19 @@ public partial class FAContentDialog : ContentControl, ICustomKeyboardNavigation
                 // ContentDialog itself to pull focus away from the main visual tree so weird things don't happen
                 // The latter shouldn't happen in 99% of cases as either something in the user content will be able
                 // to take focus OR there should always be at least one button which can take focus
-                var mgr = TopLevel.GetTopLevel(this).FocusManager;
-                // TODO: v3 - does this work?
-                var next = mgr.FindNextElement(NavigationDirection.Next, new FindNextElementOptions { SearchRoot = this });
-                next?.Focus();
+                //
+                // Do NOT go back to FindNextElement(NavigationDirection.Next, new FindNextElementOptions
+                // { SearchRoot = this }) here. Per the WinUI contract Avalonia mirrors, FindNextElementOptions
+                // is only honoured for directional navigation and is silently ignored for Next/Previous, so
+                // SearchRoot scoped nothing: the search started from whatever held focus outside the dialog and
+                // walked the whole window. FindFirstFocusableElement is both correctly scoped and the operation
+                // actually wanted here - the first focusable element inside the dialog, not the tab stop
+                // following some unrelated element.
+                var next = FocusManager.FindFirstFocusableElement(this);
+                if (next is not null)
+                    next.Focus();
+                else
+                    Focus();
 
 #if DEBUG
                 Logger.TryGet(LogEventLevel.Debug, "ContentDialog")?.Log("SetupDialog", "Set initial focus to {next}", next);

--- a/src/FluentAvalonia/UI/Controls/TabView/FATabView.cs
+++ b/src/FluentAvalonia/UI/Controls/TabView/FATabView.cs
@@ -878,9 +878,14 @@ public partial class FATabView : TemplatedControl
                 
                 if (shouldMoveFocusToNewTab)
                 {
-                    var focusable = TopLevel.GetTopLevel(this)?.FocusManager?.FindNextElement(NavigationDirection.Next,
-                        new FindNextElementOptions { SearchRoot = _tabContentPresenter });
-                    
+                    // FindNextElement(Next, ...) cannot be scoped: FindNextElementOptions is only
+                    // honoured for directional navigation, so SearchRoot was ignored here and the
+                    // search ran from whatever held focus anywhere in the window. Besides picking
+                    // the wrong element, that walk hangs outright when the current focus sits
+                    // inside a KeyboardNavigationMode.Once container. See the same fix in
+                    // FAContentDialog.SetupDialog.
+                    var focusable = FocusManager.FindFirstFocusableElement(_tabContentPresenter);
+
                     // If there is nothing focusable in the new tab, just move focus to the TabViewItem itself.
                     focusable ??= tvi;
 

--- a/tests/FluentAvaloniaTests/ControlTests/ContentDialogTests.cs
+++ b/tests/FluentAvaloniaTests/ControlTests/ContentDialogTests.cs
@@ -39,6 +39,39 @@ public class ContentDialogTests : IDisposable
         _window.Content = null;
     }
 
+    [AvaloniaFact(Timeout = 5000)]
+    public async Task DialogWithNoDefaultButtonDoesNotHangWhenFocusIsInsideAOnceContainer()
+    {
+        // Regression test. With no DefaultButton, SetupDialog picks the initial focus target
+        // itself. It used to ask FindNextElement(Next, new FindNextElementOptions
+        // { SearchRoot = this }), but FindNextElementOptions is ignored for Next/Previous, so
+        // the search actually started from whatever held focus outside the dialog. With that
+        // element nested inside a KeyboardNavigationMode.Once container, Avalonia's tab stop
+        // walk never terminates and showing the dialog hung the UI thread outright.
+        var outside = new Button { Content = "outside" };
+        _window.Content = new StackPanel
+        {
+            [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Once,
+            Children = { new StackPanel { Children = { outside } } }
+        };
+        outside.Focus();
+
+        var dlg = new FAContentDialog { CloseButtonText = "Close" };
+
+        bool opened = false;
+        dlg.Opened += (_, __) =>
+        {
+            opened = true;
+            dlg.Hide();
+        };
+
+        // Before the fix this never completed - SetupDialog spun inside Avalonia's tab stop
+        // walk and the test would hit the timeout instead of failing an assertion.
+        await dlg.ShowAsync(_window);
+
+        Assert.True(opened);
+    }
+
     [AvaloniaFact]
     public void SettingPrimaryButtonTextShowsPrimaryButton()
     {


### PR DESCRIPTION
`FAContentDialog.SetupDialog` and `FATabView` both ask for an initial focus target like this:

```csharp
var mgr = TopLevel.GetTopLevel(this).FocusManager;
// TODO: v3 - does this work?
var next = mgr.FindNextElement(NavigationDirection.Next, new FindNextElementOptions { SearchRoot = this });
next?.Focus();
```

Answering that `TODO`: no, it does not. Per the WinUI contract Avalonia mirrors, `FindNextElementOptions` is only honoured for directional navigation and is silently ignored for tab navigation. From the `FocusManager.FindNextElement` docs:

> Tab navigation (`FocusNavigationDirection.Previous` and `FocusNavigationDirection.Next`)
> cannot be used with `FindNextElementOptions`. Only directional navigation (`Up`, `Down`,
> `Left`, or `Right`) is valid.

Avalonia implements exactly that: for `Next`/`Previous` it uses `options?.FocusedElement ?? Current` and never reads `SearchRoot`. So neither call was scoped to anything - both started from whatever held focus in the window and walked the entire visual tree.

## Consequences

1. The chosen element could be *outside* the dialog / the new tab - the opposite of what the surrounding comments say the code is for.

2. Worse, it can hang the application outright. Avalonia's tab stop walk fails to terminate when the starting element is nested inside a container with `KeyboardNavigationMode.Once`: `GetNextTabStop` resets its parent walk back to the focused element's parent on every `Once` hit and oscillates between two nodes forever. Since `NavigationView` items live in exactly such a container, opening a `ContentDialog` while focus sat on a nested navigation item froze the UI thread at 100% CPU permanently. That is how this was found, in a production app.

## The fix

Both sites switch to `FocusManager.FindFirstFocusableElement(root)`, which is correctly scoped and is the operation actually wanted - the first focusable element *inside* the given root, rather than the tab stop following some unrelated element. It also takes a different code path in Avalonia, so the hang goes away without waiting for the upstream fix (verified below).

Two incidental improvements in `FAContentDialog`:

- The `else Focus()` branch now actually implements the fallback its comment promises ("focus the ContentDialog itself to pull focus away from the main visual tree"). The old `next?.Focus()` did nothing at all when `next` was null.
- `TopLevel.GetTopLevel(this)` is no longer dereferenced without a null check.

## The other two call sites are fine

For completeness, the remaining uses of these APIs were checked and left alone:

- `FANavigationView.cs:2004` passes `NavigationDirection.Up`, i.e. directional navigation, where `SearchRoot` *is* honoured. Correct as written.
- `FABreadcrumbBar.GetFindNextElementOptions()` has no callers.

## Verification

- New regression test `DialogWithNoDefaultButtonDoesNotHangWhenFocusIsInsideAOnceContainer` in `ContentDialogTests`, showing a dialog while focus is parked inside a nested `KeyboardNavigationMode.Once` container.
- Confirmed it catches the bug: with the `FAContentDialog` change reverted, and against the unmodified Avalonia 12.0.0 package, the test never completes - the run had to be killed after 95s of CPU time. With the change it passes in under a second.
- Full `FluentAvaloniaTests` suite: 168 tests, 0 failed (150 passed, 18 pre-existing skips). The `FATabView` change is covered only by the existing 30 TabView tests; I did not find a clean way to drive its focus-moving branch from a headless test.

## Things I deliberately did not change

- **The timing of the search.** When `SetupDialog` runs (from `DialogLoaded`) the dialog's content is not yet effectively visible, so `FindFirstFocusableElement` returns null and the fallback is what actually takes effect. That is still a strict improvement over walking into the window behind the dialog, but if the intent is to focus the first control of the user's content, the search likely needs to move to after `Opened`. That is a behavioural decision for you rather than something to fold into a hang fix. The same reasoning applies to the stale "it is necessary to call UpdateLayout here" comment in `FATabView`.
- **`Focusable` on `FAContentDialog`.** It is not set, so the `Focus()` fallback does not currently succeed either and focus simply stays put. Setting it would make the dialog itself a tab stop, which has its own implications - flagging rather than deciding.
- **The `Timeout` on the new test.** It is there for consistency with neighbouring tests, but an xUnit timeout cannot pre-empt a CPU-bound loop on the UI thread: if this regresses, CI will hang rather than report a failed assertion.

<!--
IMPORTANT NOTICE
1. Before submitting a PR, a corresponding issue must be opened and approved. PRs opened without an corresponding issue will be closed without warning. In the issue, indicate you would like to do the PR and be patient as it may take some time for me to respond. Exceptions: Small changes like documentation fixes/typos]

AI WARNING
All code submitted to FluentAvalonia MUST be written by a human. I have no issues with using AI to help problem solving, but please do not submit code fixes or improvements that have been authored by ChatGPT, CoPilot, Claude, Gemini, or any other AI.
If you generate a PR or issue description using AI, please review it as best you can to ensure the AI text is correct and aligns with your intentions. AI is garbage, please use it responsibly.
-->

## Description

A clear and concise description of the PR. Why was the PR necessary and how does it solve the issue?

<!-- Review the contributing guidlines as FA does not fully use modern C# conventions in all cases: https://github.com/amwx/FluentAvalonia/blob/master/.github/CONTRIBUTING.md -->

## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR. This is not required, but may be helpful to me to see the changes without needing to build your branch. Of course if your change doesn't change any visuals, then this is not needed.

## Resolved Issues

If this PR closes any active issues, please link them here
