### PR TITLE
FA 3.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,8 +4,8 @@
     <Description>Control library focused on fluent design and bringing more WinUI controls into Avalonia </Description>
     <PackageTags>c-sharp;xaml;cross-platform;dotnet;dotnetcore;avalonia;avaloniaui;fluent;fluent-design</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>3.0.2</Version>
-    <AssemblyVersion>3.0.2.0</AssemblyVersion>
+    <Version>3.1.0</Version>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <!-- Add Package Icon -->

--- a/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
+++ b/src/FluentAvalonia/UI/Controls/Frame/FAFrame.cs
@@ -225,10 +225,7 @@ public partial class FAFrame : ContentControl
     /// and what transition animation is used.</param>
     /// <returns><c>false</c> if a <see cref="NavigationFailed"/> event handler has set Handled to true or
     /// if <see cref="NavigationPageFactory" /> is not specified; otherwise, <c>true</c>.</returns>
-    public bool NavigateFromObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(
-        T target,
-        FAFrameNavigationOptions navOptions = null
-    )
+    public bool NavigateFromObject(object target, FAFrameNavigationOptions navOptions = null)
     {
         // Check the cache first to see if we have an existing page that matches
         // For this check we check by both type and object reference
@@ -244,12 +241,17 @@ public partial class FAFrame : ContentControl
                 return false;
         }
 
+#pragma warning disable IL2072
         // The page source Type here will be whatever was specified as 'target'
-        var entry = new FAPageStackEntry(typeof(T), null, navOptions?.TransitionInfoOverride)
+        // Must use target.GetType here - cannot make method Generic and use typeof(T) because typeof(T) and
+        // target.GetType might not be the same thing (see the sample app, where typeof(T) = object, but 
+        // target.GetType() is an actual page type
+        var entry = new FAPageStackEntry(target.GetType(), null, navOptions?.TransitionInfoOverride)
         {
             Instance = existing,
             Context = target
         };
+#pragma warning restore IL2072
 
         return NavigateCore(entry, FANavigationMode.New, navOptions);
     }


### PR DESCRIPTION
Package update for FA3.1

Note: This bumps the minimum Avalonia version to 12.1

Includes #759,  #761,  #765

In addition, I have removed the annotations added in #729 to FAFrame's `NavigateFromObject` method. That method specifically has returned to how it was before that PR, so it is also no longer generic. The reason is in #748. That method cannot rely on `typeof(T)` to set the SourcePageType for the navigation items, because `typeof(T)` does not always return the actual page type. Changing to `target.GetType()` led to more trim warnings because of mismatching annotations. I don't know or pay attention to trimming/AOT stuff so I don't know what else to do. This method is for non-reflection based navigation anyway so it shouldn't really need it.

Closes #748