### PR TITLE
feat(combo-box): add support for SelectionBoxItemTemplate

### DIFF
--- a/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
+++ b/src/FluentAvalonia/Styling/ControlThemes/BasicControls/ComboBoxStyles.axaml
@@ -10,6 +10,7 @@
                     <ComboBoxItem Content="Item2" />
                     <ComboBoxItem Content="Item3" />
                 </ComboBox>
+                
                 <ComboBox PlaceholderText="Placeholder">
                     <ComboBoxItem Content="Item1" />
                     <ComboBoxItem Content="Item2" />
@@ -27,6 +28,19 @@
                            />
 
                 <ComboBox IsEditable="True">
+                    <ComboBoxItem>Item1</ComboBoxItem>
+                    <ComboBoxItem>Item2</ComboBoxItem>
+                    <ComboBoxItem>Item3</ComboBoxItem>
+                </ComboBox>
+                
+                <ComboBox SelectedIndex="0">
+                    <ComboBox.SelectionBoxItemTemplate>
+                        <DataTemplate>
+                            <Border Padding="20" BorderBrush="Red" BorderThickness="1">
+                                <TextBlock Text="{ReflectionBinding}"/>
+                            </Border>
+                        </DataTemplate>
+                    </ComboBox.SelectionBoxItemTemplate>
                     <ComboBoxItem>Item1</ComboBoxItem>
                     <ComboBoxItem>Item2</ComboBoxItem>
                     <ComboBoxItem>Item3</ComboBoxItem>
@@ -134,7 +148,7 @@
 
                         <ContentPresenter Name="ContentPresenter"
                                           Content="{TemplateBinding SelectionBoxItem}"
-                                          ContentTemplate="{TemplateBinding ItemTemplate}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                           Grid.Column="0"
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"


### PR DESCRIPTION
<!--
IMPORTANT NOTICE
1. Before submitting a PR, a corresponding issue must be opened and approved. PRs opened without an corresponding issue will be closed without warning. In the issue, indicate you would like to do the PR and be patient as it may take some time for me to respond. Exceptions: Small changes like documentation fixes/typos]

AI WARNING
All code submitted to FluentAvalonia MUST be written by a human. I have no issues with using AI to help problem solving, but please do not submit code fixes or improvements that have been authored by ChatGPT, CoPilot, Claude, Gemini, or any other AI.
If you generate a PR or issue description using AI, please review it as best you can to ensure the AI text is correct and aligns with your intentions. AI is garbage, please use it responsibly.
-->

## Description

Added support for `SelectionBoxItemTemplate` in `ComboBox`.

In some cases, it's necessary for showing a different style for selection. Such as: `CurrentItem: Item1` and etc.

The design preview code comes from Avalonia's Fluent theme.

<!-- Review the contributing guidlines as FA does not fully use modern C# conventions in all cases: https://github.com/amwx/FluentAvalonia/blob/master/.github/CONTRIBUTING.md -->

## Screenshots

<img width="1243" height="330" alt="image" src="https://github.com/user-attachments/assets/7ecd1f02-184f-4c4e-9686-8157c34dfeb2" />

## Resolved Issues

Resolve #764
