### PR TITLE
Add more functionality to DataPackage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,12 +3,12 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>12.0.0</AvaloniaVersion>
+    <AvaloniaVersion>12.1.0</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Skia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
@@ -17,7 +17,7 @@
     <PackageVersion Include="LiveMarkdown" Version="1.1.2" />
     <PackageVersion Include="Markdown.Avalonia" Version="12.0.0-a3" />
     <PackageVersion Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.5" />
-    <PackageVersion Include="MicroCom.Runtime" Version="0.11.5" />
+    <PackageVersion Include="MicroCom.Runtime" Version="0.11.6" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="12.0.0" />

--- a/src/FluentAvalonia/UI/Data/DataPackage.cs
+++ b/src/FluentAvalonia/UI/Data/DataPackage.cs
@@ -14,21 +14,43 @@ public sealed class DataPackage : IDataTransfer, IAsyncDataTransfer
         _dt = new DataTransfer();
     }
 
+    public IReadOnlyList<DataFormat> Formats => _dt.Formats;
+
+    public IReadOnlyList<IAsyncDataTransferItem> Items => _dt.Items;
+
     /// <summary>
     /// Gets or sets the requested operation for the data object
     /// </summary>
     public DragDropEffects RequestedOperation { get; set; }
 
+    /// <summary>
+    /// Adds the specified text into the Data Transfer package
+    /// </summary>
     public void SetText(string text)
     {
         _dt.Add(DataTransferItem.CreateText(text));
     }
 
+    /// <summary>
+    /// If present, synchronously retrieves the current text in the Data Transfer package
+    /// </summary>
     public string GetText()
     {
         return _dt.TryGetText();
     }
 
+    /// <summary>
+    /// If present, asynchronously retrieves the current text in the Data Transfer package
+    /// </summary>
+    public Task<string> GetTextAsync()
+    {
+        return _dt.TryGetTextAsync();
+    }
+
+    /// <summary>
+    /// Sets the specified <see cref="IStorageItem"/>s into the current
+    /// Data Transfer package
+    /// </summary>
     public void SetStorageItems(IEnumerable<IStorageItem> items)
     {
         foreach (var item in items)
@@ -37,27 +59,83 @@ public sealed class DataPackage : IDataTransfer, IAsyncDataTransfer
         }
     }
 
+    /// <summary>
+    /// If present, synchronously retreives the <see cref="IStorageItem"/>s in
+    /// the current Data Transfer package
+    /// </summary>
     public IReadOnlyList<IStorageItem> GetStorageItems()
     {
         return _dt.TryGetFiles();
     }
 
+    /// <summary>
+    /// If present, asynchronously retreives the <see cref="IStorageItem"/>s in
+    /// the current Data Transfer package
+    /// </summary>
+    public async Task<IReadOnlyList<IStorageItem>> GetStorageItemsAsync()
+    {
+        var result = await _dt.TryGetFilesAsync();
+        return result;
+    }
+
+    /// <summary>
+    /// Sets the specified <see cref="Bitmap"/> to the current Data Transfer package
+    /// </summary>
     public void SetBitmap(Bitmap bmp)
     {
-        throw new NotImplementedException("Avalonia doesn't currently support this");
+        _dt.Add(DataTransferItem.Create(DataFormat.Bitmap, bmp));
+    }
+
+    /// <summary>
+    /// If present, synchronously retreives the <see cref="Bitmap"/>s in
+    /// the current Data Transfer package
+    /// </summary>
+    public Bitmap GetBitmap()
+    {
+        return _dt.TryGetBitmap();
+    }
+
+    /// <summary>
+    /// If present, asynchronously retreives the <see cref="Bitmap"/>s in
+    /// the current Data Transfer package
+    /// </summary>
+    public Task<Bitmap> GetBitmapAsync()
+    {
+        return _dt.TryGetBitmapAsync();
+    }
+
+    /// <summary>
+    /// Sets an unspecified object to the Data Transfer package with 
+    /// the custom <see cref="DataFormat{T}"/>
+    /// </summary>
+    public void Set<T>(DataFormat<T> format, T value) where T : class
+    {
+        _dt.Add(DataTransferItem.Create(format, value));
+    }
+
+    /// <summary>
+    /// If present, synchronously retreives the item in the Data Transfer package
+    /// using the specified <see cref="DataFormat{T}"/>
+    /// </summary>
+    public T Get<T>(DataFormat<T> format) where T : class
+    {
+        return _dt.TryGetValue(format);
+    }
+    
+    /// <summary>
+    /// If present, asynchronously retreives the item in the Data Transfer package
+    /// using the specified <see cref="DataFormat{T}"/>
+    /// </summary>
+    public Task<T> GetAsync<T>(DataFormat<T> format) where T : class
+    {
+        return _dt.TryGetValueAsync(format);
     }
 
     IReadOnlyList<DataFormat> IDataTransfer.Formats => _dt.Formats;
 
     IReadOnlyList<IDataTransferItem> IDataTransfer.Items => _dt.Items;
 
-    public IReadOnlyList<DataFormat> Formats => _dt.Formats;
-    public IReadOnlyList<IAsyncDataTransferItem> Items => _dt.Items;
-
-    public void Dispose()
-    {
-
-    }
+    void IDisposable.Dispose() { }
 
     private readonly DataTransfer _dt;
 }


### PR DESCRIPTION
Adds additional functionality to `DataPackage` class, primarily for setting custom data formats/items into the package. This API is used with `FATabView` and as part of the v3 overhaul of that control it was left pretty bare bones just to get it working while I wrapped my head around Avalonia's new DataTransfer/DragDrop/Clipboard API that is more difficult than it should be and I'll leave it at that. 

Implementing the Bitmaps required a bump to Avalonia 12.1 (actually it was earlier than that) but its time to bump FA to 12.1 anyway so, following this PR FA 3.1 package will be released.

Closes #742